### PR TITLE
 K 3.0.4 : Warning: preg_match() expects parameter #2303

### DIFF
--- a/libraries/kunena/route/route.php
+++ b/libraries/kunena/route/route.php
@@ -316,10 +316,14 @@ abstract class KunenaRoute {
 			{
 				// Allow all values
 			}
-			elseif (preg_match('/[^a-zA-Z0-9_ ]/i', $value))
+			// TODO: we need to find a way to here deal with arrays: &foo[]=bar
+			elseif (gettype($value)=='string')
 			{
+				if(preg_match('/[^a-zA-Z0-9_ ]/i', $value))
+				{
 				// Illegal value
-				continue;
+  				continue;
+				}
 			}
 
 			self::$current->setVar($key, $value);


### PR DESCRIPTION
it pass an array to the preg_match: array (size=6)
  0 => string 'kunena' (length=6)
  1 => string 'categories' (length=10)
  2 => string 'contacts' (length=8)
  3 => string 'content' (length=7)
  4 => string 'newsfeeds' (length=9)
  5 => string 'weblinks' (length=8)
