### PR TITLE
Under Joomla! 3.1.x with hathor template, kunena quickicon has no image

### DIFF
--- a/plugins/plg_quickicon_kunena/kunena.php
+++ b/plugins/plg_quickicon_kunena/kunena.php
@@ -76,33 +76,39 @@ class plgQuickiconKunena extends JPlugin {
 		if(!KunenaForum::installed()) {
 			// Not fully installed
 			$img = $useIcons ? 'warning' : 'kunena/icons/icon-48-kupdate-alert-white.png';
+			$icon = 'kunena/icons/icon-48-kupdate-alert-white.png';
 			$text = JText::_('PLG_QUICKICON_KUNENA_COMPLETE_INSTALLATION');
 
 		} elseif ($updateInfo === null) {
 			// Unsupported
 			$img = $useIcons ? 'remove' : 'kunena/icons/kunena-logo-48-white.png';
+			$icon = 'kunena/icons/kunena-logo-48-white.png';
 			$text = JText::_('COM_KUNENA');
 
 		} elseif ($updateInfo === false) {
 			// Disabled
 			$img = $useIcons ? 'minus' : 'kunena/icons/icon-48-kupdate-alert-white.png';
+			$icon = 'kunena/icons/icon-48-kupdate-alert-white.png';
 			$text = JText::_('COM_KUNENA') . '<br />' . JText::_('PLG_QUICKICON_KUNENA_UPDATE_DISABLED');
 
 		} elseif (!empty($updateInfo->version) && version_compare(KunenaForum::version(), $updateInfo->version, '<')) {
 			// Has updates
 			$img = $useIcons ? 'download' : 'kunena/icons/icon-48-kupdate-update-white.png';
+			$icon = 'kunena/icons/icon-48-kupdate-update-white.png';
 			$text = 'Kunena ' . $updateInfo->version . '<br />' . JText::_('PLG_QUICKICON_KUNENA_UPDATE_NOW');
 			$link = 'index.php?option=com_installer&view=update&filter_search=kunena';
 
 		} elseif (!empty($updateInfo->addons)) {
 			// Has updated add-ons
 			$img = $useIcons ? 'download' : 'kunena/icons/icon-48-kupdate-update-white.png';
+			$icon = 'kunena/icons/icon-48-kupdate-update-white.png';
 			$text = JText::_('COM_KUNENA') . '<br />' . JText::sprintf('PLG_QUICKICON_KUNENA_UPDATE_ADDONS', $updateInfo->addons);
 			$link = 'index.php?option=com_installer&view=update&filter_search=kunena';
 
 		} else {
 			// Already in the latest release
 			$img = $useIcons ? 'comments' : 'kunena/icons/icon-48-kupdate-good-white.png';
+			$icon = 'kunena/icons/icon-48-kupdate-good-white.png';
 			$text = JText::_('COM_KUNENA');
 		}
 
@@ -114,6 +120,7 @@ class plgQuickiconKunena extends JPlugin {
 			'link' => JRoute::_($link),
 			'image' => $img,
 			'text' => $text,
+			'icon' => $icon,
 			'access' => array('core.manage', 'com_kunena'),
 			'id' => 'com_kunena_icon' ) );
 	}


### PR DESCRIPTION
Tested under Joomla! 3.1.5 with hathor and isis backend templates and also too under Joomla 2.1.4 and it's ok for me
