### PR TITLE
kunenaforum.categorylist supports array $parent

### DIFF
--- a/libraries/kunena/html/html/kunenaforum.php
+++ b/libraries/kunena/html/html/kunenaforum.php
@@ -40,17 +40,19 @@ abstract class JHtmlKunenaForum {
 		if (!isset($categories)) {
 			if(is_array($parent)) {
 				$categories = array();
+				$channels = array();
 				foreach($parent as $p) {
 					$category = KunenaForumCategoryHelper::get($p);
 					$children = KunenaForumCategoryHelper::getChildren($p, $levels, $params);
 					if ($params['action'] == 'topic.create') {
-						$channels = $category->getChannels();
-						if (empty($children) && !isset($channels[$category->id])) $category = KunenaForumCategoryHelper::get();
-						foreach ($channels as $id=>$channel) {
-							if (!$id || $category->id == $id || isset($children[$id]) || !$channel->authorise ($action)) unset ($channels[$id]);
+						$channels_local = $category->getChannels();
+						if (empty($children) && !isset($channels_local[$category->id])) $category = KunenaForumCategoryHelper::get();
+						foreach ($channels_local as $id=>$channel) {
+							if (!$id || $category->id == $id || isset($children[$id]) || !$channel->authorise ($action)) unset ($channels_local[$id]);
 						}
 					}
 					$categories += $category->id > 0 ? array($category->id=>$category)+$children : $children;
+					$channels += $channels_local;
 				}
 			} else {
 				$category = KunenaForumCategoryHelper::get($parent);

--- a/libraries/kunena/html/html/kunenaforum.php
+++ b/libraries/kunena/html/html/kunenaforum.php
@@ -38,33 +38,26 @@ abstract class JHtmlKunenaForum {
 		}
 		$channels = array();
 		if (!isset($categories)) {
-			if(is_array($parent)) {
-				$categories = array();
-				$channels = array();
-				foreach($parent as $p) {
-					$category = KunenaForumCategoryHelper::get($p);
-					$children = KunenaForumCategoryHelper::getChildren($p, $levels, $params);
-					if ($params['action'] == 'topic.create') {
-						$channels_local = $category->getChannels();
-						if (empty($children) && !isset($channels_local[$category->id])) $category = KunenaForumCategoryHelper::get();
-						foreach ($channels_local as $id=>$channel) {
-							if (!$id || $category->id == $id || isset($children[$id]) || !$channel->authorise ($action)) unset ($channels_local[$id]);
-						}
+			if(!is_array($parent)) {
+				$parent = array($parent);
+			}
+			$categories = array();
+			$channels = array();
+			foreach($parent as $p) {
+				$channels_local = array();
+				$category = KunenaForumCategoryHelper::get($p);
+				$children = KunenaForumCategoryHelper::getChildren($p, $levels, $params);
+				if ($params['action'] == 'topic.create') {
+					$channels_local = $category->getChannels();
+					if (empty($children) && !isset($channels_local[$category->id])) $category = KunenaForumCategoryHelper::get();
+					foreach ($channels_local as $id=>$channel) {
+						if (!$id || $category->id == $id || isset($children[$id]) || !$channel->authorise ($action)) unset ($channels_local[$id]);
 					}
-					$categories += $category->id > 0 ? array($category->id=>$category)+$children : $children;
+				}
+				$categories += $category->id > 0 ? array($category->id=>$category)+$children : $children;
+				if(!empty($channels_local)) {
 					$channels += $channels_local;
 				}
-			} else {
-				$category = KunenaForumCategoryHelper::get($parent);
-				$children = KunenaForumCategoryHelper::getChildren($parent, $levels, $params);
-				if ($params['action'] == 'topic.create') {
-					$channels = $category->getChannels();
-					if (empty($children) && !isset($channels[$category->id])) $category = KunenaForumCategoryHelper::get();
-					foreach ($channels as $id=>$channel) {
-						if (!$id || $category->id == $id || isset($children[$id]) || !$channel->authorise ($action)) unset ($channels[$id]);
-					}
-				}
-				$categories = $category->id > 0 ? array($category->id=>$category)+$children : $children;
 			}
 			if ($hide_lonely && count($categories)+count($channels) <= 1) return;
 		}

--- a/libraries/kunena/html/html/kunenaforum.php
+++ b/libraries/kunena/html/html/kunenaforum.php
@@ -38,16 +38,32 @@ abstract class JHtmlKunenaForum {
 		}
 		$channels = array();
 		if (!isset($categories)) {
-			$category = KunenaForumCategoryHelper::get($parent);
-			$children = KunenaForumCategoryHelper::getChildren($parent, $levels, $params);
-			if ($params['action'] == 'topic.create') {
-				$channels = $category->getChannels();
-				if (empty($children) && !isset($channels[$category->id])) $category = KunenaForumCategoryHelper::get();
-				foreach ($channels as $id=>$channel) {
-					if (!$id || $category->id == $id || isset($children[$id]) || !$channel->authorise ($action)) unset ($channels[$id]);
+			if(is_array($parent)) {
+				$categories = array();
+				foreach($parent as $p) {
+					$category = KunenaForumCategoryHelper::get($p);
+					$children = KunenaForumCategoryHelper::getChildren($p, $levels, $params);
+					if ($params['action'] == 'topic.create') {
+						$channels = $category->getChannels();
+						if (empty($children) && !isset($channels[$category->id])) $category = KunenaForumCategoryHelper::get();
+						foreach ($channels as $id=>$channel) {
+							if (!$id || $category->id == $id || isset($children[$id]) || !$channel->authorise ($action)) unset ($channels[$id]);
+						}
+					}
+					$categories += $category->id > 0 ? array($category->id=>$category)+$children : $children;
 				}
+			} else {
+				$category = KunenaForumCategoryHelper::get($parent);
+				$children = KunenaForumCategoryHelper::getChildren($parent, $levels, $params);
+				if ($params['action'] == 'topic.create') {
+					$channels = $category->getChannels();
+					if (empty($children) && !isset($channels[$category->id])) $category = KunenaForumCategoryHelper::get();
+					foreach ($channels as $id=>$channel) {
+						if (!$id || $category->id == $id || isset($children[$id]) || !$channel->authorise ($action)) unset ($channels[$id]);
+					}
+				}
+				$categories = $category->id > 0 ? array($category->id=>$category)+$children : $children;
 			}
-			$categories = $category->id > 0 ? array($category->id=>$category)+$children : $children;
 			if ($hide_lonely && count($categories)+count($channels) <= 1) return;
 		}
 		if (!is_array($options)) {


### PR DESCRIPTION
KunenaForumCategoryHelper::getChildren support the variable $parent as an array.
It was possible to call kunenaforum.categorylist with an array for $parent but only the children where in the returned list.
The modification accept an array for the $parent variable and return a valid list.
