### PR TITLE
Email addresses in posts are cloaked, Joomla cloaking disabled #2427

### DIFF
--- a/components/com_kunena/admin/language/en-GB/en-GB.com_kunena.views.ini
+++ b/components/com_kunena/admin/language/en-GB/en-GB.com_kunena.views.ini
@@ -460,6 +460,8 @@ COM_KUNENA_ADMIN_CONFIG_STATSLINK_ALLOWED="Allow Guests to see Stats link"
 COM_KUNENA_ADMIN_CONFIG_STATSLINK_ALLOWED_DESC="Set to Yes to allow Guests to see Stats link."
 COM_KUNENA_A_SHOW_SUPERADMINS_IN_USERLIST="Show Super Users in user list"
 COM_KUNENA_A_SHOW_SUPERADMINS_IN_USERLIST_DESC="Should the Super Users be shown in the user list?"
+COM_KUNENA_CONFIGURATION_CLOAKEMAIL_LABEL="Email cloaking in messages"
+COM_KUNENA_CONFIGURATION_CLOAKEMAIL_DESC="Email cloaking in messages"
 
 ; JROOT/administrator/components/com_kunena/views/config/tmpl/modal.php
 

--- a/components/com_kunena/admin/models/config.php
+++ b/components/com_kunena/admin/models/config.php
@@ -389,6 +389,8 @@ class KunenaAdminModelConfig extends KunenaModel {
 		$lists ['statslink_allowed'] = JHtml::_('select.genericlist', $yesno, 'cfg_statslink_allowed', 'class="inputbox" size="1"', 'value', 'text', $this->config->statslink_allowed);
 		$lists ['superadmin_userlist'] = JHtml::_('select.genericlist', $yesno, 'cfg_superadmin_userlist', 'class="inputbox" size="1"', 'value', 'text', $this->config->superadmin_userlist);
 
+		$lists ['cloakemail'] = JHtml::_('select.genericlist', $yesno, 'cfg_cloakemail', 'class="inputbox" size="1"', 'value', 'text', $this->config->cloakemail);
+
 		return $lists;
 	}
 }

--- a/components/com_kunena/admin/template/joomla25/config/default.php
+++ b/components/com_kunena/admin/template/joomla25/config/default.php
@@ -937,6 +937,11 @@ defined ( '_JEXEC' ) or die ();
 														<td><input type="text" name="cfg_ebay_affiliate_id" value="<?php echo $this->escape($this->config->ebay_affiliate_id) ?>" /></td>
 														<td><?php echo JText::_('COM_KUNENA_A_EBAY_AFFILIATE_ID_DESC') ?></td>
 													</tr>
+													<tr>
+														<td><?php echo JText::_('COM_KUNENA_CONFIGURATION_CLOAKEMAIL_LABEL') ?></td>
+														<td><?php echo $this->lists ['cloakemail'] ?></td>
+														<td><?php echo JText::_('COM_KUNENA_CONFIGURATION_CLOAKEMAIL_DESC') ?></td>
+													</tr>
 													<?php /*
 													// TODO: If you uncomment this feature, please remove forced disable from the KunenaConfig class.
 													<tr>

--- a/components/com_kunena/admin/template/joomla30/config/default.php
+++ b/components/com_kunena/admin/template/joomla30/config/default.php
@@ -946,6 +946,11 @@ if (version_compare(JVERSION, '3.2', '>'))
 												<td><input type="text" name="cfg_ebay_affiliate_id" value="<?php echo $this->escape($this->config->ebay_affiliate_id) ?>" /></td>
 												<td><?php echo JText::_('COM_KUNENA_A_EBAY_AFFILIATE_ID_DESC') ?></td>
 											</tr>
+											<tr>
+												<td><?php echo JText::_('COM_KUNENA_CONFIGURATION_CLOAKEMAIL_LABEL') ?></td>
+												<td><?php echo $this->lists ['cloakemail'] ?></td>
+												<td><?php echo JText::_('COM_KUNENA_CONFIGURATION_CLOAKEMAIL_DESC') ?></td>
+											</tr>
 										<?php /*
 										// TODO: If you uncomment this feature, please remove forced disable from the KunenaConfig class.
 										<tr>

--- a/libraries/kunena/config.php
+++ b/libraries/kunena/config.php
@@ -229,6 +229,8 @@ class KunenaConfig extends JObject {
 	public $statslink_allowed = 1;
 	// New for 3.0.6
 	public $superadmin_userlist = 0;
+	// New for 3.0.7
+	public $cloakemail=1;
 
 	public function __construct() {
 		parent::__construct ();


### PR DESCRIPTION
There is a new setting in Kunena configuration panel : BBCode -> Email cloaking in messages
