### PR TITLE
Give an access to the inbox count value

### DIFF
--- a/src/components/com_kunena/controller/widget/login/display.php
+++ b/src/components/com_kunena/controller/widget/login/display.php
@@ -39,6 +39,8 @@ class ComponentKunenaControllerWidgetLoginDisplay extends KunenaControllerDispla
 
 	public $inboxCount;
 	
+	public $inboxCountValue;
+	
 	public $profile_edit_url;
 
 	/**
@@ -77,8 +79,8 @@ class ComponentKunenaControllerWidgetLoginDisplay extends KunenaControllerDispla
 
 			if ($private)
 			{
-				$count = $private->getUnreadCount($this->me->userid);
-				$this->inboxCount = $count ? JText::sprintf('COM_KUNENA_PMS_INBOX_NEW', $count) : JText::_('COM_KUNENA_PMS_INBOX');
+				$this->inboxCountValue = $private->getUnreadCount($this->me->userid);
+				$this->inboxCount = $this->inboxCountValue ? JText::sprintf('COM_KUNENA_PMS_INBOX_NEW', $this->inboxCountValue) : JText::_('COM_KUNENA_PMS_INBOX');
 				$this->pm_link = $private->getInboxURL();
 			}
 			


### PR DESCRIPTION
Pull Request for Improvement.

#### Summary of Changes

The login controller just provided the "inboxCount" which is a string but it can be useful to also have the number value.
Thanks to that it can be possible in the "login" layout widget, to display the counter in a small label just near the avatar icon (or as a stamp).
The users will then have a direct information of their inbox status without having to open their profile menu.

#### Testing Instructions

In the layout "widget/login/logout/default.php" is it then possible to add the code:
```
<?php if (!empty($this->pm_link) && $this->inboxCountValue > 0) : ?>
        <span class="inbox-counter"><span class="label label-info"><?php echo $this->inboxCountValue; ?></span></span>
<?php endif; ?>
```
Just before the display of the avatar image (and also add some CSS to improve the display).