### PR TITLE
re-implements legacy side profile usage (from event)

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/topic/item/message/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/item/message/default.php
@@ -12,11 +12,12 @@ defined('_JEXEC') or die;
 $topicStarter = $this->topic->first_post_userid == $this->message->userid;
 $template = KunenaTemplate::getInstance();
 $direction = $template->params->get('avatarPosition');
+$sideProfile = $this->profile->getSideProfile($this);
 
 if ($direction === "left") : ?>
 	<div class="row-fluid message message-<?php echo $this->message->getState(); ?>">
 		<div class="span2 hidden-phone">
-			<?php echo $this->subLayout('User/Profile')->set('user', $this->profile)->setLayout('default')->set('topic_starter', $topicStarter)->set('category_id', $this->category->id); ?>
+			<?php echo ($sideProfile ? $sideProfile : $this->subLayout('User/Profile')->set('user', $this->profile)->setLayout('default')->set('topic_starter', $topicStarter)->set('category_id', $this->category->id)); ?>
 		</div>
 		<div class="span10">
 			<?php echo $this->subLayout('Message/Item')->setProperties($this->getProperties()); ?>
@@ -32,7 +33,7 @@ if ($direction === "left") : ?>
 			<?php echo $this->subLayout('Message/Edit')->set('message', $this->message)->set('captchaEnabled', $this->captchaEnabled)->setLayout('quickreply'); ?>
 		</div>
 		<div class="span2 hidden-phone">
-			<?php echo $this->subLayout('User/Profile')->set('user', $this->profile)->setLayout('default')->set('topic_starter', $topicStarter)->set('category_id', $this->category->id); ?>
+			<?php echo ($sideProfile ? $sideProfile : $this->subLayout('User/Profile')->set('user', $this->profile)->setLayout('default')->set('topic_starter', $topicStarter)->set('category_id', $this->category->id)); ?>
 		</div>
 	</div>
 <?php elseif ($direction === "top") : ?>

--- a/src/libraries/kunena/user/user.php
+++ b/src/libraries/kunena/user/user.php
@@ -1178,6 +1178,66 @@ class KunenaUser extends JObject
 	}
 
 	/**
+	 * Render user sidebar.
+	 *
+	 * @param KunenaLayout $layout
+	 *
+	 * @return string
+	 *
+	 * @since  K5.0
+	 */
+	public function getSideProfile($layout)
+	{
+		$config = KunenaFactory::getConfig();
+
+		$view                  = clone $layout;
+		$view->config          = $config;
+		$view->userkarma_title = $view->userkarma_minus = $view->userkarma_plus = '';
+
+		if ($view->config->showkarma && $this->userid)
+		{
+			$view->userkarma_title = JText::_('COM_KUNENA_KARMA') . ': ' . $this->karma;
+
+			if ($view->me->userid && $view->me->userid != $this->userid)
+			{
+				$view->userkarma_minus = ' ' . JHtml::_('kunenaforum.link', 'index.php?option=com_kunena&view=user&task=karmadown&userid=' . $this->userid . '&' . JSession::getFormToken() . '=1', '<span class="kkarma-minus" title="' . JText::_('COM_KUNENA_KARMA_SMITE') . '"> </span>');
+				$view->userkarma_plus  = ' ' . JHtml::_('kunenaforum.link', 'index.php?option=com_kunena&view=user&task=karmaup&userid=' . $this->userid . '&' . JSession::getFormToken() . '=1', '<span class="kkarma-plus" title="' . JText::_('COM_KUNENA_KARMA_APPLAUD') . '"> </span>');
+			}
+		}
+
+		$view->userkarma = "{$view->userkarma_title} {$view->userkarma_minus} {$view->userkarma_plus}";
+
+		if ($view->config->showuserstats)
+		{
+			$view->userrankimage = $this->getRank($layout->category->id, 'image');
+			$view->userranktitle = $this->getRank($layout->category->id, 'title');
+			$view->userposts     = $this->posts;
+			$view->userthankyou  = $this->thankyou;
+			$activityIntegration = KunenaFactory::getActivityIntegration();
+			$view->userpoints    = $activityIntegration->getUserPoints($this->userid);
+			$view->usermedals    = $activityIntegration->getUserMedals($this->userid);
+		}
+		else
+		{
+			$view->userrankimage = null;
+			$view->userranktitle = null;
+			$view->userposts     = null;
+			$view->userthankyou  = null;
+			$view->userpoints    = null;
+			$view->usermedals    = null;
+		}
+
+		$view->personalText = $this->getPersonalText();
+
+		$params = new \Joomla\Registry\Registry();
+		$params->set('ksource', 'kunena');
+		$params->set('kunena_view', 'topic');
+		$params->set('kunena_layout', $layout->getLayout());
+
+		return KunenaFactory::getProfile()->showProfile($view, $params);
+	}
+
+	/**
 	 * @param string $name
 	 *
 	 * @return string


### PR DESCRIPTION
The sidebar event usage which allows overriding the sidebar display in topics was completely lost in Kunena 5. This implements the sidebar event usage for left/right layouts and trys to maintain B/C.

Note his has only been tested with Community Builder. I have not tested this with other integrations.
