### PR TITLE
Crypsis not possible to open attachments browse windows #2538

### DIFF
--- a/components/com_kunena/site/template/crypsis/layouts/topic/edit/default.php
+++ b/components/com_kunena/site/template/crypsis/layouts/topic/edit/default.php
@@ -132,15 +132,15 @@ $this->k=0;
 						<label class="control-label"><?php echo JText::_('COM_KUNENA_EDITOR_ATTACHMENTS'); ?></label>
 						<div class="controls">
 							<div id="kattachment-id" class="kattachment">
-							<div class="control-group">
 								<span class="kattachment-id-container"></span>
-								<input class="kfile-input-textbox" type="text" readonly />
-							</div>
-								<div class="kfile-hide hasTip control-group" title="<?php echo JText::_('COM_KUNENA_FILE_EXTENSIONS_ALLOWED')?>::<?php echo $this->escape(implode(', ', $this->allowedExtensions)) ?>" >
-									<input type="button" value="<?php echo	JText::_('COM_KUNENA_EDITOR_ADD_FILE'); ?>" class="kfile-input-button btn" />
+								<input class="kfile-input-textbox" type="text" readonly="readonly" />
+								<div class="kfile-hide hasTip" title="<?php echo JText::_('COM_KUNENA_FILE_EXTENSIONS_ALLOWED')?>::<?php echo $this->escape(implode(', ', $this->allowedExtensions)) ?>" >
+									<input type="button" value="<?php echo JText::_('COM_KUNENA_EDITOR_ADD_FILE'); ?>" class="kfile-input-button btn" />
 									<input id="kupload" class="kfile-input" name="kattachment" type="file" />
 								</div>
-								<a href="#" class="kattachment-remove btn" style="display: none"><?php echo	JText::_('COM_KUNENA_GEN_REMOVE_FILE'); ?></a> <a href="#" class="kattachment-insert btn" style="display: none"><?php echo	JText::_('COM_KUNENA_EDITOR_INSERT'); ?></a> </div>
+								<a href="#" class="kattachment-remove btn" style="display: none"><?php echo JText::_('COM_KUNENA_GEN_REMOVE_FILE'); ?></a>
+								<a href="#" class="kattachment-insert btn" style="display: none"><?php echo JText::_('COM_KUNENA_EDITOR_INSERT'); ?></a>
+							</div>
 							<?php
 							if (!empty($this->attachments))
 								echo $this->subLayout('Topic/Edit/Attachments')


### PR DESCRIPTION
Since changes on template when you are in edit view in topic, on clic on Add files it doesn't open browse windows to select the attachment to upload, it's not possible without that to test protected attachments by example...
