### PR TITLE
Fixed the wrong URL

### DIFF
--- a/src/components/com_kunena/template/crypsis/assets/js/edit.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/edit.js
@@ -16,7 +16,7 @@ function kPreviewHelper(previewActive) {
 	if (jQuery('#kbbcode-message').val() != null) {
 		jQuery.ajax({
 			type    : 'POST',
-			url     : 'index.php?option=com_kunena&view=topic&layout=edit&format=raw',
+			url     : jQuery('#kpreview_url').val(),
 			async   : false,
 			dataType: 'json',
 			data    : {body: jQuery('#kbbcode-message').val()},

--- a/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
@@ -100,7 +100,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 		<input type="hidden" name="view" value="topic" />
 		<input id="kurl_topicons_request" type="hidden" value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=topicicons&format=raw', false); ?>" />
 		<input id="kcategory_poll" type="hidden" name="kcategory_poll" value="<?php echo $this->message->catid; ?>" />
-		<input id="kpreview_url" type="hidden" name="kpreview_url" value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=edit&format=raw', false) ?>" />
+		<input id="kpreview_url" type="hidden" name="kpreview_url" value="<?php JUri::root(true) . '/index.php?option=com_kunena&view=topic&layout=edit&format=raw' ?>" />
 		<?php if (!$this->config->allow_change_subject) : ?>
 			<input type="hidden" name="subject" value="<?php echo $this->escape($this->message->subject); ?>" />
 		<?php endif; ?>

--- a/src/components/com_kunena/template/crypsisb3/assets/js/edit.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/edit.js
@@ -16,7 +16,7 @@ function kPreviewHelper(previewActive) {
 	if (jQuery('#kbbcode-message').val() != null) {
 		jQuery.ajax({
 			type    : 'POST',
-			url     : 'index.php?option=com_kunena&view=topic&layout=edit&format=raw',
+			url     : jQuery('#kpreview_url').val(),
 			async   : false,
 			dataType: 'json',
 			data    : {body: jQuery('#kbbcode-message').val()},

--- a/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
@@ -97,7 +97,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 		<input type="hidden" name="view" value="topic" />
 		<input id="kurl_topicons_request" type="hidden" value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=topicicons&format=raw', false); ?>" />
 		<input id="kcategory_poll" type="hidden" name="kcategory_poll" value="<?php echo $this->message->catid; ?>" />
-		<input id="kpreview_url" type="hidden" name="kpreview_url" value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=edit&format=raw', false) ?>" />
+		<input id="kpreview_url" type="hidden" name="kpreview_url" value="<?php JUri::root(true) . '/index.php?option=com_kunena&view=topic&layout=edit&format=raw' ?>" />
 		<?php if (!$this->config->allow_change_subject) : ?>
 			<input type="hidden" name="subject" value="<?php echo $this->escape($this->message->subject); ?>" />
 		<?php endif; ?>


### PR DESCRIPTION
The preview action while editing a post, points to a malformed URL (half SEF, half non-sef), which is not guaranteed to be parsed correctly by Joomla, and alerts some Web Application Firewall since the php file called (/forum/5-support/topic/index.php) does not exists on the filesystem (see below).

Given that the topic URL is http:// site.com/forum/5-support/topic/create.html
and the preview URL is relative index.php?option=com_kunena&view=topic&layout=edit&format=raw
then the actual preview URL will be /forum/**5-support/topic/index.php**?option=com_kunena&view=topic&layout=edit&format=raw which is wrong.

In addition, the value calculated for "kpreview_url" was never used.
