### PR TITLE
fixes link escaping and improves tooltip usage with user content

### DIFF
--- a/src/libraries/kunena/html/html/kunenaforum.php
+++ b/src/libraries/kunena/html/html/kunenaforum.php
@@ -193,17 +193,17 @@ abstract class JHtmlKunenaForum
 		$list['href'] = (is_string($uri) && $uri[0] == '/') ? $uri : KunenaRoute::_($uri);
 		if ($title)
 		{
-			$list['title'] = $title;
+			$list['title'] = htmlspecialchars($title);
 		}
 
 		if ($class)
 		{
-			$list['class'] = $class;
+			$list['class'] = htmlspecialchars($class);
 		}
 
 		if ($rel)
 		{
-			$list['rel'] = $rel;
+			$list['rel'] = htmlspecialchars($rel);
 		}
 
 		if (is_array($attributes))

--- a/src/libraries/kunena/layout/layout.php
+++ b/src/libraries/kunena/layout/layout.php
@@ -156,10 +156,16 @@ class KunenaLayout extends KunenaLayoutBase
 
 		if ($title === null)
 		{
-			$title = JText::sprintf('COM_KUNENA_VIEW_CATEGORY_LIST_CATEGORY_TITLE', $this->escape($category->name));
+			$title = JText::sprintf('COM_KUNENA_VIEW_CATEGORY_LIST_CATEGORY_TITLE', $category->name);
+
+			if (strpos($class, 'hasTooltip') !== false)
+			{
+				// Tooltips will decode HTML and we don't want the HTML to be parsed
+				$title = $this->escape($title);
+			}
 		}
 
-		$link = JHtml::_('kunenaforum.link', $category->getUrl(), $content, $this->escape($title), $class, 'follow');
+		$link = JHtml::_('kunenaforum.link', $category->getUrl(), $content, $title, $class, 'follow');
 
 		KUNENA_PROFILER ? KunenaProfiler::instance()->stop('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
 
@@ -210,9 +216,15 @@ class KunenaLayout extends KunenaLayoutBase
 						$title = KunenaHtmlParser::stripBBCode($topic->first_post_message, 200, false);
 				}
 			}
+
+			if (strpos($class, 'hasTooltip') !== false)
+			{
+				// Tooltips will decode HTML and we don't want the HTML to be parsed
+				$title = $this->escape($title);
+			}
 		}
 
-		$link = JHtml::_('kunenaforum.link', $url, $content, $this->escape($title), $class, 'nofollow');
+		$link = JHtml::_('kunenaforum.link', $url, $content, $title, $class, 'nofollow');
 
 		KUNENA_PROFILER ? KunenaProfiler::instance()->stop('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
 
@@ -248,9 +260,15 @@ class KunenaLayout extends KunenaLayoutBase
 
 		if ($title === null)
 		{
-			$title = KunenaHtmlParser::stripBBCode($category->getLastTopic()->last_post_message, 200, false);
+			$title = KunenaHtmlParser::stripBBCode($lastTopic->last_post_message, 200, false);
+
+			if (strpos($class, 'hasTooltip') !== false)
+			{
+				// Tooltips will decode HTML and we don't want the HTML to be parsed
+				$title = $this->escape($title);
+			}
 		}
 
-		return JHtml::_('kunenaforum.link', $uri, $content, $this->escape($title), $class, 'nofollow');
+		return JHtml::_('kunenaforum.link', $uri, $content, $title, $class, 'nofollow');
 	}
 }


### PR DESCRIPTION
kunenaforum.link usage has no escaping for class, title, and rel variables.

Additionally tooltips are allowing the HTML in a post to render. This is normal tooltip behavior and to prevent it you basically double escape (once the content then of course once at the attribute), but since these functions are used for tooltip and non-tooltip usage an if check is added to ensure double escape is only applied to tooltip outputs.
