### PR TITLE
Add template file override path for the current Kunena template

### DIFF
--- a/administrator/components/com_kunena/libraries/view.php
+++ b/administrator/components/com_kunena/libraries/view.php
@@ -35,6 +35,12 @@ class KunenaView extends JView {
 		if ($this->app->isSite() && !isset($config['template_path'])) $config['template_path'] = $this->ktemplate->getTemplatePaths("html/$name", true);
 
 		parent::__construct($config);
+
+		if ($this->app->isSite()) {
+			// Add another template file lookup path specific to the current template
+			$fallback = JPATH_THEMES . "/{$this->app->getTemplate()}/html/com_kunena/{$this->ktemplate->name}/{$this->getName()}";
+			$this->addTemplatePath($fallback);
+		}
 	}
 
 	public function displayAll() {


### PR DESCRIPTION
Here's example from the current layout file lookup paths:
- /var/www-kunena/kunena2025/templates/beez_20/html/com_kunena/blue_eagle/topics/
- /var/www-kunena/kunena2025/templates/beez_20/html/com_kunena/topics/
- /var/www-kunena/kunena2025/components/com_kunena/template/blue_eagle/html/topics/
