### PR TITLE
Get purge items implode removal

### DIFF
--- a/administrator/components/com_kunena/libraries/forum/message/helper.php
+++ b/administrator/components/com_kunena/libraries/forum/message/helper.php
@@ -209,7 +209,7 @@ abstract class KunenaForumMessageHelper {
 		$count = 0;
 		foreach ($location->hold as $meshold=>$values) {
 			if (isset($hold[$meshold])) {
-				$count += $values[$direction == 'asc' ? 'before' : 'after'];
+				$count += $values[$direction = 'asc' ? 'before' : 'after'];
 				if ($direction == 'both') $count += $values['before'];
 			}
 		}


### PR DESCRIPTION
Code cleanup. Implode is not needed in getPrugeItems function, since both KunenaForumTopicHelper::getTopics and KunenaForumMessageHelper::getMessages functions are accepting Ids as an array.
