### PR TITLE
[K3.1] Crypsis: Fix language backend #2705

### DIFF
--- a/libraries/kunena/template/template.php
+++ b/libraries/kunena/template/template.php
@@ -159,11 +159,24 @@ class KunenaTemplate extends JObject
 		// Loading language strings for the template
 		$lang = JFactory::getLanguage();
 		KunenaFactory::loadLanguage('com_kunena.templates', 'site');
-		foreach (array_reverse($this->default) as $template) {
-			$file = 'com_kunena.tpl_'.$template;
-			$lang->load($file, JPATH_SITE)
-				|| $lang->load($file, KPATH_SITE)
-				|| $lang->load($file, KPATH_SITE.'/template/'.$template);
+
+		foreach (array_reverse($this->default) as $template)
+		{
+			// Try to load language file for legacy templates
+			if ($lang->load('com_kunena.tpl_' . $template, JPATH_SITE)
+				|| $lang->load('com_kunena.tpl_' . $template, KPATH_SITE)
+				|| $lang->load('com_kunena.tpl_' . $template, KPATH_SITE . '/template/' . $template))
+			{
+				$lang->load('com_kunena.tpl_' . $template, JPATH_SITE)
+					|| $lang->load('com_kunena.tpl_' . $template, KPATH_SITE)
+					|| $lang->load('com_kunena.tpl_' . $template, KPATH_SITE . '/template/' . $template);
+			}
+			else
+			{
+				$lang->load('kunena_tmpl_' . $template, JPATH_SITE)
+				|| $lang->load('kunena_tmpl_' . $template, KPATH_SITE)
+				|| $lang->load('kunena_tmpl_' . $template, KPATH_SITE . '/template/' . $template);
+			}
 		}
 	}
 


### PR DESCRIPTION
Tests realized with followings templates : 

- Blue eagle : **Loaded** : JROOT/components/com_kunena/language/en-GB/en-GB.com_kunena.tpl_blue_eagle.ini
- Crypsis : **Not loaded** : JROOT/components/com_kunena/template/crypsis/language/en-GB/en-GB.com_kunena.tpl_crypsis.ini
**Loaded** : JROOT/components/com_kunena/language/en-GB/en-GB.kunena_tmpl_crypsis.ini
- Garava - Kunena 2.x : **Loaded** : JROOT/components/com_kunena/template/garava/language/en-GB/en-GB.com_kunena.tpl_garava.ini