### PR TITLE
K2.0 blue_eagle template: URL with empty hostname in profile view

### DIFF
--- a/components/com_kunena/template/blue_eagle/html/user/default_tab.php
+++ b/components/com_kunena/template/blue_eagle/html/user/default_tab.php
@@ -34,11 +34,17 @@ JHtml::_('behavior.tooltip');
 <div class="clrline"></div>
 <div id="kprofile-rightcolbot">
 	<div class="kprofile-rightcol2">
-		<ul>
-			<?php if ( $this->email ): ?><li><span class="kicon-profile kicon-profile-email"></span><?php echo $this->email ?></li><?php endif; ?>
-			<?php // FIXME: we need a better way to add http/https ?>
-			<li><?php if (!empty($this->profile->websiteurl)):?><span class="kicon-profile kicon-profile-website"></span><?php endif;?><a href="http://<?php echo $this->escape($this->profile->websiteurl); ?>" target="_blank"><?php echo KunenaHtmlParser::parseText($this->profile->websitename); ?></a></li>
-		</ul>
+		<?php if ($this->email || !empty($this->profile->websiteurl)): ?>
+			<ul>
+				<?php if ($this->email): ?>
+					<li><span class="kicon-profile kicon-profile-email"></span><?php echo $this->email; ?></li>
+				<?php endif; ?>
+				<?php if (!empty($this->profile->websiteurl)): ?>
+					<?php // FIXME: we need a better way to add http/https ?>
+					<li><span class="kicon-profile kicon-profile-website"></span><a href="http://<?php echo $this->escape($this->profile->websiteurl); ?>" target="_blank"><?php echo KunenaHtmlParser::parseText($this->profile->websitename); ?></a></li>
+				<?php endif; ?>
+			</ul>
+		<?php endif;?>
 	</div>
 	<div class="kprofile-rightcol1">
 		<h4><?php echo JText::_('COM_KUNENA_MYPROFILE_SIGNATURE'); ?></h4>


### PR DESCRIPTION
- fixed wrong placed endif that caused the creation of an URL with an empty hostname if the user has not specified a website in his profile
- added additional if-clause to prevent an empty unordered list when neither e-mail address nor website are specified by the user
