### PR TITLE
Little improvements in database finder

### DIFF
--- a/src/libraries/kunena/database/object/finder.php
+++ b/src/libraries/kunena/database/object/finder.php
@@ -107,7 +107,7 @@ abstract class KunenaDatabaseObjectFinder
 	public function order($by, $direction = 1, $alias = 'a')
 	{
 		$direction = $direction > 0 ? 'ASC' : 'DESC';
-		$by        = $alias . '.' . $this->db->quoteName($by);
+		$by        = (!empty($alias) ? ($alias . '.') : '') . $this->db->quoteName($by);
 		$this->query->order("{$by} {$direction}");
 
 		return $this;
@@ -219,7 +219,7 @@ abstract class KunenaDatabaseObjectFinder
 		}
 		else
 		{
-			$query->clear('select')->select('COUNT(*)');
+			$query->clear('select')->clear('order')->select('COUNT(*)');
 			$this->db->setQuery($query);
 		}
 


### PR DESCRIPTION
Pull Request for Issue #4643 .
#### Summary of Changes

Few modifications in the finder object so plugins will be able to modify the content without generating SQL errors.
#### Testing Instructions

When a plugin wants to interact with the finder, it can add some ordering fields which will generate a SQL error during the count.
The patch autorise an empty alias for the "count" function and will also clear the "order" during the "count".
