### PR TITLE
Check attachments size on upload take care of avatar setting instead of images/files settings #3466

### DIFF
--- a/components/com_kunena/site/language/en-GB/en-GB.com_kunena.ini
+++ b/components/com_kunena/site/language/en-GB/en-GB.com_kunena.ini
@@ -135,6 +135,7 @@ COM_KUNENA_UPLOADED_LABEL_DRAG_AND_DROP_OR_BROWSE = "You can drop files here or 
 COM_KUNENA_UPLOAD_ERROR_FILE_RIGHT_MEDIA_DIR = "Failed to move avatar file to media directory"
 COM_KUNENA_UPLOAD_ERROR_AVATAR_EXCEED_LIMIT_IN_CONFIGURATION = "Avatar file size exceed limit allowed by configuration"
 COM_KUNENA_UPLOAD_ERROR_FILE_EXCEED_LIMIT_IN_CONFIGURATION  = "Attachment file size exceed limit allowed by configuration"
+COM_KUNENA_UPLOAD_ERROR_IMAGE_EXCEED_LIMIT_IN_CONFIGURATION  = "Attachment image size exceed limit allowed by configuration"
 
 ; Automatically generated strings for COM_KUNENA_BUTTON_*
 


### PR DESCRIPTION
### Blue Eagle
- [x] Upload avatar
- [x] Show error upload avatar when reached limit
- [x] Upload image
- [x] Show error when upload image limit is reached
- [x] Upload File
- [x] Show error when file upload limit is reached
- [x] Split error message
- [x] Split limit attachments
### Crypsis/Crypsisb3 (still need tests)
- [x] Upload avatar
- [ ] Show error upload avatar when reached limit - Failed show correct error but standard default avatar is now set as default
- [x] Upload image
- [x] Show error when upload image limit is reached
- [x] Upload File
- [x] Show error when file upload limit is reached
- [x] Split error message
- [x] Split limit attachments
