### PR TITLE
Restore a trigger "onKunenaGetTopics"

### DIFF
--- a/src/components/com_kunena/controller/topic/list/user/display.php
+++ b/src/components/com_kunena/controller/topic/list/user/display.php
@@ -107,6 +107,12 @@ class ComponentKunenaControllerTopicListUserDisplay extends ComponentKunenaContr
 				$finder->filterByUser($user, 'subscribed');
 				break;
 
+			case 'plugin':
+				$pluginmode = $this->state->get('list.modetype');
+				$dispatcher = JEventDispatcher::getInstance();
+				$dispatcher->trigger('onKunenaGetUserTopics', array($pluginmode, &$finder, &$order, &$categoryIds, $this));
+				break;
+
 			default :
 				$finder
 					->filterByUser($user, 'involved')
@@ -114,8 +120,10 @@ class ComponentKunenaControllerTopicListUserDisplay extends ComponentKunenaContr
 				break;
 		}
 
-		$categories = KunenaForumCategoryHelper::getCategories($categoryIds, $reverse, $authorise);
-		$finder->filterByCategories($categories);
+		if($categoryIds !== null) {
+			$categories = KunenaForumCategoryHelper::getCategories($categoryIds, $reverse, $authorise);
+			$finder->filterByCategories($categories);
+		}
 
 		$this->pagination = new KunenaPagination($finder->count(), $start, $limit);
 

--- a/src/components/com_kunena/controller/topic/list/user/display.php
+++ b/src/components/com_kunena/controller/topic/list/user/display.php
@@ -120,7 +120,8 @@ class ComponentKunenaControllerTopicListUserDisplay extends ComponentKunenaContr
 				break;
 		}
 
-		if($categoryIds !== null) {
+		if ($categoryIds !== null)
+		{
 			$categories = KunenaForumCategoryHelper::getCategories($categoryIds, $reverse, $authorise);
 			$finder->filterByCategories($categories);
 		}

--- a/src/libraries/kunena/forum/topic/finder.php
+++ b/src/libraries/kunena/forum/topic/finder.php
@@ -306,8 +306,10 @@ class KunenaForumTopicFinder extends KunenaDatabaseObjectFinder
 	 * @param   mixed  $columns  A string or an array of field names.
 	 * @return $this
 	 */
-	public function select($columns) {
+	public function select($columns)
+	{
 		$this->query->select($columns);
+
 		return $this;
 	}
 

--- a/src/libraries/kunena/forum/topic/finder.php
+++ b/src/libraries/kunena/forum/topic/finder.php
@@ -301,6 +301,17 @@ class KunenaForumTopicFinder extends KunenaDatabaseObjectFinder
 	}
 
 	/**
+	 * Access to the query select
+	 *
+	 * @param   mixed  $columns  A string or an array of field names.
+	 * @return $this
+	 */
+	public function select($columns) {
+		$this->query->select($columns);
+		return $this;
+	}
+
+	/**
 	 * @param   JDatabaseQuery $query
 	 */
 	protected function build(JDatabaseQuery $query)


### PR DESCRIPTION
Pull Request for Issue #4643 .
#### Summary of Changes

Due to the modification in the Kunena core, some files (models) are not used anymore.
In the new core, the trigger "onKunenaGetTopics" is not more called, so the option "Select View: By Plugin" is not working anymore.

That patch will restore a trigger but will rename it in order to not generate side effect due to the modification in the parameters.
#### Testing Instructions

Create a Kunena menu and select the "By plugin" view mode.
In the header text, put "moderation".

In a plugin, put the trigger:

```
    public function onKunenaGetUserTopics($pluginmode, &$finder, &$order, &$categoryIds, $controller) {
        if($pluginmode != 'moderation')
            return;

        $finder->filterByHold(array(0,1));

        // Force all categories
        $categoryIds = null;

        $finder
            ->select('a.id')
            ->order('last_post_time', 1)
            ->where('a.first_post_userid', '>', '0');
    }
```

_We removed some code for extra columns used by our moderation system_
