### PR TITLE
[k3.1] Regression: setting to hide admins in userlist has no effect #793

### DIFF
--- a/components/com_kunena/admin/template/joomla25/config/default.php
+++ b/components/com_kunena/admin/template/joomla25/config/default.php
@@ -464,11 +464,6 @@ defined ( '_JEXEC' ) or die ();
 														<td><?php echo $this->lists ['show_imgfiles_manage_profile'] ?></td>
 														<td><?php echo JText::_('COM_KUNENA_A_DISPLAY_IMGFILES_TAB_MANAGEMENT_PROFILE_DESC') ?></td>
 													</tr>
-													<tr>
-														<td><?php echo JText::_('COM_KUNENA_A_SHOW_SUPERADMINS_IN_USERLIST') ?></td>
-														<td><?php echo $this->lists ['superadmin_userlist'] ?></td>
-														<td><?php echo JText::_('COM_KUNENA_A_SHOW_SUPERADMINS_IN_USERLIST_DESC') ?></td>
-													</tr>
 												</tbody>
 											</table>
 										</fieldset>

--- a/components/com_kunena/admin/template/joomla30/config/default.php
+++ b/components/com_kunena/admin/template/joomla30/config/default.php
@@ -473,11 +473,6 @@ if (version_compare(JVERSION, '3.2', '>'))
 												<td><?php echo $this->lists ['show_imgfiles_manage_profile'] ?></td>
 												<td><?php echo JText::_('COM_KUNENA_A_DISPLAY_IMGFILES_TAB_MANAGEMENT_PROFILE_DESC') ?></td>
 											</tr>
-											<tr>
-												<td><?php echo JText::_('COM_KUNENA_A_SHOW_SUPERADMINS_IN_USERLIST') ?></td>
-												<td><?php echo $this->lists ['superadmin_userlist'] ?></td>
-												<td><?php echo JText::_('COM_KUNENA_A_SHOW_SUPERADMINS_IN_USERLIST_DESC') ?></td>
-											</tr>
 										</tbody>
 									</table>
 								</fieldset>

--- a/components/com_kunena/site/controller/user/list/display.php
+++ b/components/com_kunena/site/controller/user/list/display.php
@@ -49,8 +49,8 @@ class ComponentKunenaControllerUserListDisplay extends KunenaControllerDisplay
 		$start = $this->state->get('list.start');
 		$limit = $this->state->get('list.limit');
 
-		// Exclude super admins if configured to do so.
-		$filter = $this->config->superadmin_userlist ? JAccess::getUsersByGroup(8) : array();
+		// Get list of super admins to exclude or not in filter by configuration.
+		$filter = JAccess::getUsersByGroup(8);
 
 		$finder = new KunenaUserFinder;
 		$finder

--- a/libraries/kunena/user/finder.php
+++ b/libraries/kunena/user/finder.php
@@ -76,8 +76,12 @@ class KunenaUserFinder extends KunenaDatabaseObjectFinder
 		} elseif ($this->config->userlist_count_users == '3' ) {
 			$this->query->where('a.block=0');
 		}
+
 		// Hide super admins from the list
-		if ($ignore) $this->query->where('a.id NOT IN ('.implode(',', $ignore).')');
+		if ( !$this->config->superadmin_userlist && $ignore)
+		{
+			$this->query->where('a.id NOT IN (' . implode(',', $ignore) . ')');
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
Needed to remove the setting "Show Super Users in user list" under  tab Users because was duplicate (already available under tab Extra)