### PR TITLE
Properly declare variables in mediaboxAdv.js

### DIFF
--- a/media/kunena/js/mediaboxAdv.js
+++ b/media/kunena/js/mediaboxAdv.js
@@ -27,7 +27,7 @@ var Mediabox;
 	// Global variables, accessible to Mediabox only
 	var options, mediaArray, activeMedia, prevMedia, nextMedia, top, mTop, left, mLeft, winWidth, winHeight, fx, preload, preloadPrev = new Image(), preloadNext = new Image(),
 	// DOM elements
-	overlay, center, media, bottom, captionSplit, title, caption, number, prevLink, nextLink,
+	overlay, center, media, bottom, captionSplit, title, caption, number, prevLink, nextLink, container, closeLink,
 	// Mediabox specific vars
 	URL, WH, WHL, elrel, mediaWidth, mediaHeight, mediaType = "none", mediaSplit, mediaId = "mediaBox", margin, marginBottom;
 


### PR DESCRIPTION
The mediaboxAdvanced uses some variables which are not declared properly: container and closeLink. This can cause issues if this are used elsewhere.
In my case container is used as an id in my template which caused issues in IE.
