### PR TITLE
Regression emails aren't sent for subscribers after last changes #2366

### DIFF
--- a/libraries/kunena/email/email.php
+++ b/libraries/kunena/email/email.php
@@ -24,7 +24,16 @@ abstract class KunenaEmail
 	public static function send(JMail $mail, array $receivers)
 	{
 		$config = KunenaFactory::getConfig();
-		$email_recipient_count = $config->get('email_recipient_count', 1);
+
+		if (!empty($config->email_recipient_count))
+		{
+			$email_recipient_count = $config->email_recipient_count;
+		}
+		else
+		{
+			$email_recipient_count = 1;
+		}
+
 		$email_recipient_privacy = $config->get('email_recipient_privacy', 'bcc');
 
 		// If we hide email addresses from other users, we need to add TO address to prevent email from becoming spam.


### PR DESCRIPTION
There was this issue : Warning: array_chunk(): Size parameter expected to be greater than 0 in libraries/kunena/email/email.php on line 44 because the setting email_recipient_count in config is set by default on 0 and in K3.0.x there was a different check....

Related to #2366 
