### PR TITLE
Non existent topic autorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ components/com_kunena/template/**/params.ini
 .externalToolBuilders/build.kunena.2.0.launch
 /build
 .idea/
+.DS_Store

--- a/administrator/components/com_kunena/libraries/forum/message/message.php
+++ b/administrator/components/com_kunena/libraries/forum/message/message.php
@@ -314,7 +314,7 @@ class KunenaForumMessage extends KunenaDatabaseObject {
 			return false;
 		}
 		$topic = $this->getTopic();
-		$auth = ($topic->category_id==0 || $topic->authorise('post.'.$action, $user, $silent) ); // Category_id == 0 if topic is not exists anymore
+		$auth = ((!$topic->exists()) || $topic->authorise('post.'.$action, $user, $silent) );
 		if (!$auth) {
 			if (!$silent) $this->setError ( $topic->getError() );
 			return false;


### PR DESCRIPTION
Messages which has no topics can't be deleted, as during the Purge process the topic is authorized first.
This patch alway passes authorization if Topic is not existing (category_id == 0), therefore such messages can be purged.
