### PR TITLE
fix to preserve upload path when sending file attachment upload

### DIFF
--- a/src/libraries/kunena/upload/upload.php
+++ b/src/libraries/kunena/upload/upload.php
@@ -570,7 +570,8 @@ class KunenaUpload
 		}
 		else
 		{
-			$file->tmp_name = JFile::makeSafe($fileInput['tmp_name']);
+			$pathInfo = pathinfo($fileInput['tmp_name']);
+			$file->tmp_name = $pathInfo['dirname'] . '/' . JFile::makeSafe($pathInfo['basename']);
 		}
 
 		$file->error = $fileInput['error'];


### PR DESCRIPTION
Pull Request for Issue #4380  .
#### Summary of Changes
#### Testing Instructions

The function JFile::makeSafe expect a filename, not a full path, so, if uploaded file is in '/tmp/uploaded_file.txt', the previous code make it appaead as 'uploaded_file.txt' (without the file path), and it ends in a upload error.
