### PR TITLE
#2098 J3.2:Warning: strtolower() expects parameter 1 to be string,array given

### DIFF
--- a/libraries/kunena/template/template.php
+++ b/libraries/kunena/template/template.php
@@ -96,7 +96,7 @@ class KunenaTemplate extends JObject
 		$this->xml = simplexml_load_file($this->xml_path);
 		if ($this->xml) {
 			foreach ($this->xml->xpath('//field') as $node) {
-				if (isset($node['name']) && isset($node['default'])) $this->params->def($node['name'], $node['default']);
+				if (isset($node['name']) && isset($node['default'])) $this->params->def($node['name'], (string)$node['default']);
 			}
 			// Generate CSS variables for less compiler.
 			foreach ($this->params->toArray() as $key=>$value)  {


### PR DESCRIPTION
Warning: strtolower() expects parameter 1 to be string, array given in C:\wamp\www\bugs\j32\libraries\joomla\form\fields\color.php on line 16
