### PR TITLE
KunenaTemplate->addScript never finds a "-min" version

### DIFF
--- a/libraries/kunena/template/template.php
+++ b/libraries/kunena/template/template.php
@@ -283,7 +283,7 @@ HTML;
 	 */
 	function addScript($filename) {
 		$filemin_path = preg_replace ( '/\.js$/u', '-min.js', $filename );
-		if (!JDEBUG && !KunenaFactory::getConfig ()->debug && !KunenaForum::isDev () && JFile::exists(JPATH_ROOT."/$filemin_path")) {
+		if (!JDEBUG && !KunenaFactory::getConfig ()->debug && !KunenaForum::isDev () && JFile::exists(JPATH_ROOT."/media/kunena/$filemin_path")) {
 			// If we are in debug more, make sure we load the unpacked css
 			$filename = preg_replace ( '/\.js$/u', '-min.js', $filename );
 		}


### PR DESCRIPTION
Adding proper path to the filecheck.

It should also be considered to change JFactory::getDocument ()->addScript() to JHTML::Script() to allow overriding using the site template. See http://www.babdev.com/blog/139-use-the-media-folder-allow-overridable-media for this
