### PR TITLE
Rank image size fails with allow_url_fopen disabled

### DIFF
--- a/src/libraries/kunena/user/user.php
+++ b/src/libraries/kunena/user/user.php
@@ -836,7 +836,7 @@ class KunenaUser extends JObject
 			}
 
 			$url = KunenaTemplate::getInstance()->getRankPath($rank->rank_image, true);
-			$location = JUri::root() . 'media/kunena/ranks/' . $rank->rank_image;
+			$location = JPATH_SITE . '/media/kunena/ranks/' . $rank->rank_image;
 			$data = getimagesize($location);
 			$width = $data[0];
 			$height = $data[1];


### PR DESCRIPTION
getimagesize is being used with a live_site path causing an HTTP request. This will fail if allow_url_fopen is disabled, which is hosting security standard to have disabled. Rank images are always internal to the Joomla site so absolute_path usage should be used.
