### PR TITLE
Rendering Error in layout Widget/Login/Logout: Property "category_id"

### DIFF
--- a/components/com_kunena/site/template/crypsis/layouts/widget/login/logout/default.php
+++ b/components/com_kunena/site/template/crypsis/layouts/widget/login/logout/default.php
@@ -32,7 +32,7 @@ $markAllReadUrl = KunenaForumCategoryHelper::get()->getMarkReadUrl();
 		<div class="dropdown-menu" id="nav-menu">
 
 			<div class="center">
-				<p><strong><?php echo $this->me->getLink(null, null, 'nofollow', '', null, $this->category_id); ?></strong></p>
+				<p><strong><?php echo $this->me->getLink(null, null, 'nofollow', '', null); ?></strong></p>
 				<a href="<?php echo $this->me->getURL(); ?>">
 					<?php echo $this->me->getAvatarImage('img-polaroid', 128, 128); ?>
 				</a>


### PR DESCRIPTION
Rendering Error in layout Widget/Login/Logout: Property "category_id" is not defined in C:\wamp\www\joomla3.4.1\components\com_kunena\template\crypsis\layouts\widget\login\logout\default.php on line 35
Layout was rendered in C:\wamp\www\joomla3.4.1\libraries\kunena\controller\display.php on line 161