### PR TITLE
Backend list size

### DIFF
--- a/administrator/components/com_kunena/libraries/forum/message/helper.php
+++ b/administrator/components/com_kunena/libraries/forum/message/helper.php
@@ -209,7 +209,7 @@ abstract class KunenaForumMessageHelper {
 		$count = 0;
 		foreach ($location->hold as $meshold=>$values) {
 			if (isset($hold[$meshold])) {
-				$count += $values[$direction == 'asc' ? 'before' : 'after'];
+				$count += $values[$direction = 'asc' ? 'before' : 'after'];
 				if ($direction == 'both') $count += $values['before'];
 			}
 		}


### PR DESCRIPTION
If no limit is provided to getLatestMessages function it used threads_per_page settings.
This behavior is wrong on backend, since Joomla passes empty limit parameter if pagination set to "All".
With this patch threads_per_page only used if code is invocated from the frontend application.
