### PR TITLE
jQuery ready noConflict compatibility fixes

### DIFF
--- a/src/components/com_kunena/template/crypsis/assets/js/edit.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/edit.js
@@ -27,14 +27,14 @@ function kPreviewHelper(previewActive) {
 	}
 }
 
-jQuery(document).ready(function () {
-	jQuery('#tabs_kunena_editor a:first').tab('show');
+jQuery(document).ready(function ($) {
+	$('#tabs_kunena_editor a:first').tab('show');
 
-	jQuery('#tabs_kunena_editor a:last').click(function (e) {
+	$('#tabs_kunena_editor a:last').click(function (e) {
 		e.preventDefault();
 
-		var preview = jQuery("#kbbcode-preview");
-		var message = jQuery("#kbbcode-message");
+		var preview = $("#kbbcode-preview");
+		var message = $("#kbbcode-message");
 
 		preview.css('display', 'block');
 
@@ -47,36 +47,36 @@ jQuery(document).ready(function () {
 		preview.css('height', message.css('height'));
 	});
 
-	jQuery('#tabs_kunena_editor a:not(:last)').click(function (e) {
-		jQuery('#kbbcode-preview').hide();
-		jQuery('#kbbcode-message').css('display', 'inline-block');
-		jQuery('#markItUpKbbcode-message').css('display', 'inline-block');
+	$('#tabs_kunena_editor a:not(:last)').click(function (e) {
+		$('#kbbcode-preview').hide();
+		$('#kbbcode-message').css('display', 'inline-block');
+		$('#markItUpKbbcode-message').css('display', 'inline-block');
 	});
 
-	jQuery('#tabs_kunena_editor a:last').click(function (e) {
-		jQuery('#kbbcode-message').hide();
-		jQuery('#markItUpKbbcode-message').hide();
+	$('#tabs_kunena_editor a:last').click(function (e) {
+		$('#kbbcode-message').hide();
+		$('#markItUpKbbcode-message').hide();
 	});
 
 	/* To enabled emojis in kunena textera feature like on github */
-	if (jQuery('#kemojis_allowed').val()==1) {
+	if ($('#kemojis_allowed').val()==1) {
 		var item = '';
-		if (jQuery('#kbbcode-message').length > 0 && jQuery('.qreply').length == 0) {
+		if ($('#kbbcode-message').length > 0 && $('.qreply').length == 0) {
 			item = '#kbbcode-message';
-		} else if (jQuery('.qreply').length > 0) {
+		} else if ($('.qreply').length > 0) {
 			item = '.qreply';
 		}
 
 		if (item != undefined) {
-			jQuery(item).atwho({
+			$(item).atwho({
 				at              : ":",
 				displayTpl      : "<li data-value='${key}'>${name} <img src='${url}' height='20' width='20' /></li>",
 				insertTpl       : ':${name}:',
 				callbacks: {
 					remoteFilter: function (query, callback) {
 						if (query.length > 0) {
-							jQuery.ajax({
-								url    : jQuery("#kurl_emojis").val(),
+							$.ajax({
+								url    : $("#kurl_emojis").val(),
 								data   : {
 									search: query
 								},
@@ -92,63 +92,62 @@ jQuery(document).ready(function () {
 	}
 
 	/* Store form data into localstorage every 1 second */
-	if (jQuery.fn.sisyphus != undefined) {
-		jQuery("#postform").sisyphus({
+	if ($.fn.sisyphus != undefined) {
+		$("#postform").sisyphus({
 			locationBased: true,
 			timeout      : 5
 		});
 	}
 
-	jQuery('#kshow_attach_form').click(function () {
-		if (jQuery('#kattach_form').is(":visible")) {
-			jQuery('#kattach_form').hide();
+	$('#kshow_attach_form').click(function () {
+		if ($('#kattach_form').is(":visible")) {
+			$('#kattach_form').hide();
 		}
 		else {
-			jQuery('#kattach_form').show();
+			$('#kattach_form').show();
 		}
 	});
 
 	// Load topic icons by ajax request
-	jQuery('#postcatid').change(function () {
-		var catid = jQuery('select#postcatid option').filter(':selected').val();
-		var kurl_topicons_request = jQuery('#kurl_topicons_request').val();
+	$('#postcatid').change(function () {
+		var catid = $('select#postcatid option').filter(':selected').val();
+		var kurl_topicons_request = $('#kurl_topicons_request').val();
 
-		if (jQuery('#kanynomous-check').length > 0) {
+		if ($('#kanynomous-check').length > 0) {
 			if (arrayanynomousbox[catid] !== undefined) {
-				jQuery('#kanynomous-check').show();
-				jQuery('#kanonymous').prop('checked', true);
+				$('#kanynomous-check').show();
+				$('#kanonymous').prop('checked', true);
 			} else {
-				jQuery('#kanynomous-check').hide();
-				jQuery('#kanonymous').prop('checked', false);
+				$('#kanynomous-check').hide();
+				$('#kanonymous').prop('checked', false);
 			}
 		}
 
-		jQuery.ajax({
+		$.ajax({
 			type    : 'POST',
 			url     : kurl_topicons_request,
 			async   : false,
 			dataType: 'json',
 			data    : {catid: catid},
 			success : function (data) {
-				jQuery('#iconset_topic_list').remove();
+				$('#iconset_topic_list').remove();
 
-				var div_object = jQuery('<div>', {'id': 'iconset_topic_list'});
+				var div_object = $('<div>', {'id': 'iconset_topic_list'});
 
-				jQuery('#iconset_inject').append(div_object);
+				$('#iconset_inject').append(div_object);
 
-				jQuery.each(data, function (index, value) {
+				$.each(data, function (index, value) {
 					if (value.type != 'system') {
 						if (value.id == 0) {
-							var input = jQuery('<input>', {
+							var input = $('<input>', {
 								type   : 'radio',
 								id     : 'radio' + value.id,
-								checked: 'checked',
 								name   : 'topic_emoticon',
 								value  : value.id
-							});
+							}).prop('checked',true);
 						}
 						else {
-							var input = jQuery('<input>', {
+							var input = $('<input>', {
 								type : 'radio',
 								id   : 'radio' + value.id,
 								name : 'topic_emoticon',
@@ -156,45 +155,45 @@ jQuery(document).ready(function () {
 							});
 						}
 
-						var span_object = jQuery('<span>', {'class': 'kiconsel'}).append(input);
+						var span_object = $('<span>', {'class': 'kiconsel'}).append(input);
 
 						if (kunena_topicicontype=='B2') {
-							var label = jQuery('<label>', {
+							var label = $('<label>', {
 								'class': 'radio inline',
 								'for'  : 'radio' + value.id
-							}).append(jQuery('<span>', {
+							}).append($('<span>', {
 								'class' : 'icon icon-topic icon-' + value.b2,
 								'border': '0',
 								'al'    : ''
 							}));
 						} else if(kunena_topicicontype=='fa') {
-							var label = jQuery('<label>', {
+							var label = $('<label>', {
 								'class': 'radio inline',
 								'for'  : 'radio' + value.id
-							}).append(jQuery('<i>', {
+							}).append($('<i>', {
 								'class' : 'fa glyphicon-topic fa-2x fa-' + value.fa,
 								'border': '0',
 								'al'    : ''
 							}));
 						} else {
-							var label = jQuery('<label>', {
+							var label = $('<label>', {
 								'class': 'radio inline',
 								'for'  : 'radio' + value.id
-							}).append(jQuery('<img>', {'src': value.path, 'border': '0', 'al': ''}));
+							}).append($('<img>', {'src': value.path, 'border': '0', 'al': ''}));
 						}
 
 						span_object.append(label);
 
-						jQuery('#iconset_topic_list').append(span_object);
+						$('#iconset_topic_list').append(span_object);
 					}
 				});
 			}
 		});
 	});
 
-	if (jQuery.fn.datepicker != undefined) {
+	if ($.fn.datepicker != undefined) {
 		// Load datepicker for poll
-		jQuery('#datepoll-container .input-append.date').datepicker({
+		$('#datepoll-container .input-append.date').datepicker({
 			orientation: "top auto"
 		});
 	}

--- a/src/components/com_kunena/template/crypsis/assets/js/krating.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/krating.js
@@ -7,16 +7,16 @@
  * @link        https://www.kunena.org
  **/
 
-jQuery(document).ready(function() {
+jQuery(document).ready(function($) {
 	// Krating element
 	var krating = document.querySelector('#krating');
 
 	// Initialize
 	(function init() {
-		var topic_id = jQuery("#topic_id").val();
+		var topic_id = $("#topic_id").val();
 		
-		if (jQuery('#krating').length > 0) {
-			jQuery.ajax({
+		if ($('#krating').length > 0) {
+			$.ajax({
 				 dataType: "json",
 				 url: 'index.php?option=com_kunena&view=topic&layout=getrate&format=raw',
 				 data: 'topic_id=' + topic_id 
@@ -43,21 +43,21 @@ jQuery(document).ready(function() {
 		var currentRating = rate;
 		var maxRating = 5;
 		var callback = function(rating) {
-			jQuery.ajax({
+			$.ajax({
 				dataType: "json",
-				url: jQuery('#krating_submit_url').val(),
+				url: $('#krating_submit_url').val(),
 				data: 'starid=' + rating + '&topic_id=' + topicid  
 				}).done(function(response) {
 					if (response.success)
 					{
-						jQuery('<div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Success</h4>'+Joomla.JText._(response.message)+'</div>').appendTo('#system-message-container');
+						$('<div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Success</h4>'+Joomla.JText._(response.message)+'</div>').appendTo('#system-message-container');
 					}
 					else
 					{
-						jQuery('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Warning!</h4>'+Joomla.JText._(response.message)+'</div>').appendTo('#system-message-container');
+						$('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Warning!</h4>'+Joomla.JText._(response.message)+'</div>').appendTo('#system-message-container');
 					}
 				}).fail(function(reponse) {
-					jQuery('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Warning!</h4>'+reponse+'</div>').appendTo('#system-message-container');
+					$('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Warning!</h4>'+reponse+'</div>').appendTo('#system-message-container');
 				});  
 		};
 		var r = rating(ratingElement, currentRating, maxRating, callback);

--- a/src/components/com_kunena/template/crypsis/assets/js/main.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/main.js
@@ -15,9 +15,9 @@ function kunenatableOrdering( order, dir, task, form ) {
 	form.submit( task );
 }
 
-jQuery(document).ready(function() {
+jQuery(document).ready(function($) {
 	/* To hide or open collapse localStorage */
-	jQuery('.collapse').on('hidden', function() {
+	$('.collapse').on('hidden', function() {
 				if (this.id) {
 						localStorage[this.id] = 'true';
 				}
@@ -27,54 +27,54 @@ jQuery(document).ready(function() {
 				}
 		}).each(function() {
 				if (this.id && localStorage[this.id] === 'true' ) {
-						jQuery(this).collapse('hide');
+						$(this).collapse('hide');
 				}
 	});
 
 	/* To check or uncheck boxes to select items */
-	jQuery('input.kcheckall').click(function() {
-		jQuery( '.kcheck' ).each(function( ) {
-			jQuery(this).prop('checked',!jQuery(this).prop('checked'));
+	$('input.kcheckall').click(function() {
+		$( '.kcheck' ).each(function( ) {
+			$(this).prop('checked',!$(this).prop('checked'));
 		});
 	});
 
 	/* Allow to make working drop-down choose destination */
-	jQuery('#kchecktask').change(function() {
-		var task = jQuery("select#kchecktask").val();
+	$('#kchecktask').change(function() {
+		var task = $("select#kchecktask").val();
 		if (task=='move') {
-			jQuery("#kchecktarget").attr('disabled', false).trigger("liszt:updated");
+			$("#kchecktarget").attr('disabled', false).trigger("liszt:updated");
 		} else {
-			jQuery("#kchecktarget").attr('disabled', true);
+			$("#kchecktarget").attr('disabled', true);
 		}
 	});
 
-	jQuery("input.kcatcheckall").click(function(){
-		jQuery("input.kcatcheckall:checkbox").not(this).prop('checked', this.checked);
+	$("input.kcatcheckall").click(function(){
+		$("input.kcatcheckall:checkbox").not(this).prop('checked', this.checked);
 	});
 
-	jQuery("input.kcheckallcategories").click(function(){
-		jQuery("input.kcheckallcategory:checkbox").not(this).prop('checked', this.checked);
+	$("input.kcheckallcategories").click(function(){
+		$("input.kcheckallcategory:checkbox").not(this).prop('checked', this.checked);
 	});
 
-	jQuery(document).ready(function() {
-		jQuery('[rel=popover]').popover();
+	$(document).ready(function() {
+		$('[rel=popover]').popover();
 	});
 
-	jQuery('#avatar_gallery_select').change(function() {
-		var gallery_selected = jQuery("select#avatar_gallery_select").val();
+	$('#avatar_gallery_select').change(function() {
+		var gallery_selected = $("select#avatar_gallery_select").val();
 
-		var gallery_list = jQuery('#gallery_list');
+		var gallery_list = $('#gallery_list');
 
 		// We remove avatar which exist in td tag to allow us to put new one items
 		gallery_list.empty();
 
 		// Get the list of images from the gallery selected drop-down above
-		jQuery.ajax({
+		$.ajax({
 			 dataType: "json",
 			 url: 'index.php?option=com_kunena&view=user&layout=galleryimages&format=raw',
 			 data: 'gallery_name=' + gallery_selected
 		}).done(function(response) {
-       jQuery.each(response, function( key, value ) {
+       $.each(response, function( key, value ) {
 				  gallery_list.append('<li class="span2"><input id="radio'+gallery_selected+'/'+value.filename+'" type="radio" value="gallery/'+gallery_selected+'/'+value.filename+'" name="avatar"><label class=" radio thumbnail" for="radio'+gallery_selected+'/'+value.filename+'"><img alt="" src="'+value.url+'"></label></li>');
 			  });
 		}).fail(function(response) {
@@ -82,19 +82,19 @@ jQuery(document).ready(function() {
 		});
 	});
 
-	if (jQuery.fn.datepicker != undefined) {
+	if ($.fn.datepicker != undefined) {
 		// Load datepicker for announcement
-		jQuery('#ann-date .input-append.date').datepicker({
+		$('#ann-date .input-append.date').datepicker({
 			orientation: "top auto",
 			format: "yyyy-mm-dd"
 		});
 
-		jQuery('#ann-date2 .input-append.date').datepicker({
+		$('#ann-date2 .input-append.date').datepicker({
 			orientation: "top auto",
 			format: "yyyy-mm-dd"
 		});
 
-		jQuery('#ann-date3 .input-append.date').datepicker({
+		$('#ann-date3 .input-append.date').datepicker({
 			orientation: "top auto",
 			format: "yyyy-mm-dd"
 		});

--- a/src/components/com_kunena/template/crypsis/assets/js/markitup.set.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/markitup.set.js
@@ -10,20 +10,20 @@
 // Feel free to add more tags
 // ----------------------------------------------------------------------------
 
-jQuery(document).ready(function (){
-	jQuery('#kbbcode-message').markItUp(bbcodeSettings);
+jQuery(document).ready(function ($){
+	$('#kbbcode-message').markItUp(bbcodeSettings);
 
-	if (jQuery('#modal-code').length == 0) {
-		jQuery('.codemodalboxbutton').hide();
+	if ($('#modal-code').length == 0) {
+		$('.codemodalboxbutton').hide();
 	} else {
-		jQuery('.codesimplebutton').hide();
+		$('.codesimplebutton').hide();
 	}
 
 	// For code
-	jQuery('#code-modal-submit').click(function() {
-		var codetype = jQuery("#kcodetype option:selected").val();
+	$('#code-modal-submit').click(function() {
+		var codetype = $("#kcodetype option:selected").val();
 
-		jQuery.markItUp(
+		$.markItUp(
 			{ openWith:'[code type="'+codetype+'"]',
 			  closeWith:'[/code]' }
 		);
@@ -31,10 +31,10 @@ jQuery(document).ready(function (){
 	});
 
 	// For map
-	jQuery('#map-modal-submit').click(function() {
-		var modalcity = jQuery('#modal-map-city').val();
-		var modaltype = jQuery('#modal-map-type').val();
-		var modalzoom = jQuery('#modal-map-zoomlevel').val();
+	$('#map-modal-submit').click(function() {
+		var modalcity = $('#modal-map-city').val();
+		var modaltype = $('#modal-map-type').val();
+		var modalzoom = $('#modal-map-zoomlevel').val();
 		var type = '';
 		var zoom = '';
 
@@ -48,7 +48,7 @@ jQuery(document).ready(function (){
 			zoom = 'zoom='+modalzoom;
 		}
 
-		jQuery.markItUp(
+		$.markItUp(
 		{ openWith:'[map '+type+' '+zoom+']'+modalcity,
 		  closeWith:'[/map]' }
 		);
@@ -56,9 +56,9 @@ jQuery(document).ready(function (){
 	});
 
 	// For picture settings
-	jQuery('#picture-modal-submit').click(function() {
-		var modalpictureurl = jQuery('#modal-picture-url').val();
-		var modalpicturesize = jQuery('#modal-picture-size').val();
+	$('#picture-modal-submit').click(function() {
+		var modalpictureurl = $('#modal-picture-url').val();
+		var modalpicturesize = $('#modal-picture-size').val();
 
 		var size = '';
 		if ( modalpicturesize.length > 0 ) {
@@ -66,7 +66,7 @@ jQuery(document).ready(function (){
 		}
 
 		if ( modalpictureurl.length > 0 ) {
-			jQuery.markItUp(
+			$.markItUp(
 				{ openWith:'[img '+size+']'+modalpictureurl,
 				closeWith:'[/img]' }
 			);
@@ -75,9 +75,9 @@ jQuery(document).ready(function (){
 	});
 
 	//For link settings
-	jQuery('#link-modal-submit').click(function() {
-		var modallinkurl = jQuery('#modal-link-url').val();
-		var modallinktext = jQuery('#modal-link-text').val();
+	$('#link-modal-submit').click(function() {
+		var modallinkurl = $('#modal-link-url').val();
+		var modallinktext = $('#modal-link-text').val();
 
 		var text = '';
 		if ( modallinktext.length > 0 ) {
@@ -88,7 +88,7 @@ jQuery(document).ready(function (){
 		}
 
 		if ( modallinkurl.length > 0 ) {
-			jQuery.markItUp(
+			$.markItUp(
 			{ openWith:'[url='+modallinkurl+']'+text,
 				closeWith:'[/url]' }
 			);
@@ -98,13 +98,13 @@ jQuery(document).ready(function (){
 	});
 
 	// For video settings
-	jQuery('#videosettings-modal-submit').click(function() {
-		var kvideoprovider = jQuery('#kvideoprovider-modal').val();
-		var providerid = jQuery('#modal-video-id').val();
-		var videowidth = jQuery('#modal-video-width').val();
-		var videoheight = jQuery('#modal-video-height').val();
-		var videosize = jQuery('#modal-video-size').val();
-		var kvideoproviderlist = jQuery("#kvideoprovider-list-modal option:selected").val();
+	$('#videosettings-modal-submit').click(function() {
+		var kvideoprovider = $('#kvideoprovider-modal').val();
+		var providerid = $('#modal-video-id').val();
+		var videowidth = $('#modal-video-width').val();
+		var videoheight = $('#modal-video-height').val();
+		var videosize = $('#modal-video-size').val();
+		var kvideoproviderlist = $("#kvideoprovider-list-modal option:selected").val();
 
 		var width = '425';
 		var height = '344';
@@ -121,10 +121,10 @@ jQuery(document).ready(function (){
 			size = 'size='+videosize;
 		}
 
-		if (jQuery('#kvideoprovider-modal').length > 0)
+		if ($('#kvideoprovider-modal').length > 0)
 		{
 			if ( kvideoprovider.lentgth > 0 && providerid.length > 0 ) {
-				jQuery.markItUp(
+				$.markItUp(
 					{ openWith:'[video '+size+' '+width+' '+height+' type='+kvideoprovider+']'+providerid,
 					closeWith:'[/video]' }
 				);
@@ -133,7 +133,7 @@ jQuery(document).ready(function (){
 		}
 		else
 		{
-			jQuery.markItUp(
+			$.markItUp(
 				{ openWith:'[video '+size+' '+width+' '+height+' type='+kvideoproviderlist+']'+providerid,
 				closeWith:'[/video]' }
 			);
@@ -142,10 +142,10 @@ jQuery(document).ready(function (){
 	});
 
 	// For video provider URL
-	jQuery('#videourlprovider-modal-submit').click(function() {
-		var providerurl = jQuery('#modal-video-urlprovider-input').val();
+	$('#videourlprovider-modal-submit').click(function() {
+		var providerurl = $('#modal-video-urlprovider-input').val();
 
-		jQuery.markItUp(
+		$.markItUp(
 			{ openWith:'[video]'+providerurl,
 			closeWith:'[/video]' }
 		);
@@ -153,10 +153,10 @@ jQuery(document).ready(function (){
 	});
 
 	// For smileys
-	jQuery('.smileyimage').click(function() {
-		var smiley = jQuery(this).attr('alt');
+	$('.smileyimage').click(function() {
+		var smiley = $(this).attr('alt');
 
-		jQuery.markItUp(
+		$.markItUp(
 			 { openWith:smiley,
 			closeWith:'' }
 		);
@@ -164,62 +164,62 @@ jQuery(document).ready(function (){
 	});
 
 	if (!kunena_showvideotag) {
-		jQuery('.videodropdownbutton').remove();
+		$('.videodropdownbutton').remove();
 	}
 
 	if (!kunena_disemoticons) {
-		jQuery('.emoticonsbutton').remove();
+		$('.emoticonsbutton').remove();
 	}
 
 	if (!kunena_showebaytag) {
-		jQuery('.ebaybutton').remove();
+		$('.ebaybutton').remove();
 	}
 
 	if (!kunena_showspoilertag) {
-		jQuery('.spoilerbutton').remove();
+		$('.spoilerbutton').remove();
 	}
 
 	if (!kunena_showmapstag) {
-		jQuery('.mapbutton').remove();
+		$('.mapbutton').remove();
 	}
 
 	if (!kunena_showtwittertag) {
-		jQuery('.tweetbutton').remove();
+		$('.tweetbutton').remove();
 	}
 
 	if (!kunena_showlinktag) {
-		jQuery('.linkbutton').remove();
+		$('.linkbutton').remove();
 	}
 
 	if (!kunena_showpicturetag) {
-		jQuery('.picturebutton').remove();
+		$('.picturebutton').remove();
 	}
 
 	if (!kunena_showhidetag) {
-		jQuery('.hiddentextbutton').remove();
+		$('.hiddentextbutton').remove();
 	}
 
 	if (!kunena_showtabletag) {
-		jQuery('.tablebutton').remove();
+		$('.tablebutton').remove();
 	}
 
 	if (!kunena_showcodetag) {
-		jQuery('.codesimplebutton').remove();
+		$('.codesimplebutton').remove();
 	}
 
 	if (!kunena_showquotetag) {
-		jQuery('.quotebutton').remove();
+		$('.quotebutton').remove();
 	}
 
 	if (!kunena_showdividertag) {
-		jQuery('.markItUpSeparator').remove();
+		$('.markItUpSeparator').remove();
 	}
 
 	if (!kunena_showinstagramtag) {
-		jQuery('.instagrambutton').remove();
+		$('.instagrambutton').remove();
 	}
 
 	if (!kunena_showsoundcloudtag) {
-		jQuery('.soundcloudbutton').remove();
+		$('.soundcloudbutton').remove();
 	}
 });

--- a/src/components/com_kunena/template/crypsis/assets/js/poll.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/poll.js
@@ -7,13 +7,13 @@
 * @link https://www.kunena.org
 **/
 
-jQuery(document).ready(function() {
+jQuery(document).ready(function($) {
 	/**
 	 * Get the number of field options inserted in form
 	 */
 	function getOptionsNumber()
 	{
-		var myoptions = jQuery('#kbbcode-poll-options').children('div.polloption');
+		var myoptions = $('#kbbcode-poll-options').children('div.polloption');
 
 		return myoptions.length;
 	}
@@ -25,9 +25,9 @@ jQuery(document).ready(function() {
 		var	options = getOptionsNumber();
 		options++;
 
-		var polldiv = jQuery('<div></div>').attr('class','polloption').appendTo('#kbbcode-poll-options');
+		var polldiv = $('<div></div>').attr('class','polloption').appendTo('#kbbcode-poll-options');
 
-		var label = jQuery('<label>').text(Joomla.JText._('COM_KUNENA_POLL_OPTION_NAME')+' '+options+' ');
+		var label = $('<label>').text(Joomla.JText._('COM_KUNENA_POLL_OPTION_NAME')+' '+options+' ');
 		polldiv.append(label);
 
 		newInput = document.createElement('input');
@@ -39,9 +39,9 @@ jQuery(document).ready(function() {
 		polldiv.append(newInput);
 	}
 
-	if( jQuery('#kbutton-poll-add') != undefined ) {
-		jQuery('#kbutton-poll-add').click(function() {
-			var nboptionsmax = jQuery('#nb_options_allowed').val();
+	if( $('#kbutton-poll-add') != undefined ) {
+		$('#kbutton-poll-add').click(function() {
+			var nboptionsmax = $('#nb_options_allowed').val();
 			var koptions = getOptionsNumber();
 
 			if(!nboptionsmax || (koptions < nboptionsmax && koptions >= 2) ){
@@ -51,69 +51,69 @@ jQuery(document).ready(function() {
 				createNewOptionField();
 			} else {
 				// Set error message with alert bootstrap way
-				jQuery('#kpoll-alert-error').show();
+				$('#kpoll-alert-error').show();
 
-				jQuery('#kbutton-poll-add').hide();
+				$('#kbutton-poll-add').hide();
 			}
 		});
 	}
-	if( jQuery('#kbutton-poll-rem') != undefined ) {
-		jQuery('#kbutton-poll-rem').click(function() {
-			var koption = jQuery ('div.polloption:last');
+	if( $('#kbutton-poll-rem') != undefined ) {
+		$('#kbutton-poll-rem').click(function() {
+			var koption = $ ('div.polloption:last');
 			if(koption) {
-				var isvisible = jQuery('#kpoll-alert-error').is(":visible");
+				var isvisible = $('#kpoll-alert-error').is(":visible");
 
 				if (isvisible){
-					jQuery('#kpoll-alert-error').hide();
+					$('#kpoll-alert-error').hide();
 
-					jQuery('#kbutton-poll-add').show();
+					$('#kbutton-poll-add').show();
 				}
 				koption.remove();
 			}
 		});
 	}
 
-	if( jQuery('#postcatid') != undefined ) {
-		jQuery('#postcatid').change(function() {
-			var catid = jQuery('select#postcatid option').filter(':selected').val();
+	if( $('#postcatid') != undefined ) {
+		$('#postcatid').change(function() {
+			var catid = $('select#postcatid option').filter(':selected').val();
 			if ( pollcategoriesid[catid] !== undefined ) {
-				jQuery('.pollbutton').show();
+				$('.pollbutton').show();
 			} else {
-				jQuery('.pollbutton').hide();
+				$('.pollbutton').hide();
 			}
 		});
 	}
 
-	jQuery('#kpoll_go_results').click(function() {
-		if(jQuery('#poll-results').is(':visible')==true)
+	$('#kpoll_go_results').click(function() {
+		if($('#poll-results').is(':visible')==true)
 		{
-			jQuery('#poll-results').hide();
-			jQuery('#kpoll_hide_results').hide();
+			$('#poll-results').hide();
+			$('#kpoll_hide_results').hide();
 		}
 		else
 		{
-			jQuery('#poll-results').show();
-			jQuery('#kpoll_hide_results').show();
-			jQuery('#kpoll_go_results').hide();
+			$('#poll-results').show();
+			$('#kpoll_hide_results').show();
+			$('#kpoll_go_results').hide();
 		}
 	});
 
-	jQuery('#kpoll_hide_results').click(function() {
-		if(jQuery('#poll-results').is(':visible')==true)
+	$('#kpoll_hide_results').click(function() {
+		if($('#poll-results').is(':visible')==true)
 		{
-			jQuery('#poll-results').hide();
-      jQuery('#kpoll_go_results').show();
-			jQuery('#kpoll_hide_results').hide();
+			$('#poll-results').hide();
+      $('#kpoll_go_results').show();
+			$('#kpoll_hide_results').hide();
 		}
 		else
 		{
-			jQuery('#poll-results').show();
-			jQuery('#kpoll_hide_results').show();
-			jQuery('#kpoll_go_results').hide();
+			$('#poll-results').show();
+			$('#kpoll_hide_results').show();
+			$('#kpoll_go_results').hide();
 		}
 	});
 
-	jQuery('#kpoll-moreusers').click(function() {
-		jQuery('#kpoll-moreusers-div').show();
+	$('#kpoll-moreusers').click(function() {
+		$('#kpoll-moreusers-div').show();
 	});
 });

--- a/src/components/com_kunena/template/crypsis/assets/js/pollcheck.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/pollcheck.js
@@ -7,18 +7,18 @@
 * @link https://www.kunena.org
 **/
 
-jQuery(document).ready(function() {
-	if ( typeof pollcategoriesid != 'undefined' && jQuery('#poll_exist_edit').length == 0 ) {
-		var catid = jQuery('#kcategory_poll').val();
+jQuery(document).ready(function($) {
+	if ( typeof pollcategoriesid != 'undefined' && $('#poll_exist_edit').length == 0 ) {
+		var catid = $('#kcategory_poll').val();
 
 		if ( pollcategoriesid[catid] !== undefined ) {
-			jQuery('.pollbutton').show();
+			$('.pollbutton').show();
 		} else {
-			jQuery('.pollbutton').hide();
+			$('.pollbutton').hide();
 		}
-	} else if ( jQuery('#poll_exist_edit').length > 0 ) {
-		jQuery('.pollbutton').show();
+	} else if ( $('#poll_exist_edit').length > 0 ) {
+		$('.pollbutton').show();
 	} else {
-		jQuery('.pollbutton').hide();
+		$('.pollbutton').hide();
 	}
 });

--- a/src/components/com_kunena/template/crypsis/assets/js/search.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/search.js
@@ -7,19 +7,19 @@
  * @link https://www.kunena.org
  **/
 
-jQuery(document).ready(function() {
+jQuery(document).ready(function($) {
 
 	/* Provide autocomplete user list in search form and in user list */
-	if ( jQuery( '#kurl_users' ).length > 0 ) {
-		var users_url = jQuery( '#kurl_users' ).val();
+	if ( $( '#kurl_users' ).length > 0 ) {
+		var users_url = $( '#kurl_users' ).val();
 
 		var NameObjs = {};
 		var UserNames = [];
 
-		jQuery("#kusersearch").typeahead({
+		$("#kusersearch").typeahead({
 			source: function ( query, process ) {
 
-			jQuery.ajax({
+			$.ajax({
 				url: users_url
 				,cache: false
 				,success: function(data){
@@ -28,7 +28,7 @@ jQuery(document).ready(function() {
 					NameObjs = {};
 					UserNames = [];
 
-					jQuery.each( data, function( index, item ){
+					$.each( data, function( index, item ){
 
 						//for each iteration of this loop the "item" argument contains
 						//1 user object from the array in our json, such as:
@@ -60,8 +60,8 @@ jQuery(document).ready(function() {
 	}
 
 	/* Hide search form when there are search results found */
-	if ( jQuery('#kunena_search_results').is(':visible') ) {
-		jQuery('#search').collapse("hide");
+	if ( $('#kunena_search_results').is(':visible') ) {
+		$('#search').collapse("hide");
 	}
 });
 

--- a/src/components/com_kunena/template/crypsis/assets/js/topic.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/topic.js
@@ -7,80 +7,80 @@
  * @link https://www.kunena.org
  **/
 
-jQuery(document).ready(function () {
+jQuery(document).ready(function ($) {
 
 	/* To hide or open spoiler on click */
-	jQuery('.kspoiler').each(function( index ) {
-		jQuery( this ).click(function() {
-			if ( !jQuery(this).find('.kspoiler-content').is(':visible') ) {
-				jQuery(this).find('.kspoiler-content').show();
-				jQuery(this).find('.kspoiler-expand').hide();
-				jQuery(this).find('.kspoiler-hide').show();
+	$('.kspoiler').each(function( index ) {
+		$( this ).click(function() {
+			if ( !$(this).find('.kspoiler-content').is(':visible') ) {
+				$(this).find('.kspoiler-content').show();
+				$(this).find('.kspoiler-expand').hide();
+				$(this).find('.kspoiler-hide').show();
 			} else {
-				jQuery(this).find('.kspoiler-content').hide();
-				jQuery(this).find('.kspoiler-expand').show();
-				jQuery(this).find('.kspoiler-hide').hide();
+				$(this).find('.kspoiler-content').hide();
+				$(this).find('.kspoiler-expand').show();
+				$(this).find('.kspoiler-hide').hide();
 			}
 		});
 	});
 
 	/* To allow to close or open the quick-reply modal box */
-	jQuery('.openmodal').click(function () {
-		var boxToOpen = jQuery(this).attr('href');
-		jQuery(boxToOpen).css('visibility', 'visible');
+	$('.openmodal').click(function () {
+		var boxToOpen = $(this).attr('href');
+		$(boxToOpen).css('visibility', 'visible');
 	});
 
 	/* Button to show more info on profilebox */
-	jQuery(".heading").click(function () {
-		if (!jQuery(this).hasClass('heading-less')) {
-			jQuery(this).prev(".heading").show();
-			jQuery(this).hide();
-			jQuery(this).next(".content").slideToggle(500);
+	$(".heading").click(function () {
+		if (!$(this).hasClass('heading-less')) {
+			$(this).prev(".heading").show();
+			$(this).hide();
+			$(this).next(".content").slideToggle(500);
 		} else {
-			var content = jQuery(this).next(".heading").show();
-			jQuery(this).hide();
+			var content = $(this).next(".heading").show();
+			$(this).hide();
 			content.next(".content").slideToggle(500);
 		}
 	});
 
 	/* On moderate page display subject or field to enter manually the topic ID */
-	jQuery('#kmod_topics').change(function () {
-		var id_item_selected = jQuery(this).val();
+	$('#kmod_topics').change(function () {
+		var id_item_selected = $(this).val();
 		if (id_item_selected != 0) {
-			jQuery('#kmod_subject').hide();
+			$('#kmod_subject').hide();
 		} else {
-			jQuery('#kmod_subject').show();
+			$('#kmod_subject').show();
 		}
 
 		if (id_item_selected == -1) {
-			jQuery('#kmod_targetid').show();
+			$('#kmod_targetid').show();
 		} else {
-			jQuery('#kmod_targetid').hide();
+			$('#kmod_targetid').hide();
 		}
 	});
 
-	if (jQuery.fn.jsSocials != undefined) {
-		jQuery("#share").jsSocials({
+	if ($.fn.jsSocials != undefined) {
+		$("#share").jsSocials({
 			showCount: true,
 			showLabel: true,
 			shares: ["email", "twitter", "facebook", "googleplus", "linkedin", "pinterest", "stumbleupon", "whatsapp"]
 		});
 	}
 
-	jQuery('#kmod_categories').change(function () {
-		jQuery.getJSON(
-			kunena_url_ajax, {catid: jQuery(this).val()}
+	$('#kmod_categories').change(function () {
+		$.getJSON(
+			kunena_url_ajax, {catid: $(this).val()}
 		).done(function (json) {
-			var first_item = jQuery('#kmod_topics option:nth(0)').clone();
-			var second_item = jQuery('#kmod_topics option:nth(1)').clone();
+			var first_item = $('#kmod_topics option:nth(0)').clone();
+			var second_item = $('#kmod_topics option:nth(1)').clone();
 
-			jQuery('#kmod_topics').empty();
+			$('#kmod_topics').empty();
 			first_item.appendTo('#kmod_topics');
 			second_item.appendTo('#kmod_topics');
 
-			jQuery.each(json, function (index, object) {
-				jQuery.each(object, function (key, element) {
-					jQuery('#kmod_topics').append('<option value="' + element['id'] + '">' + element['subject'] + '</option>');
+			$.each(json, function (index, object) {
+				$.each(object, function (key, element) {
+					$('#kmod_topics').append('<option value="' + element['id'] + '">' + element['subject'] + '</option>');
 				});
 			});
 		});

--- a/src/components/com_kunena/template/crypsis/assets/js/upload.main.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/upload.main.js
@@ -3,9 +3,9 @@ jQuery(function ($) {
 
 	// Insert bbcode in message
 	function insertInMessage(attachid, filename, button) {
-		var value = jQuery('#kbbcode-message').val();
+		var value = $('#kbbcode-message').val();
 
-		jQuery('#kbbcode-message').val(value + ' [attachment=' + attachid + ']' + filename + '[/attachment]');
+		$('#kbbcode-message').val(value + ' [attachment=' + attachid + ']' + filename + '[/attachment]');
 
 		if (button != undefined) {
 			button.removeClass('btn-primary');
@@ -17,21 +17,21 @@ jQuery(function ($) {
 	var fileCount = null;
 	var filesedit = null;
 
-	jQuery('#remove-all').on('click', function (e) {
+	$('#remove-all').on('click', function (e) {
 		e.preventDefault();
 
 		// Removing items in edit if they are present
 		if ($.isEmptyObject(filesedit) == false) {
 			$(filesedit).each(function (index, file) {
-				if (jQuery('#kattachs-' + file.id).length == 0) {
-					jQuery('#kattach-list').append('<input id="kattachs-' + file.id + '" type="hidden" name="attachments[' + file.id + ']" value="1" />');
+				if ($('#kattachs-' + file.id).length == 0) {
+					$('#kattach-list').append('<input id="kattachs-' + file.id + '" type="hidden" name="attachments[' + file.id + ']" value="1" />');
 				}
 
-				if (jQuery('#kattach-' + file.id).length > 0) {
-					jQuery('#kattach-' + file.id).remove();
+				if ($('#kattach-' + file.id).length > 0) {
+					$('#kattach-' + file.id).remove();
 				}
 
-				jQuery.ajax({
+				$.ajax({
 					url    : kunena_upload_files_rem + '&fil_id=' + file.id,
 					type   : 'DELETE',
 					success: function (result) {
@@ -43,7 +43,7 @@ jQuery(function ($) {
 			filesedit = null;
 		}
 
-		var child = jQuery('#kattach-list').find('input');
+		var child = $('#kattach-list').find('input');
 
 		child.each(function (i, el) {
 			var elem = $(el);
@@ -51,15 +51,15 @@ jQuery(function ($) {
 			if (!elem.attr('id').match("[a-z]{8}")) {
 				var fileid = elem.attr('id').match("[0-9]{2}");
 
-				if (jQuery('#kattachs-' + fileid).length == 0) {
-					jQuery('#kattach-list').append('<input id="kattachs-' + fileid + '" type="hidden" name="attachments[' + fileid + ']" value="1" />');
+				if ($('#kattachs-' + fileid).length == 0) {
+					$('#kattach-list').append('<input id="kattachs-' + fileid + '" type="hidden" name="attachments[' + fileid + ']" value="1" />');
 				}
 
-				if (jQuery('#kattach-' + fileid).length > 0) {
-					jQuery('#kattach-' + fileid).remove();
+				if ($('#kattach-' + fileid).length > 0) {
+					$('#kattach-' + fileid).remove();
 				}
 
-				jQuery.ajax({
+				$.ajax({
 					url    : kunena_upload_files_rem + '&fil_id=' + fileid,
 					type   : 'DELETE',
 					success: function (result) {
@@ -72,7 +72,7 @@ jQuery(function ($) {
 		fileCount = 0;
 	});
 
-	jQuery('#insert-all').on('click', function (e) {
+	$('#insert-all').on('click', function (e) {
 		e.preventDefault();
 
 		// Inserting items from edit if they are present
@@ -83,7 +83,7 @@ jQuery(function ($) {
 		}
 		filesedit = null;
 
-		var child = jQuery('#kattach-list').find('input');
+		var child = $('#kattach-list').find('input');
 
 		child.each(function (i, el) {
 			var elem = $(el);
@@ -94,9 +94,9 @@ jQuery(function ($) {
 
 				insertInMessage(attachid, filename);
 
-				jQuery('#insert-all').removeClass('btn-primary');
-				jQuery('#insert-all').addClass('btn-success');
-				jQuery('#insert-all').html('<i class="icon-upload"></i>' + Joomla.JText._('COM_KUNENA_EDITOR_IN_MESSAGE'));
+				$('#insert-all').removeClass('btn-primary');
+				$('#insert-all').addClass('btn-success');
+				$('#insert-all').html('<i class="icon-upload"></i>' + Joomla.JText._('COM_KUNENA_EDITOR_IN_MESSAGE'));
 			}
 		});
 	});
@@ -144,18 +144,18 @@ jQuery(function ($) {
 				}
 			}
 
-			if (jQuery('#kattachs-' + file_id).length == 0) {
-				jQuery('#kattach-list').append('<input id="kattachs-' + file_id + '" type="hidden" name="attachments[' + file_id + ']" value="1" />');
+			if ($('#kattachs-' + file_id).length == 0) {
+				$('#kattach-list').append('<input id="kattachs-' + file_id + '" type="hidden" name="attachments[' + file_id + ']" value="1" />');
 			}
 
-			if (jQuery('#kattach-' + file_id).length > 0) {
-				jQuery('#kattach-' + file_id).remove();
+			if ($('#kattach-' + file_id).length > 0) {
+				$('#kattach-' + file_id).remove();
 			}
 
 			fileCount = fileCount - 1;
 
 			// Ajax Request to delete the file from filesystem
-			jQuery.ajax({
+			$.ajax({
 				url    : kunena_upload_files_rem + '&fil_id=' + file_id,
 				type: 'DELETE',
 				success: function (result) {
@@ -165,7 +165,7 @@ jQuery(function ($) {
 		});
 
 	$('#fileupload').fileupload({
-		url               : jQuery('#kunena_upload_files_url').val(),
+		url               : $('#kunena_upload_files_url').val(),
 		dataType          : 'json',
 		autoUpload        : true,
 		// Enable image resizing, except for Android and Opera,
@@ -180,7 +180,7 @@ jQuery(function ($) {
 			var params = {};
 			$.each(data.files, function (index, file) {
 				params = {
-					'catid'   : jQuery('#kunena_upload').val(),
+					'catid'   : $('#kunena_upload').val(),
 					'filename': file.name,
 					'size'    : file.size,
 					'mime'    : file.type
@@ -261,8 +261,8 @@ jQuery(function ($) {
 
 		if (data.result.success == true) {
 			// The attachment has been right uploaded, so now we need to put into input hidden to added to message
-			jQuery('#kattach-list').append('<input id="kattachs-' + data.result.data.id + '" type="hidden" name="attachments[' + data.result.data.id + ']" value="1" />');
-			jQuery('#kattach-list').append('<input id="kattach-' + data.result.data.id + '" placeholder="' + data.result.data.filename + '" type="hidden" name="attachment[' + data.result.data.id + ']" value="1" />');
+			$('#kattach-list').append('<input id="kattachs-' + data.result.data.id + '" type="hidden" name="attachments[' + data.result.data.id + ']" value="1" />');
+			$('#kattach-list').append('<input id="kattach-' + data.result.data.id + '" placeholder="' + data.result.data.filename + '" type="hidden" name="attachment[' + data.result.data.id + ']" value="1" />');
 
 			data.uploaded = true;
 

--- a/src/components/com_kunena/template/crypsisb3/assets/js/edit.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/edit.js
@@ -27,7 +27,7 @@ function kPreviewHelper(previewActive) {
 	}
 }
 
-$(document).ready(function ($) {
+jQuery(document).ready(function ($) {
 	$('#tabs_kunena_editor a:first').tab('show');
 
 	$('#tabs_kunena_editor a:last').click(function (e) {

--- a/src/components/com_kunena/template/crypsisb3/assets/js/edit.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/edit.js
@@ -27,14 +27,14 @@ function kPreviewHelper(previewActive) {
 	}
 }
 
-jQuery(document).ready(function () {
-	jQuery('#tabs_kunena_editor a:first').tab('show');
+$(document).ready(function ($) {
+	$('#tabs_kunena_editor a:first').tab('show');
 
-	jQuery('#tabs_kunena_editor a:last').click(function (e) {
+	$('#tabs_kunena_editor a:last').click(function (e) {
 		e.preventDefault();
 
-		var preview = jQuery("#kbbcode-preview");
-		var message = jQuery("#kbbcode-message");
+		var preview = $("#kbbcode-preview");
+		var message = $("#kbbcode-message");
 
 		preview.css('display', 'block');
 
@@ -47,36 +47,36 @@ jQuery(document).ready(function () {
 		preview.css('height', message.css('height'));
 	});
 
-	jQuery('#tabs_kunena_editor a:not(:last)').click(function (e) {
-		jQuery('#kbbcode-preview').hide();
-		jQuery('#kbbcode-message').css('display', 'inline-block');
-		jQuery('#markItUpKbbcode-message').css('display', 'inline-block');
+	$('#tabs_kunena_editor a:not(:last)').click(function (e) {
+		$('#kbbcode-preview').hide();
+		$('#kbbcode-message').css('display', 'inline-block');
+		$('#markItUpKbbcode-message').css('display', 'inline-block');
 	});
 
-	jQuery('#tabs_kunena_editor a:last').click(function (e) {
-		jQuery('#kbbcode-message').hide();
-		jQuery('#markItUpKbbcode-message').hide();
+	$('#tabs_kunena_editor a:last').click(function (e) {
+		$('#kbbcode-message').hide();
+		$('#markItUpKbbcode-message').hide();
 	});
 
 	/* To enabled emojis in kunena textera feature like on github */
-	if (jQuery('#kemojis_allowed').val()==1) {
+	if ($('#kemojis_allowed').val()==1) {
 		var item = '';
-		if (jQuery('#kbbcode-message').length > 0 && jQuery('.qreply').length == 0) {
+		if ($('#kbbcode-message').length > 0 && $('.qreply').length == 0) {
 			item = '#kbbcode-message';
-		} else if (jQuery('.qreply').length > 0) {
+		} else if ($('.qreply').length > 0) {
 			item = '.qreply';
 		}
 
 		if (item != undefined) {
-			jQuery(item).atwho({
+			$(item).atwho({
 				at              : ":",
 				displayTpl      : "<li data-value='${key}'>${name} <img src='${url}' height='20' width='20' /></li>",
 				insertTpl       : ':${name}:',
 				callbacks: {
 					remoteFilter: function (query, callback) {
 						if (query.length > 0) {
-							jQuery.ajax({
-								url    : jQuery("#kurl_emojis").val(),
+							$.ajax({
+								url    : $("#kurl_emojis").val(),
 								data   : {
 									search: query
 								},
@@ -92,63 +92,62 @@ jQuery(document).ready(function () {
 	}
 
 	/* Store form data into localstorage every 1 second */
-	if (jQuery.fn.sisyphus != undefined) {
-		jQuery("#postform").sisyphus({
+	if ($.fn.sisyphus != undefined) {
+		$("#postform").sisyphus({
 			locationBased: true,
 			timeout      : 5
 		});
 	}
 
-	jQuery('#kshow_attach_form').click(function () {
-		if (jQuery('#kattach_form').is(":visible")) {
-			jQuery('#kattach_form').hide();
+	$('#kshow_attach_form').click(function () {
+		if ($('#kattach_form').is(":visible")) {
+			$('#kattach_form').hide();
 		}
 		else {
-			jQuery('#kattach_form').show();
+			$('#kattach_form').show();
 		}
 	});
 
 	// Load topic icons by ajax request
-	jQuery('#postcatid').change(function () {
-		var catid = jQuery('select#postcatid option').filter(':selected').val();
-		var kurl_topicons_request = jQuery('#kurl_topicons_request').val();
+	$('#postcatid').change(function () {
+		var catid = $('select#postcatid option').filter(':selected').val();
+		var kurl_topicons_request = $('#kurl_topicons_request').val();
 
-		if (jQuery('#kanynomous-check').length > 0) {
+		if ($('#kanynomous-check').length > 0) {
 			if (arrayanynomousbox[catid] !== undefined) {
-				jQuery('#kanynomous-check').show();
-				jQuery('#kanonymous').prop('checked', true);
+				$('#kanynomous-check').show();
+				$('#kanonymous').prop('checked', true);
 			} else {
-				jQuery('#kanynomous-check').hide();
-				jQuery('#kanonymous').prop('checked', false);
+				$('#kanynomous-check').hide();
+				$('#kanonymous').prop('checked', false);
 			}
 		}
 
-		jQuery.ajax({
+		$.ajax({
 			type    : 'POST',
 			url     : kurl_topicons_request,
 			async   : false,
 			dataType: 'json',
 			data    : {catid: catid},
 			success : function (data) {
-				jQuery('#iconset_topic_list').remove();
+				$('#iconset_topic_list').remove();
 
-				var div_object = jQuery('<div>', {'id': 'iconset_topic_list'});
+				var div_object = $('<div>', {'id': 'iconset_topic_list'});
 
-				jQuery('#iconset_inject').append(div_object);
+				$('#iconset_inject').append(div_object);
 
-				jQuery.each(data, function (index, value) {
+				$.each(data, function (index, value) {
 					if (value.type != 'system') {
 						if (value.id == 0) {
-							var input = jQuery('<input>', {
+							var input = $('<input>', {
 								type   : 'radio',
 								id     : 'radio' + value.id,
-								checked: 'checked',
 								name   : 'topic_emoticon',
 								value  : value.id
-							});
+							}).prop('checked',true);
 						}
 						else {
-							var input = jQuery('<input>', {
+							var input = $('<input>', {
 								type : 'radio',
 								id   : 'radio' + value.id,
 								name : 'topic_emoticon',
@@ -156,45 +155,45 @@ jQuery(document).ready(function () {
 							});
 						}
 
-						var span_object = jQuery('<span>', {'class': 'kiconsel'}).append(input);
+						var span_object = $('<span>', {'class': 'kiconsel'}).append(input);
 
 						if (kunena_topicicontype=='B3') {
-							var label = jQuery('<label>', {
+							var label = $('<label>', {
 								'class': 'radio inline',
 								'for'  : 'radio' + value.id
-							}).append(jQuery('<span>', {
+							}).append($('<span>', {
 								'class': 'glyphicon glyphicon-topic glyphicon-' + value.b3,
 								'border': '0',
 								'al'    : ''
 							}));
 						} else if(kunena_topicicontype=='fa') {
-							var label = jQuery('<label>', {
+							var label = $('<label>', {
 								'class': 'radio inline',
 								'for'  : 'radio' + value.id
-							}).append(jQuery('<i>', {
+							}).append($('<i>', {
 								'class' : 'fa glyphicon-topic fa-2x fa-' + value.fa,
 								'border': '0',
 								'al'    : ''
 							}));
 						} else {
-							var label = jQuery('<label>', {
+							var label = $('<label>', {
 								'class': 'radio inline',
 								'for'  : 'radio' + value.id
-							}).append(jQuery('<img>', {'src': value.path, 'border': '0', 'al': ''}));
+							}).append($('<img>', {'src': value.path, 'border': '0', 'al': ''}));
 						}
 
 						span_object.append(label);
 
-						jQuery('#iconset_topic_list').append(span_object);
+						$('#iconset_topic_list').append(span_object);
 					}
 				});
 			}
 		});
 	});
 
-	if (jQuery.fn.datepicker != undefined) {
+	if ($.fn.datepicker != undefined) {
 		// Load datepicker for poll
-		jQuery('#datepoll-container .input-append.date').datepicker({
+		$('#datepoll-container .input-append.date').datepicker({
 			orientation: "top auto"
 		});
 	}

--- a/src/components/com_kunena/template/crypsisb3/assets/js/krating.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/krating.js
@@ -7,16 +7,16 @@
  * @link        https://www.kunena.org
  **/
 
-jQuery(document).ready(function() {
+$(document).ready(function($) {
 	// Krating element
 	var krating = document.querySelector('#krating');
 
 	// Initialize
 	(function init() {
-		var topic_id = jQuery("#topic_id").val();
+		var topic_id = $("#topic_id").val();
 		
-		if (jQuery('#krating').length > 0) {
-			jQuery.ajax({
+		if ($('#krating').length > 0) {
+			$.ajax({
 				 dataType: "json",
 				 url: 'index.php?option=com_kunena&view=topic&layout=getrate&format=raw',
 				 data: 'topic_id=' + topic_id 
@@ -43,21 +43,21 @@ jQuery(document).ready(function() {
 		var currentRating = rate;
 		var maxRating = 5;
 		var callback = function(rating) {
-			jQuery.ajax({
+			$.ajax({
 				dataType: "json",
-				url: jQuery('#krating_submit_url').val(),
+				url: $('#krating_submit_url').val(),
 				data: 'starid=' + rating + '&topic_id=' + topicid  
 				}).done(function(response) {
 					if (response.success)
 					{
-						jQuery('<div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Success</h4>'+Joomla.JText._(response.message)+'</div>').appendTo('#system-message-container');
+						$('<div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Success</h4>'+Joomla.JText._(response.message)+'</div>').appendTo('#system-message-container');
 					}
 					else
 					{
-						jQuery('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Warning!</h4>'+Joomla.JText._(response.message)+'</div>').appendTo('#system-message-container');
+						$('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Warning!</h4>'+Joomla.JText._(response.message)+'</div>').appendTo('#system-message-container');
 					}
 				}).fail(function(reponse) {
-					jQuery('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Warning!</h4>'+reponse+'</div>').appendTo('#system-message-container');
+					$('<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">&times;</button><h4>Warning!</h4>'+reponse+'</div>').appendTo('#system-message-container');
 				});  
 		};
 		var r = rating(ratingElement, currentRating, maxRating, callback);

--- a/src/components/com_kunena/template/crypsisb3/assets/js/main.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/main.js
@@ -15,9 +15,9 @@ function kunenatableOrdering( order, dir, task, form ) {
 	form.submit( task );
 }
 
-jQuery(document).ready(function() {
+jQuery(document).ready(function($) {
 	/* To hide or open collapse localStorage */
-	jQuery('.collapse').on('hidden', function() {
+	$('.collapse').on('hidden', function() {
 				if (this.id) {
 						localStorage[this.id] = 'true';
 				}
@@ -27,54 +27,54 @@ jQuery(document).ready(function() {
 				}
 		}).each(function() {
 				if (this.id && localStorage[this.id] === 'true' ) {
-						jQuery(this).collapse('hide');
+						$(this).collapse('hide');
 				}
 	});
 
 	/* To check or uncheck boxes to select items */
-	jQuery('input.kcheckall').click(function() {
-		jQuery( '.kcheck' ).each(function( ) {
-			jQuery(this).prop('checked',!jQuery(this).prop('checked'));
+	$('input.kcheckall').click(function() {
+		$( '.kcheck' ).each(function( ) {
+			$(this).prop('checked',!$(this).prop('checked'));
 		});
 	});
 
 	/* Allow to make working drop-down choose destination */
-	jQuery('#kchecktask').change(function() {
-		var task = jQuery("select#kchecktask").val();
+	$('#kchecktask').change(function() {
+		var task = $("select#kchecktask").val();
 		if (task=='move') {
-			jQuery("#kchecktarget").attr('disabled', false).trigger("liszt:updated");
+			$("#kchecktarget").attr('disabled', false).trigger("liszt:updated");
 		} else {
-			jQuery("#kchecktarget").attr('disabled', true);
+			$("#kchecktarget").attr('disabled', true);
 		}
 	});
 
-	jQuery("input.kcatcheckall").click(function(){
-		jQuery("input.kcatcheckall:checkbox").not(this).prop('checked', this.checked);
+	$("input.kcatcheckall").click(function(){
+		$("input.kcatcheckall:checkbox").not(this).prop('checked', this.checked);
 	});
 
-	jQuery("input.kcheckallcategories").click(function(){
-		jQuery("input.kcheckallcategory:checkbox").not(this).prop('checked', this.checked);
+	$("input.kcheckallcategories").click(function(){
+		$("input.kcheckallcategory:checkbox").not(this).prop('checked', this.checked);
 	});
 
-	jQuery(document).ready(function() {
-		jQuery('[rel=popover]').popover();
+	$(document).ready(function() {
+		$('[rel=popover]').popover();
 	});
 
-	jQuery('#avatar_gallery_select').change(function() {
-		var gallery_selected = jQuery("select#avatar_gallery_select").val();
+	$('#avatar_gallery_select').change(function() {
+		var gallery_selected = $("select#avatar_gallery_select").val();
 
-		var gallery_list = jQuery('#gallery_list');
+		var gallery_list = $('#gallery_list');
 
 		// We remove avatar which exist in td tag to allow us to put new one items
 		gallery_list.empty();
 
 		// Get the list of images from the gallery selected drop-down above
-	 jQuery.ajax({
+	 $.ajax({
 			 dataType: "json",
 			 url: 'index.php?option=com_kunena&view=user&layout=galleryimages&format=raw',
 			 data: 'gallery_name=' + gallery_selected
 		}).done(function(response) {
-       jQuery.each(response, function( key, value ) {
+       $.each(response, function( key, value ) {
 				  gallery_list.append('<li class="span2"><input id="radio'+gallery_selected+'/'+value.filename+'" type="radio" value="gallery/'+gallery_selected+'/'+value.filename+'" name="avatar"><label class=" radio thumbnail" for="radio'+gallery_selected+'/'+value.filename+'"><img alt="" src="'+value.url+'"></label></li>');
 			  });
 		}).fail(function(response) {
@@ -82,19 +82,19 @@ jQuery(document).ready(function() {
 		});
 	});
 
-	if (jQuery.fn.datepicker != undefined) {
+	if ($.fn.datepicker != undefined) {
 		// Load datepicker for announcement
-		jQuery('#ann-date .input-group.date').datepicker({
+		$('#ann-date .input-group.date').datepicker({
 			orientation: "top auto",
 			format: "yyyy-mm-dd"
 		});
 
-		jQuery('#ann-date2 .input-group.date').datepicker({
+		$('#ann-date2 .input-group.date').datepicker({
 			orientation: "top auto",
 			format: "yyyy-mm-dd"
 		});
 
-		jQuery('#ann-date3 .input-group.date').datepicker({
+		$('#ann-date3 .input-group.date').datepicker({
 			orientation: "top auto",
 			format: "yyyy-mm-dd"
 		});

--- a/src/components/com_kunena/template/crypsisb3/assets/js/markitup.set.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/markitup.set.js
@@ -10,20 +10,20 @@
 // Feel free to add more tags
 // ----------------------------------------------------------------------------
 
-jQuery(document).ready(function (){
-	jQuery('#kbbcode-message').markItUp(bbcodeSettings);
+jQuery(document).ready(function ($){
+	$('#kbbcode-message').markItUp(bbcodeSettings);
 
-	if (jQuery('#modal-code').length == 0) {
-		jQuery('.codemodalboxbutton').hide();
+	if ($('#modal-code').length == 0) {
+		$('.codemodalboxbutton').hide();
 	} else {
-		jQuery('.codesimplebutton').hide();
+		$('.codesimplebutton').hide();
 	}
 
 	// For code
-	jQuery('#code-modal-submit').click(function() {
-		var codetype = jQuery("#kcodetype option:selected").val();
+	$('#code-modal-submit').click(function() {
+		var codetype = $("#kcodetype option:selected").val();
 
-		jQuery.markItUp(
+		$.markItUp(
 			{ openWith:'[code type="'+codetype+'"]',
 			  closeWith:'[/code]' }
 		);
@@ -31,10 +31,10 @@ jQuery(document).ready(function (){
 	});
 
 	// For map
-	jQuery('#map-modal-submit').click(function() {
-		var modalcity = jQuery('#modal-map-city').val();
-		var modaltype = jQuery('#modal-map-type').val();
-		var modalzoom = jQuery('#modal-map-zoomlevel').val();
+	$('#map-modal-submit').click(function() {
+		var modalcity = $('#modal-map-city').val();
+		var modaltype = $('#modal-map-type').val();
+		var modalzoom = $('#modal-map-zoomlevel').val();
 		var type = '';
 		var zoom = '';
 
@@ -48,7 +48,7 @@ jQuery(document).ready(function (){
 			zoom = 'zoom='+modalzoom;
 		}
 
-		jQuery.markItUp(
+		$.markItUp(
 		{ openWith:'[map '+type+' '+zoom+']'+modalcity,
 		  closeWith:'[/map]' }
 		);
@@ -56,9 +56,9 @@ jQuery(document).ready(function (){
 	});
 
 	// For picture settings
-	jQuery('#picture-modal-submit').click(function() {
-		var modalpictureurl = jQuery('#modal-picture-url').val();
-		var modalpicturesize = jQuery('#modal-picture-size').val();
+	$('#picture-modal-submit').click(function() {
+		var modalpictureurl = $('#modal-picture-url').val();
+		var modalpicturesize = $('#modal-picture-size').val();
 
 		var size = '';
 		if ( modalpicturesize.length > 0 ) {
@@ -66,7 +66,7 @@ jQuery(document).ready(function (){
 		}
 
 		if ( modalpictureurl.length > 0 ) {
-			jQuery.markItUp(
+			$.markItUp(
 				{ openWith:'[img '+size+']'+modalpictureurl,
 				closeWith:'[/img]' }
 			);
@@ -75,9 +75,9 @@ jQuery(document).ready(function (){
 	});
 
 	//For link settings
-	jQuery('#link-modal-submit').click(function() {
-		var modallinkurl = jQuery('#modal-link-url').val();
-		var modallinktext = jQuery('#modal-link-text').val();
+	$('#link-modal-submit').click(function() {
+		var modallinkurl = $('#modal-link-url').val();
+		var modallinktext = $('#modal-link-text').val();
 
 		var text = '';
 		if ( modallinktext.length > 0 ) {
@@ -88,7 +88,7 @@ jQuery(document).ready(function (){
 		}
 
 		if ( modallinkurl.length > 0 ) {
-			jQuery.markItUp(
+			$.markItUp(
 			{ openWith:'[url='+modallinkurl+']'+text,
 				closeWith:'[/url]' }
 			);
@@ -98,13 +98,13 @@ jQuery(document).ready(function (){
 	});
 
 	// For video settings
-	jQuery('#videosettings-modal-submit').click(function() {
-		var kvideoprovider = jQuery('#kvideoprovider-modal').val();
-		var providerid = jQuery('#modal-video-id').val();
-		var videowidth = jQuery('#modal-video-width').val();
-		var videoheight = jQuery('#modal-video-height').val();
-		var videosize = jQuery('#modal-video-size').val();
-		var kvideoproviderlist = jQuery("#kvideoprovider-list-modal option:selected").val();
+	$('#videosettings-modal-submit').click(function() {
+		var kvideoprovider = $('#kvideoprovider-modal').val();
+		var providerid = $('#modal-video-id').val();
+		var videowidth = $('#modal-video-width').val();
+		var videoheight = $('#modal-video-height').val();
+		var videosize = $('#modal-video-size').val();
+		var kvideoproviderlist = $("#kvideoprovider-list-modal option:selected").val();
 
 		var width = '425';
 		var height = '344';
@@ -121,10 +121,10 @@ jQuery(document).ready(function (){
 			size = 'size='+videosize;
 		}
 
-		if (jQuery('#kvideoprovider-modal').length > 0)
+		if ($('#kvideoprovider-modal').length > 0)
 		{
 			if ( kvideoprovider.lentgth > 0 && providerid.length > 0 ) {
-				jQuery.markItUp(
+				$.markItUp(
 					{ openWith:'[video '+size+' '+width+' '+height+' type='+kvideoprovider+']'+providerid,
 					closeWith:'[/video]' }
 				);
@@ -133,7 +133,7 @@ jQuery(document).ready(function (){
 		}
 		else
 		{
-			jQuery.markItUp(
+			$.markItUp(
 				{ openWith:'[video '+size+' '+width+' '+height+' type='+kvideoproviderlist+']'+providerid,
 				closeWith:'[/video]' }
 			);
@@ -142,10 +142,10 @@ jQuery(document).ready(function (){
 	});
 
 	// For video provider URL
-	jQuery('#videourlprovider-modal-submit').click(function() {
-		var providerurl = jQuery('#modal-video-urlprovider-input').val();
+	$('#videourlprovider-modal-submit').click(function() {
+		var providerurl = $('#modal-video-urlprovider-input').val();
 
-		jQuery.markItUp(
+		$.markItUp(
 			{ openWith:'[video]'+providerurl,
 			closeWith:'[/video]' }
 		);
@@ -153,10 +153,10 @@ jQuery(document).ready(function (){
 	});
 
 	// For smileys
-	jQuery('.smileyimage').click(function() {
-		var smiley = jQuery(this).attr('alt');
+	$('.smileyimage').click(function() {
+		var smiley = $(this).attr('alt');
 
-		jQuery.markItUp(
+		$.markItUp(
 			 { openWith:smiley,
 			closeWith:'' }
 		);
@@ -164,62 +164,62 @@ jQuery(document).ready(function (){
 	});
 
 	if (!kunena_showvideotag) {
-		jQuery('.videodropdownbutton').remove();
+		$('.videodropdownbutton').remove();
 	}
 
 	if (!kunena_disemoticons) {
-		jQuery('.emoticonsbutton').remove();
+		$('.emoticonsbutton').remove();
 	}
 
 	if (!kunena_showebaytag) {
-		jQuery('.ebaybutton').remove();
+		$('.ebaybutton').remove();
 	}
 
 	if (!kunena_showspoilertag) {
-		jQuery('.spoilerbutton').remove();
+		$('.spoilerbutton').remove();
 	}
 
 	if (!kunena_showmapstag) {
-		jQuery('.mapbutton').remove();
+		$('.mapbutton').remove();
 	}
 
 	if (!kunena_showtwittertag) {
-		jQuery('.tweetbutton').remove();
+		$('.tweetbutton').remove();
 	}
 
 	if (!kunena_showlinktag) {
-		jQuery('.linkbutton').remove();
+		$('.linkbutton').remove();
 	}
 
 	if (!kunena_showpicturetag) {
-		jQuery('.picturebutton').remove();
+		$('.picturebutton').remove();
 	}
 
 	if (!kunena_showhidetag) {
-		jQuery('.hiddentextbutton').remove();
+		$('.hiddentextbutton').remove();
 	}
 
 	if (!kunena_showtabletag) {
-		jQuery('.tablebutton').remove();
+		$('.tablebutton').remove();
 	}
 
 	if (!kunena_showcodetag) {
-		jQuery('.codesimplebutton').remove();
+		$('.codesimplebutton').remove();
 	}
 
 	if (!kunena_showquotetag) {
-		jQuery('.quotebutton').remove();
+		$('.quotebutton').remove();
 	}
 
 	if (!kunena_showdividertag) {
-		jQuery('.markItUpSeparator').remove();
+		$('.markItUpSeparator').remove();
 	}
 
 	if (!kunena_showinstagramtag) {
-		jQuery('.instagrambutton').remove();
+		$('.instagrambutton').remove();
 	}
 
 	if (!kunena_showsoundcloudtag) {
-		jQuery('.soundcloudbutton').remove();
+		$('.soundcloudbutton').remove();
 	}
 });

--- a/src/components/com_kunena/template/crypsisb3/assets/js/poll.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/poll.js
@@ -7,13 +7,13 @@
 * @link https://www.kunena.org
 **/
 
-jQuery(document).ready(function() {
+jQuery(document).ready(function($) {
 	/**
 	 * Get the number of field options inserted in form
 	 */
 	function getOptionsNumber()
 	{
-		var myoptions = jQuery('#kbbcode-poll-options').children('div.polloption');
+		var myoptions = $('#kbbcode-poll-options').children('div.polloption');
 
 		return myoptions.length;
 	}
@@ -25,9 +25,9 @@ jQuery(document).ready(function() {
 		var	options = getOptionsNumber();
 		options++;
 
-		var polldiv = jQuery('<div></div>').attr('class','polloption').appendTo('#kbbcode-poll-options');
+		var polldiv = $('<div></div>').attr('class','polloption').appendTo('#kbbcode-poll-options');
 
-		var label = jQuery('<label>').text(Joomla.JText._('COM_KUNENA_POLL_OPTION_NAME')+' '+options+' ');
+		var label = $('<label>').text(Joomla.JText._('COM_KUNENA_POLL_OPTION_NAME')+' '+options+' ');
 		polldiv.append(label);
 
 		newInput = document.createElement('input');
@@ -39,9 +39,9 @@ jQuery(document).ready(function() {
 		polldiv.append(newInput);
 	}
 
-	if( jQuery('#kbutton-poll-add') != undefined ) {
-		jQuery('#kbutton-poll-add').click(function() {
-			var nboptionsmax = jQuery('#nb_options_allowed').val();
+	if( $('#kbutton-poll-add') != undefined ) {
+		$('#kbutton-poll-add').click(function() {
+			var nboptionsmax = $('#nb_options_allowed').val();
 			var koptions = getOptionsNumber();
 
 			if(!nboptionsmax || (koptions < nboptionsmax && koptions >= 2) ){
@@ -51,69 +51,69 @@ jQuery(document).ready(function() {
 				createNewOptionField();
 			} else {
 				// Set error message with alert bootstrap way
-				jQuery('#kpoll-alert-error').show();
+				$('#kpoll-alert-error').show();
 
-				jQuery('#kbutton-poll-add').hide();
+				$('#kbutton-poll-add').hide();
 			}
 		});
 	}
-	if( jQuery('#kbutton-poll-rem') != undefined ) {
-		jQuery('#kbutton-poll-rem').click(function() {
-			var koption = jQuery ('div.polloption:last');
+	if( $('#kbutton-poll-rem') != undefined ) {
+		$('#kbutton-poll-rem').click(function() {
+			var koption = $ ('div.polloption:last');
 			if(koption) {
-				var isvisible = jQuery('#kpoll-alert-error').is(":visible");
+				var isvisible = $('#kpoll-alert-error').is(":visible");
 
 				if (isvisible){
-					jQuery('#kpoll-alert-error').hide();
+					$('#kpoll-alert-error').hide();
 
-					jQuery('#kbutton-poll-add').show();
+					$('#kbutton-poll-add').show();
 				}
 				koption.remove();
 			}
 		});
 	}
 
-	if( jQuery('#postcatid') != undefined ) {
-		jQuery('#postcatid').change(function() {
-			var catid = jQuery('select#postcatid option').filter(':selected').val();
+	if( $('#postcatid') != undefined ) {
+		$('#postcatid').change(function() {
+			var catid = $('select#postcatid option').filter(':selected').val();
 			if ( pollcategoriesid[catid] !== undefined ) {
-				jQuery('.pollbutton').show();
+				$('.pollbutton').show();
 			} else {
-				jQuery('.pollbutton').hide();
+				$('.pollbutton').hide();
 			}
 		});
 	}
 
-	jQuery('#kpoll_go_results').click(function() {
-		if(jQuery('#poll-results').is(':visible')==true)
+	$('#kpoll_go_results').click(function() {
+		if($('#poll-results').is(':visible')==true)
 		{
-			jQuery('#poll-results').hide();
-			jQuery('#kpoll_hide_results').hide();
+			$('#poll-results').hide();
+			$('#kpoll_hide_results').hide();
 		}
 		else
 		{
-			jQuery('#poll-results').show();
-			jQuery('#kpoll_hide_results').show();
-			jQuery('#kpoll_go_results').hide();
+			$('#poll-results').show();
+			$('#kpoll_hide_results').show();
+			$('#kpoll_go_results').hide();
 		}
 	});
 
-	jQuery('#kpoll_hide_results').click(function() {
-		if(jQuery('#poll-results').is(':visible')==true)
+	$('#kpoll_hide_results').click(function() {
+		if($('#poll-results').is(':visible')==true)
 		{
-			jQuery('#poll-results').hide();
-      jQuery('#kpoll_go_results').show();
-			jQuery('#kpoll_hide_results').hide();
+			$('#poll-results').hide();
+      $('#kpoll_go_results').show();
+			$('#kpoll_hide_results').hide();
 		}
 		else
 		{
-			jQuery('#poll-results').show();
-			jQuery('#kpoll_hide_results').show();
-			jQuery('#kpoll_go_results').hide();
+			$('#poll-results').show();
+			$('#kpoll_hide_results').show();
+			$('#kpoll_go_results').hide();
 		}
 	});
 
-	jQuery('#kpoll-moreusers').click(function() {
-		jQuery('#kpoll-moreusers-div').show();
+	$('#kpoll-moreusers').click(function() {
+		$('#kpoll-moreusers-div').show();
 	});
 });

--- a/src/components/com_kunena/template/crypsisb3/assets/js/pollcheck.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/pollcheck.js
@@ -7,18 +7,18 @@
 * @link https://www.kunena.org
 **/
 
-jQuery(document).ready(function() {
-	if ( typeof pollcategoriesid != 'undefined' && jQuery('#poll_exist_edit').length == 0 ) {
-		var catid = jQuery('#kcategory_poll').val();
+jQuery(document).ready(function($) {
+	if ( typeof pollcategoriesid != 'undefined' && $('#poll_exist_edit').length == 0 ) {
+		var catid = $('#kcategory_poll').val();
 
 		if ( pollcategoriesid[catid] !== undefined ) {
-			jQuery('.pollbutton').show();
+			$('.pollbutton').show();
 		} else {
-			jQuery('.pollbutton').hide();
+			$('.pollbutton').hide();
 		}
-	} else if ( jQuery('#poll_exist_edit').length > 0 ) {
-		jQuery('.pollbutton').show();
+	} else if ( $('#poll_exist_edit').length > 0 ) {
+		$('.pollbutton').show();
 	} else {
-		jQuery('.pollbutton').hide();
+		$('.pollbutton').hide();
 	}
 });

--- a/src/components/com_kunena/template/crypsisb3/assets/js/search.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/search.js
@@ -7,19 +7,19 @@
  * @link https://www.kunena.org
  **/
 
-jQuery(document).ready(function() {
+jQuery(document).ready(function($) {
 
 	/* Provide autocomplete user list in search form and in user list */
-	if ( jQuery( '#kurl_users' ).length > 0 ) {
-		var users_url = jQuery( '#kurl_users' ).val();
+	if ( $( '#kurl_users' ).length > 0 ) {
+		var users_url = $( '#kurl_users' ).val();
 
-		jQuery('#kusersearch').atwho({
+		$('#kusersearch').atwho({
 			at: "",
 			tpl: '<li data-value="${username}"><i class="icon-user"></i> ${username} <small>(${name})</small></li>',
 			limit: 7,
 			callbacks: {
 				remote_filter: function(query, callback)  {
-					jQuery.ajax({
+					$.ajax({
 						url: users_url,
 						data: {
 							search : query
@@ -34,8 +34,8 @@ jQuery(document).ready(function() {
 	}
 
 	/* Hide search form when there are search results found */
-	if ( jQuery('#kunena_search_results').is(':visible') ) {
-		jQuery('#search').collapse("hide");
+	if ( $('#kunena_search_results').is(':visible') ) {
+		$('#search').collapse("hide");
 	}
 
 });

--- a/src/components/com_kunena/template/crypsisb3/assets/js/topic.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/topic.js
@@ -7,80 +7,80 @@
  * @link https://www.kunena.org
  **/
 
-jQuery(document).ready(function () {
+jQuery(document).ready(function ($) {
 
 	/* To hide or open spoiler on click */
-	jQuery('.kspoiler').each(function( index ) {
-		jQuery( this ).click(function() {
-			if ( !jQuery(this).find('.kspoiler-content').is(':visible') ) {
-				jQuery(this).find('.kspoiler-content').show();
-				jQuery(this).find('.kspoiler-expand').hide();
-				jQuery(this).find('.kspoiler-hide').show();
+	$('.kspoiler').each(function( index ) {
+		$( this ).click(function() {
+			if ( !$(this).find('.kspoiler-content').is(':visible') ) {
+				$(this).find('.kspoiler-content').show();
+				$(this).find('.kspoiler-expand').hide();
+				$(this).find('.kspoiler-hide').show();
 			} else {
-				jQuery(this).find('.kspoiler-content').hide();
-				jQuery(this).find('.kspoiler-expand').show();
-				jQuery(this).find('.kspoiler-hide').hide();
+				$(this).find('.kspoiler-content').hide();
+				$(this).find('.kspoiler-expand').show();
+				$(this).find('.kspoiler-hide').hide();
 			}
 		});
 	});
 
 	/* To allow to close or open the quick-reply modal box */
-	jQuery('.openmodal').click(function () {
-		var boxToOpen = jQuery(this).attr('href');
-		jQuery(boxToOpen).css('visibility', 'visible');
+	$('.openmodal').click(function () {
+		var boxToOpen = $(this).attr('href');
+		$(boxToOpen).css('visibility', 'visible');
 	});
 
 	/* Button to show more info on profilebox */
-	jQuery(".heading").click(function () {
-		if (!jQuery(this).hasClass('heading-less')) {
-			jQuery(this).prev(".heading").show();
-			jQuery(this).hide();
-			jQuery(this).next(".content").slideToggle(500);
+	$(".heading").click(function () {
+		if (!$(this).hasClass('heading-less')) {
+			$(this).prev(".heading").show();
+			$(this).hide();
+			$(this).next(".content").slideToggle(500);
 		} else {
-			var content = jQuery(this).next(".heading").show();
-			jQuery(this).hide();
+			var content = $(this).next(".heading").show();
+			$(this).hide();
 			content.next(".content").slideToggle(500);
 		}
 	});
 
 	/* On moderate page display subject or field to enter manually the topic ID */
-	jQuery('#kmod_topics').change(function () {
-		var id_item_selected = jQuery(this).val();
+	$('#kmod_topics').change(function () {
+		var id_item_selected = $(this).val();
 		if (id_item_selected != 0) {
-			jQuery('#kmod_subject').hide();
+			$('#kmod_subject').hide();
 		} else {
-			jQuery('#kmod_subject').show();
+			$('#kmod_subject').show();
 		}
 
 		if (id_item_selected == -1) {
-			jQuery('#kmod_targetid').show();
+			$('#kmod_targetid').show();
 		} else {
-			jQuery('#kmod_targetid').hide();
+			$('#kmod_targetid').hide();
 		}
 	});
 
-	if (jQuery.fn.jsSocials != undefined) {
-		jQuery("#share").jsSocials({
+	if ($.fn.jsSocials != undefined) {
+		$("#share").jsSocials({
 			showCount: true,
 			showLabel: true,
 			shares: ["email", "twitter", "facebook", "googleplus", "linkedin", "pinterest", "stumbleupon", "whatsapp"]
 		});
 	}
 
-	jQuery('#kmod_categories').change(function () {
-		jQuery.getJSON(
-			kunena_url_ajax, {catid: jQuery(this).val()}
+	$('#kmod_categories').change(function () {
+		$.getJSON(
+			kunena_url_ajax, {catid: $(this).val()}
 		).done(function (json) {
-			var first_item = jQuery('#kmod_topics option:nth(0)').clone();
-			var second_item = jQuery('#kmod_topics option:nth(1)').clone();
+			var first_item = $('#kmod_topics option:nth(0)').clone();
+			var second_item = $('#kmod_topics option:nth(1)').clone();
 
-			jQuery('#kmod_topics').empty();
+			$('#kmod_topics').empty();
 			first_item.appendTo('#kmod_topics');
 			second_item.appendTo('#kmod_topics');
 
-			jQuery.each(json, function (index, object) {
-				jQuery.each(object, function (key, element) {
-					jQuery('#kmod_topics').append('<option value="' + element['id'] + '">' + element['subject'] + '</option>');
+			$.each(json, function (index, object) {
+				$.each(object, function (key, element) {
+					$('#kmod_topics').append('<option value="' + element['id'] + '">' + element['subject'] + '</option>');
 				});
 			});
 		});

--- a/src/components/com_kunena/template/crypsisb3/assets/js/upload.main.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/upload.main.js
@@ -3,9 +3,9 @@ jQuery(function ($) {
 
 	// Insert bbcode in message
 	function insertInMessage(attachid, filename, button) {
-		var value = jQuery('#kbbcode-message').val();
+		var value = $('#kbbcode-message').val();
 
-		jQuery('#kbbcode-message').val(value + ' [attachment=' + attachid + ']' + filename + '[/attachment]');
+		$('#kbbcode-message').val(value + ' [attachment=' + attachid + ']' + filename + '[/attachment]');
 
 		if (button != undefined) {
 			button.removeClass('btn-primary');
@@ -17,21 +17,21 @@ jQuery(function ($) {
 	var fileCount = null;
 	var filesedit = null;
 
-	jQuery('#remove-all').on('click', function (e) {
+	$('#remove-all').on('click', function (e) {
 		e.preventDefault();
 
 		// Removing items in edit if they are present
 		if ($.isEmptyObject(filesedit) == false) {
 			$(filesedit).each(function (index, file) {
-				if (jQuery('#kattachs-' + file.id).length == 0) {
-					jQuery('#kattach-list').append('<input id="kattachs-' + file.id + '" type="hidden" name="attachments[' + file.id + ']" value="1" />');
+				if ($('#kattachs-' + file.id).length == 0) {
+					$('#kattach-list').append('<input id="kattachs-' + file.id + '" type="hidden" name="attachments[' + file.id + ']" value="1" />');
 				}
 
-				if (jQuery('#kattach-' + file.id).length > 0) {
-					jQuery('#kattach-' + file.id).remove();
+				if ($('#kattach-' + file.id).length > 0) {
+					$('#kattach-' + file.id).remove();
 				}
 
-				jQuery.ajax({
+				$.ajax({
 					url    : kunena_upload_files_rem + '&fil_id=' + file.id,
 					type   : 'DELETE',
 					success: function (result) {
@@ -43,7 +43,7 @@ jQuery(function ($) {
 			filesedit = null;
 		}
 
-		var child = jQuery('#kattach-list').find('input');
+		var child = $('#kattach-list').find('input');
 
 		child.each(function (i, el) {
 			var elem = $(el);
@@ -51,15 +51,15 @@ jQuery(function ($) {
 			if (!elem.attr('id').match("[a-z]{8}")) {
 				var fileid = elem.attr('id').match("[0-9]{2}");
 
-				if (jQuery('#kattachs-' + fileid).length == 0) {
-					jQuery('#kattach-list').append('<input id="kattachs-' + fileid + '" type="hidden" name="attachments[' + fileid + ']" value="1" />');
+				if ($('#kattachs-' + fileid).length == 0) {
+					$('#kattach-list').append('<input id="kattachs-' + fileid + '" type="hidden" name="attachments[' + fileid + ']" value="1" />');
 				}
 
-				if (jQuery('#kattach-' + fileid).length > 0) {
-					jQuery('#kattach-' + fileid).remove();
+				if ($('#kattach-' + fileid).length > 0) {
+					$('#kattach-' + fileid).remove();
 				}
 
-				jQuery.ajax({
+				$.ajax({
 					url    : kunena_upload_files_rem + '&fil_id=' + fileid,
 					type   : 'DELETE',
 					success: function (result) {
@@ -72,7 +72,7 @@ jQuery(function ($) {
 		fileCount = 0;
 	});
 
-	jQuery('#insert-all').on('click', function (e) {
+	$('#insert-all').on('click', function (e) {
 		e.preventDefault();
 
 		// Inserting items from edit if they are present
@@ -83,7 +83,7 @@ jQuery(function ($) {
 		}
 		filesedit = null;
 
-		var child = jQuery('#kattach-list').find('input');
+		var child = $('#kattach-list').find('input');
 
 		child.each(function (i, el) {
 			var elem = $(el);
@@ -94,9 +94,9 @@ jQuery(function ($) {
 
 				insertInMessage(attachid, filename);
 
-				jQuery('#insert-all').removeClass('btn-primary');
-				jQuery('#insert-all').addClass('btn-success');
-				jQuery('#insert-all').html('<i class="icon-upload"></i>' + Joomla.JText._('COM_KUNENA_EDITOR_IN_MESSAGE'));
+				$('#insert-all').removeClass('btn-primary');
+				$('#insert-all').addClass('btn-success');
+				$('#insert-all').html('<i class="icon-upload"></i>' + Joomla.JText._('COM_KUNENA_EDITOR_IN_MESSAGE'));
 			}
 		});
 	});
@@ -144,18 +144,18 @@ jQuery(function ($) {
 				}
 			}
 
-			if (jQuery('#kattachs-' + file_id).length == 0) {
-				jQuery('#kattach-list').append('<input id="kattachs-' + file_id + '" type="hidden" name="attachments[' + file_id + ']" value="1" />');
+			if ($('#kattachs-' + file_id).length == 0) {
+				$('#kattach-list').append('<input id="kattachs-' + file_id + '" type="hidden" name="attachments[' + file_id + ']" value="1" />');
 			}
 
-			if (jQuery('#kattach-' + file_id).length > 0) {
-				jQuery('#kattach-' + file_id).remove();
+			if ($('#kattach-' + file_id).length > 0) {
+				$('#kattach-' + file_id).remove();
 			}
 
 			fileCount = fileCount - 1;
 
 			// Ajax Request to delete the file from filesystem
-			jQuery.ajax({
+			$.ajax({
 				url    : kunena_upload_files_rem + '&fil_id=' + file_id,
 				type: 'DELETE',
 				success: function (result) {
@@ -165,7 +165,7 @@ jQuery(function ($) {
 		});
 
 	$('#fileupload').fileupload({
-		url               : jQuery('#kunena_upload_files_url').val(),
+		url               : $('#kunena_upload_files_url').val(),
 		dataType          : 'json',
 		autoUpload        : true,
 		// Enable image resizing, except for Android and Opera,
@@ -180,7 +180,7 @@ jQuery(function ($) {
 			var params = {};
 			$.each(data.files, function (index, file) {
 				params = {
-					'catid'   : jQuery('#kunena_upload').val(),
+					'catid'   : $('#kunena_upload').val(),
 					'filename': file.name,
 					'size'    : file.size,
 					'mime'    : file.type
@@ -261,8 +261,8 @@ jQuery(function ($) {
 
 		if (data.result.success == true) {
 			// The attachment has been right uploaded, so now we need to put into input hidden to added to message
-			jQuery('#kattach-list').append('<input id="kattachs-' + data.result.data.id + '" type="hidden" name="attachments[' + data.result.data.id + ']" value="1" />');
-			jQuery('#kattach-list').append('<input id="kattach-' + data.result.data.id + '" placeholder="' + data.result.data.filename + '" type="hidden" name="attachment[' + data.result.data.id + ']" value="1" />');
+			$('#kattach-list').append('<input id="kattachs-' + data.result.data.id + '" type="hidden" name="attachments[' + data.result.data.id + ']" value="1" />');
+			$('#kattach-list').append('<input id="kattach-' + data.result.data.id + '" placeholder="' + data.result.data.filename + '" type="hidden" name="attachment[' + data.result.data.id + ']" value="1" />');
 
 			data.uploaded = true;
 


### PR DESCRIPTION
For noConflict compatible usages jQuery ready needs to define $ and the subsequent jQuery must use $. This fixes all such usages to properly be compatible with other jQuery defines with noConflict.
