### PR TITLE
Fix the search when no "search at date"

### DIFF
--- a/src/components/com_kunena/models/search.php
+++ b/src/components/com_kunena/models/search.php
@@ -201,7 +201,7 @@ class KunenaModelSearch extends KunenaModel
 		$time         = 0;
 		$searchatdate = $this->getState('query.searchatdate');
 
-		if ($searchatdate == JFactory::getDate()->format('m/d/Y'))
+		if (empty($searchatdate) || $searchatdate == JFactory::getDate()->format('m/d/Y'))
 		{
 			switch ($this->getState('query.searchdate'))
 			{


### PR DESCRIPTION
Pull Request for Search Issue.
#### Summary of Changes

The "search at date" can accept an empty value as a non-value.
The reading of the input (line 71) will put "null" as the default value ; which will force the search on a specific "null" date, converted automatically into "now".
#### Testing Instructions

When the field "search at date" is not displayed in the search form, it is not possible to perform a valid search.
