### PR TITLE
Fix error : JUser tryAuthorise does not exists

### DIFF
--- a/src/administrator/components/com_kunena/template/categories/default.php
+++ b/src/administrator/components/com_kunena/template/categories/default.php
@@ -272,7 +272,7 @@ $filterItem = $this->escape($this->state->get('item.id'));
 							<?php
 								echo str_repeat('<span class="gi">&mdash;</span>', $item->level);
 								if ($item->checked_out) {
-									$canCheckin = $item->checked_out == 0 || $item->checked_out == $this->user->id || $this->user->tryAuthorise('core.admin', 'com_checkin');
+									$canCheckin = $item->checked_out == 0 || $item->checked_out == $this->user->id || $this->user->authorise('core.admin', 'com_checkin');
 									$editor = KunenaFactory::getUser($item->editor)->getName();
 									echo JHtml::_('jgrid.checkedout', $i, $editor, $item->checked_out_time, 'categories.', $canCheckin);
 								}


### PR DESCRIPTION
#### Summary of Changes

There is no "tryAuthorise" function for the JUser class but there is one in the Kunena category.
Regarding the parameters, it looks like it was designed to be the call to the JUser authorise function.
#### Testing Instructions

With an account, edit a Kunena category.
With another account, go in the category listing, in a page where you can see the category under edition.
