### PR TITLE
Fix check to make difference between image ad file in attachments

### DIFF
--- a/src/libraries/kunena/upload/upload.php
+++ b/src/libraries/kunena/upload/upload.php
@@ -329,7 +329,7 @@ class KunenaUpload
 
 				$size += $bytes;
 
-				if (stripos($type, 'image/') !== true)
+				if (stripos($type, 'image/') === false && stripos($type, 'image/') <= 0)
 				{
 					if (!$this->checkFileSizeFileAttachment($size))
 					{
@@ -337,7 +337,7 @@ class KunenaUpload
 					}
 				}
 
-				if (stripos($type, 'image/') !== false)
+				if (stripos($type, 'image/') !== false && stripos($type, 'image/') >= 0)
 				{
 					if (!$this->checkFileSizeImageAttachment($size))
 					{


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions

When you do a reply or new topic, add or drag & drop attachments (image or file) and check that the error message which said that the file or image has exceed the limit set in configuration. 

Try by setting in Kunena configuration differents limit for the size for image and file.
