### PR TITLE
KHeader font color unreadable

### DIFF
--- a/components/com_kunena/site/template/blue_eagle/css/kunena.default.css
+++ b/components/com_kunena/site/template/blue_eagle/css/kunena.default.css
@@ -84,7 +84,9 @@ Pink forum dark:			#ffd0ff 		RGB: 255/208/255
 	color: #FFFFFF;
 }
 #Kunena .kheader h2,
-#Kunena .kheader h2 a {
+#Kunena .kheader h2 a,
+#Kunena .kheader h3,
+#Kunena .kheader h3 a {
 	color: #fff !important;
 }
 


### PR DESCRIPTION
Now that kheader uses h3 in addition to h2, the previous h2 styles need to be extended to h3 otherwise the kheader h3 may became unreadable.
