### PR TITLE
Remove method loadMootools() which is deprecated on k4.0.x

### DIFF
--- a/src/libraries/kunena/template/template.php
+++ b/src/libraries/kunena/template/template.php
@@ -393,20 +393,6 @@ HTML;
 	}
 
 	/**
-	 *
-	 */
-	public function loadMootools()
-	{
-		JHtml::_('behavior.framework', true);
-
-		if (JDEBUG || KunenaFactory::getConfig()->debug)
-		{
-			// Debugging Mootools issues
-			$this->addScript('debug.js');
-		}
-	}
-
-	/**
 	 * @return array
 	 */
 	public function getStyleVariables()


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions
