### PR TITLE
Strict standards: Declaration of KunenaBbcodeEditorButton::parseXML()

### DIFF
--- a/administrator/components/com_kunena/libraries/bbcode/editor.php
+++ b/administrator/components/com_kunena/libraries/bbcode/editor.php
@@ -188,7 +188,7 @@ abstract class KunenaBbcodeEditorElement {
 	 * @abstract
 	 * @param $xml
 	 */
-	public static function parseXML ($xml) {}
+	public static function parseXML (SimpleXMLElement $xml) {}
 }
 
 class KunenaBbcodeEditorButton extends KunenaBbcodeEditorElement {
@@ -397,7 +397,7 @@ class KunenaBbcodeEditorSeparator extends KunenaBbcodeEditorElement {
 		return $js;
 	}
 
-	public static function parseXML ($xml) {
+	public static function parseXML (SimpleXMLElement $xml) {
 		return new KunenaBbcodeEditorSeparator((string)$xml['name']);
 	}
 }


### PR DESCRIPTION
When reply to a topic :

Strict standards: Declaration of KunenaBbcodeEditorButton::parseXML() should be compatible with KunenaBbcodeEditorElement::parseXML($xml) in C:\wamp\www\joomla-3.0\libraries\kunena\bbcode\editor.php on line 388
