### PR TITLE
Removed failing and useless email check on Gravatar integration

### DIFF
--- a/components/com_kunena/admin/install/plugins/plg_kunena_gravatar/class.php
+++ b/components/com_kunena/admin/install/plugins/plg_kunena_gravatar/class.php
@@ -62,34 +62,13 @@ class KunenaGravatar
 	}
 
 	/**
-	 * Check if the email is valid by comparing it against regular expression
-	 *
-	 * @return boolean
-	 */
-	public function isValidEmail($email)
-	{
-		// Source: http://www.zend.com/zend/spotlight/ev12apr.php
-		if (preg_match('/^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$/i', $email) !== false)
-		{
-			return true;
-		}
-		else
-		{
-			false;
-		}
-	}
-
-	/**
 	 * @param string $email
 	 *
 	 * @return string $email
 	 */
 	public function setEmail($email)
 	{
-		if ($this->isValidEmail($email))
-		{
-			$this->email = $email;
-		}
+		$this->email = $email;
 	}
 
 	/**


### PR DESCRIPTION
Kunena should only send a request by hash and waiting for a response. Checking the email validity it's up to gravatar not to Kunena.
By doing email checks by itself, Kunena runs the risk of making mistakes without having back any real advantage.

Here we have a lot of them.
1. Argument PHPDoc missing. It should be @param string $email
2. "else false;" doesn't do anything, and it produces a missing return statement. It should be "else return false;"
3. The regular expression used here does not match valid email addresses on [ICANN-era top-level domains](http://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#ICANN-era_generic_top-level_domains) nor [Internationalized top-level domains](http://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#Internationalized_generic_top-level_domains)
4. It does not match even **old and well know valid domains** 4 characters long, such as .info or .mobi.
5. The [http link](http://www.zend.com/zend/spotlight/ev12apr.php) cited as source in the comment, returns a 404 error, which may mean that Zend no longer propose such an obsolete regular expression.

Not bad for only 4 lines of code. :smile:
