### PR TITLE
Call to undefined method KunenaAccess::getGroupName()

### DIFF
--- a/src/libraries/kunena/access.php
+++ b/src/libraries/kunena/access.php
@@ -286,6 +286,33 @@ window.addEvent('domready', function(){
 
 		return $list;
 	}
+	
+	/**
+	 * Get group name in selected access type. Can be removed only when all the calls has been removed.
+	 *
+	 * @param string	$accesstype	Access type.
+	 * @param mixed		$id			Group id.
+	 * @return string|null
+	 *
+	 * @deprecated 3.0.1
+	 */
+	public function getGroupName($accesstype, $id)
+	{
+		if (!isset($this->accesstypes[$accesstype]))
+		{
+			return JText::sprintf('COM_KUNENA_INTEGRATION_UNKNOWN', $id);
+		}
+		
+		/** @var KunenaAccess $access */
+		foreach ($this->accesstypes[$accesstype] as $access)
+		{
+			if (method_exists($access, 'getGroupName'))
+			{
+				return $access->getGroupName($accesstype, $id);
+			}
+		}
+		return null;
+	}
 
 	/**
 	 * Get category administrators.


### PR DESCRIPTION
Pull Request for Issue  : https://www.kunena.org/forum/k5-0-bugs/136899-call-to-undefined-method-kunenaaccess-getgroupname-cb-integration-plugin
#### Summary of Changes
#### Testing Instructions
