### PR TITLE
Enabled Gravatar Defalt Image feature

### DIFF
--- a/src/administrator/components/com_kunena/install/plugins/plg_kunena_gravatar/avatar.php
+++ b/src/administrator/components/com_kunena/install/plugins/plg_kunena_gravatar/avatar.php
@@ -46,7 +46,7 @@ class KunenaAvatarGravatar extends KunenaAvatar
 		$user     = KunenaFactory::getUser($user);
 		$gravatar = new KunenaGravatar($user->email);
 		$gravatar->setAvatarSize(min($sizex, $sizey));
-		$gravatar->setDefaultImage(false);
+		$gravatar->setDefaultImage($this->params->get("default_image", false));
 		$gravatar->setMaxRating('g');
 
 		return $gravatar->buildGravatarURL(true);

--- a/src/administrator/components/com_kunena/install/plugins/plg_kunena_gravatar/gravatar.xml
+++ b/src/administrator/components/com_kunena/install/plugins/plg_kunena_gravatar/gravatar.xml
@@ -23,6 +23,7 @@
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
+				<field name="default_image" type="text" label="PLG_KUNENA_GRAVATAR_DEFAULT_IMAGE" description="PLG_KUNENA_GRAVATAR_DEFAULT_IMAGE_DESC" />
 			</fieldset>
 		</fields>
 	</config>

--- a/src/administrator/components/com_kunena/language/en-GB/en-GB.plg_kunena_gravatar.sys.ini
+++ b/src/administrator/components/com_kunena/language/en-GB/en-GB.plg_kunena_gravatar.sys.ini
@@ -14,3 +14,5 @@ PLG_KUNENA_GRAVATAR_DESCRIPTION="Kunena Integration Plugin for Gravatars."
 
 PLG_KUNENA_GRAVATAR_AVATAR="Enable Gravatars"
 PLG_KUNENA_GRAVATAR_AVATAR_DESC="Use Gravatar images in Kunena."
+PLG_KUNENA_GRAVATAR_DEFAULT_IMAGE="Default image"
+PLG_KUNENA_GRAVATAR_DEFAULT_IMAGE_DESC="The default image to serve up when there is no Gravatar image associated with the requested email. Supply the URL of your own default image, or specify a built in option, such as identicon, monsterid, wavatar or retro."


### PR DESCRIPTION
#### Summary of Changes

Enabled Gravatar Defalt Image feature ([further details](https://gravatar.com/site/implement/images/#default-image)).
It's the default image to serve up when there is no Gravatar image associated with the requested email.
The backward compatibility is guaranteed by the default parameter "false".
#### Testing Instructions

Configure plugin Kunena Gravatar and specify your image URL or one of the supported default options: identicon, monsterid, wavatar or retro.
Gravatar API would support 3 additional options (404, mm and blank) but they are not noteworthy to the public.
