### PR TITLE
Add destroy method into KunenaImage class

### DIFF
--- a/libraries/kunena/image/image.php
+++ b/libraries/kunena/image/image.php
@@ -169,5 +169,21 @@ class KunenaImage extends JImage
         return true;
     }
 
+    /**
+     * Method to destroy an image handle and
+     * free the memory associated with the handle
+     *
+     * @return  boolean  True on success, false on failure or if no image is loaded
+     *
+     * @since 3.1
+     */
+	public function destroy()
+	{
+		if ($this->isLoaded())
+		{
+			return imagedestroy($this->handle);
+		}
 
+		return false;
+	}
 }


### PR DESCRIPTION
JImage has destroy method only since Joomla Platform 12.3, it's between Joomla! 3.0 and Joomla! 3.1 so not available into Joomla! 2.5. This destroy method is needed to help to fix this issue : https://github.com/Kunena/Kunena-Forum/issues/2310
