### PR TITLE
Fixed mod_see_deleted config

### DIFF
--- a/administrator/components/com_kunena/models/config.php
+++ b/administrator/components/com_kunena/models/config.php
@@ -239,8 +239,8 @@ class KunenaAdminModelConfig extends KunenaModel {
 
 		$seerestoredeleted = array();
 		$seerestoredeleted[] =JHTML::_('select.option', 2, JText::_('COM_KUNENA_A_SEE_RESTORE_DELETED_NOBODY'));
-		$seerestoredeleted[] =JHTML::_('select.option', 1, JText::_('COM_KUNENA_A_SEE_RESTORE_DELETED_ADMINS'));
-		$seerestoredeleted[] =JHTML::_('select.option', 0, JText::_('COM_KUNENA_A_SEE_RESTORE_DELETED_ADMINSMODS'));
+		$seerestoredeleted[] =JHTML::_('select.option', 1, JText::_('COM_KUNENA_A_SEE_RESTORE_DELETED_ADMINSMODS'));
+		$seerestoredeleted[] =JHTML::_('select.option', 0, JText::_('COM_KUNENA_A_SEE_RESTORE_DELETED_ADMINS'));
 		$lists ['mod_see_deleted'] = JHTML::_('select.genericlist', $seerestoredeleted, 'cfg_mod_see_deleted', 'class="inputbox" size="1"', 'value', 'text', $this->config->mod_see_deleted);
 
 		$listBbcodeImgSecure = array();


### PR DESCRIPTION
COM_KUNENA_A_SEE_RESTORE_DELETED_ADMINS and
COM_KUNENA_A_SEE_RESTORE_DELETED_ADMINSMODS were replaced.
Now the default setting is Admins (0)

this commit fixes #1014
