### PR TITLE
Issue on reply when you have in previous message a confidential tag

### DIFF
--- a/libraries/kunena/bbcode/bbcode.php
+++ b/libraries/kunena/bbcode/bbcode.php
@@ -1415,7 +1415,16 @@ class KunenaBbcodeLibrary extends BBCodeLibrary {
 		$message = $this->getMessage();
 		$moderator = $me->userid && $me->isModerator($message ? $message->getCategory() : null);
 
-		if (($me->userid && $bbcode->parent->userid == $me->userid) || $moderator)
+		if ( isset($bbcode->parent->message->userid))
+		{
+			$message_userid = $bbcode->parent->message->userid;
+		}
+		else
+		{
+			$message_userid = $bbcode->parent->userid;
+		}
+
+		if (($me->userid && $message_userid == $me->userid) || $moderator)
 		{
 			$layout = KunenaLayout::factory('BBCode/Confidential');
 


### PR DESCRIPTION
On reply if you have a previous message with a confidential item in it, you will see this error : 

```
Rendering Error in layout Topic/Edit/History: Property "userid" is not defined in C:\wamp\www\joomla3.4.0\libraries\kunena\bbcode\bbcode.php on line 1427
Layout was rendered in C:\wamp\www\joomla3.4.0\libraries\kunena\controller\display.php on line 161
```
