### PR TITLE
Missing id for Subscription field

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
@@ -260,7 +260,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 							</div>
 						<?php endif; ?>
 						<?php if ($this->canSubscribe) : ?>
-							<div class="control-group">
+							<div class="control-group" id="kpost-subscribe">
 								<label class="control-label"><?php echo JText::_('COM_KUNENA_POST_SUBSCRIBE'); ?></label>
 
 								<div class="controls">

--- a/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
@@ -240,7 +240,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 						<?php endif; ?>
 
 						<?php if ($this->canSubscribe) : ?>
-							<div class="control-group">
+							<div class="control-group" id="kpost-subscribe">
 								<label class="control-label"><?php echo JText::_('COM_KUNENA_POST_SUBSCRIBE'); ?></label>
 								<div class="controls">
 									<input style="float: left; margin-right: 10px;" type="checkbox" name="subscribeMe" id="subscribeMe" value="1" <?php if ($this->subscriptionschecked == 1 && $this->me->canSubscribe != 0 || $this->subscriptionschecked == 0 && $this->me->canSubscribe == 1)


### PR DESCRIPTION
In Blue Eagle template, the new topic / edit topic window had a unique id for each field, and a different unique id for its container.
For example, the field "Check this box to be notified of replies to this topic" 

```
<tr id="kpost-subscribe"> ...
<input type="checkbox" id="subscribeMe" ...
```

While in crypsis the id has not been implemented for the container

```
<div class="control-group"> ...
<input type="checkbox" name="subscribeMe" ...
```

All the field containers have the generic class "control-group", but there is no way to style individually those control groups with css.

I suggest to restore the containers id as follows:

```
<div class="control-group" id="kpost-subscribe"> ...
<input type="checkbox" name="subscribeMe" ...
```
