### PR TITLE
 Avoid issues when editing Ktemplate when XML is malformed

### DIFF
--- a/components/com_kunena/admin/template/joomla25/templates/edit.php
+++ b/components/com_kunena/admin/template/joomla25/templates/edit.php
@@ -67,7 +67,7 @@ JHtml::_('behavior.tooltip');
 										<td>
 											<ul class="adminformlist">
 											</ul>
-											<?php if (count($this->form->getFieldset())) : ?>
+											<?php if ($this->form !== false && count($this->form->getFieldset())) : ?>
 												<table class="table table-bordered table-striped">
 													<?php foreach($this->form->getFieldset() as $field) : if (!$field->hidden) : ?>
 														<tr>

--- a/components/com_kunena/admin/template/joomla30/templates/edit.php
+++ b/components/com_kunena/admin/template/joomla30/templates/edit.php
@@ -67,7 +67,7 @@ JHtml::_('dropdown.init');
 							<td>
 								<ul class="adminformlist">
 								</ul>
-								<?php if (count($this->form->getFieldset())) : ?>
+								<?php if ($this->form !== false && count($this->form->getFieldset())) : ?>
 								<table class="table table-bordered table-striped">
 								<?php foreach($this->form->getFieldset() as $field) : if (!$field->hidden) : ?>
 									<tr>


### PR DESCRIPTION
See : http://www.kunena.org/forum/k-3-0-installation-and-upgrade/128682-fatal-error-call-to-a-member-function-getfieldset-on-a-non-object-in-components-com-kunena-template-joomla30-templates-edit-php-on-line-70
