### PR TITLE
Check php version in installer without the extra part else it fails

### DIFF
--- a/src/administrator/components/com_kunena/install/install.script.php
+++ b/src/administrator/components/com_kunena/install/install.script.php
@@ -170,7 +170,7 @@ class Com_KunenaInstallerScript
 	public function checkRequirements($version)
 	{
 		$db   = JFactory::getDbo();
-		$pass = $this->checkVersion('PHP', phpversion());
+		$pass = $this->checkVersion('PHP', $this->getCleanPhpVersion());
 		$pass &= $this->checkVersion('Joomla!', JVERSION);
 		$pass &= $this->checkVersion('MySQL', $db->getVersion());
 		$pass &= $this->checkDbo($db->name, array('mysql', 'mysqli', 'pdomysql'));
@@ -181,7 +181,19 @@ class Com_KunenaInstallerScript
 	}
 
 	// Internal functions
-
+	
+	/**
+	 * On some hosting the PHP version given with the version of the packet in the distribution
+	 * 
+	 * @param string $version The PHP version to clean
+	 */
+	protected function getCleanPhpVersion()
+	{
+		$version = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
+		
+		return $version;
+	}
+	
 	/**
 	 * @param $name
 	 * @param $version


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions

Try to install the Kunena on system where the php version contains the extra part like : 7.0.3-nmm1...
