### PR TITLE
When AUP integration is enabled link avatar for guests are incorrect

### DIFF
--- a/components/com_kunena/admin/install/plugins/plg_kunena_alphauserpoints/avatar.php
+++ b/components/com_kunena/admin/install/plugins/plg_kunena_alphauserpoints/avatar.php
@@ -37,8 +37,7 @@ class KunenaAvatarAlphaUserPoints extends KunenaAvatar {
 			$avatar = AlphaUserPointsHelper::getAupAvatar ( $user->userid, 0, $size->x, $size->y  );
 		}
 		if (!$avatar) {
-			// FIXME: need a better way to do this
-			$avatar = '<img border="0" width="100" height="100" alt="" src="http://kunena16cb/components/com_alphauserpoints/assets/images/avatars/generic_gravatar_grey.gif">';
+			$avatar = '<img border="0" width="100" height="100" alt="" src="'.JUri::root().'components/com_alphauserpoints/assets/images/avatars/generic_gravatar_grey.png">';
 		}
 		return $avatar;
 	}


### PR DESCRIPTION
When AUP integration is enabled, the link for avatar in Kunena profile for guests are incorrect
