### PR TITLE
Hide delete and insert all buttons when no attachments are in the form #4452

### DIFF
--- a/src/components/com_kunena/template/crypsis/assets/js/upload.main.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/upload.main.js
@@ -48,7 +48,10 @@ jQuery(function ($) {
 
 	$('#remove-all').on('click', function (e) {
 		e.preventDefault();
-
+		
+		$('#remove-all').hide();
+	    $('#insert-all').hide();
+		
 		// Removing items in edit if they are present
 		if ($.isEmptyObject(filesedit) == false) {
 			$(filesedit).each(function (index, file) {
@@ -221,6 +224,9 @@ jQuery(function ($) {
 		.bind('fileuploaddrop', function (e, data) {
 			$('#form_submit_button').prop('disabled', true);
 			
+			$('#insert-all').show();
+			$('#remove-all').show();
+			
 			var filecoutntmp = Object.keys(data['files']).length + fileCount;
 
 			if (filecoutntmp > kunena_upload_files_maxfiles) {
@@ -234,6 +240,9 @@ jQuery(function ($) {
 		})
 		.bind('fileuploadchange', function (e, data) {
 			$('#form_submit_button').prop('disabled', true);
+			
+			$('#insert-all').show();
+			$('#remove-all').show();
 			
 			var filecoutntmp = Object.keys(data['files']).length + fileCount;
 

--- a/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
@@ -238,11 +238,11 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 											<!-- The file input field used as target for the file upload widget -->
 											<input id="fileupload" type="file" name="file" multiple>
 										</span>
-										<button id="insert-all" class="btn btn-primary" type="submit">
+										<button id="insert-all" class="btn btn-primary" type="submit" style="display:none">
 											<?php echo KunenaIcons::upload();?>
 											<span><?php echo JText::_('COM_KUNENA_UPLOADED_LABEL_INSERT_ALL_BUTTON') ?></span>
 										</button>
-										<button id="remove-all" class="btn btn-danger" type="submit">
+										<button id="remove-all" class="btn btn-danger" type="submit" style="display:none">
 											<?php echo KunenaIcons::cancel();?>
 											<span><?php echo JText::_('COM_KUNENA_UPLOADED_LABEL_REMOVE_ALL_BUTTON') ?></span>
 										</button>

--- a/src/components/com_kunena/template/crypsisb3/assets/js/upload.main.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/upload.main.js
@@ -48,6 +48,9 @@ jQuery(function ($) {
 
 	$('#remove-all').on('click', function (e) {
 		e.preventDefault();
+		
+		$('#remove-all').hide();
+	    $('#insert-all').hide();
 
 		// Removing items in edit if they are present
 		if ($.isEmptyObject(filesedit) == false) {
@@ -219,6 +222,11 @@ jQuery(function ($) {
 			data.formData = params;
 		})
 		.bind('fileuploaddrop', function (e, data) {
+			$('#form_submit_button').prop('disabled', true);
+			
+			$('#insert-all').show();
+			$('#remove-all').show();
+			
 			var filecoutntmp = Object.keys(data['files']).length + fileCount;
 
 			if (filecoutntmp > kunena_upload_files_maxfiles) {
@@ -232,6 +240,9 @@ jQuery(function ($) {
 		})
 		.bind('fileuploadchange', function (e, data) {
 			$('#form_submit_button').prop('disabled', true);
+			
+			$('#insert-all').show();
+			$('#remove-all').show();
 			
 			var filecoutntmp = Object.keys(data['files']).length + fileCount;
 

--- a/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
@@ -224,11 +224,11 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 											<!-- The file input field used as target for the file upload widget -->
 											<input id="fileupload" type="file" name="file" multiple>
 										</span>
-										<button id="insert-all" class="btn btn-primary" type="submit">
+										<button id="insert-all" class="btn btn-primary" type="submit" style="display:none">
 											<?php echo KunenaIcons::upload();?>
 											<span><?php echo JText::_('COM_KUNENA_UPLOADED_LABEL_INSERT_ALL_BUTTON') ?></span>
 										</button>
-										<button id="remove-all" class="btn btn-danger" type="submit">
+										<button id="remove-all" class="btn btn-danger" type="submit" style="display:none">
 											<?php echo KunenaIcons::cancel();?>
 											<span><?php echo JText::_('COM_KUNENA_UPLOADED_LABEL_REMOVE_ALL_BUTTON') ?></span>
 										</button>


### PR DESCRIPTION
Pull Request for Issue #4452.
#### Summary of Changes
#### Testing Instructions

Remove all attachments, then buttons delete all and insert all should be hided. When you add attachments the buttons delete all and insert all should appear.
