### PR TITLE
Activity Integration don't call every activity plugins

### DIFF
--- a/libraries/kunena/integration/activity.php
+++ b/libraries/kunena/integration/activity.php
@@ -47,12 +47,14 @@ class KunenaIntegrationActivity
 	 * @return mixed
 	 */
 	public function __call($method, $arguments) {
+		$ret = null;
 		foreach ($this->instances as $instance) {
 			if (method_exists($instance, $method)) {
-				$ret = call_user_func_array(array($instance, $method), $arguments);
-				if($ret !== null)
-					return $ret;
+				$r = call_user_func_array(array($instance, $method), $arguments);
+				if($r !== null & $ret === null)
+					$ret = $r;
 			}
 		}
+		return $ret;
 	}
 }


### PR DESCRIPTION
Do not return every time, otherwise all triggers like onBeforePost will just work on the first plugin and not on the other.
This patch will not fix the compatibility with the existing plugins because some are returning "true" for generic triggers.
It is also possible to get all values and return a merge of these, but the __call function must call every activity plugins.
