### PR TITLE
Generalized login links

### DIFF
--- a/src/components/com_kunena/controller/message/item/actions/display.php
+++ b/src/components/com_kunena/controller/message/item/actions/display.php
@@ -176,7 +176,8 @@ class ComponentKunenaControllerMessageItemActionsDisplay extends KunenaControlle
 			&& !$config->read_only || !$this->message->isAuthorised('reply') && !$this->topic->locked && $login->enabled()
 			&& !$me->userid && !$this->message->hold && !$config->read_only)
 		{
-			$logintext =  '<a class="btn-link" href="#klogin" id="login-link" rel="nofollow"> ' . JText::_('JLOGIN') . '</a>';
+			$loginurl = $login->getLoginURL() . '?return=' . base64_encode((string)JUri::getInstance());
+			$logintext = sprintf('<a class="btn-link" href="%s" rel="nofollow">%s</a>', $loginurl, JText::_('JLOGIN'));
 
 			if ($login->getRegistrationUrl())
 			{

--- a/src/components/com_kunena/controller/message/item/actions/display.php
+++ b/src/components/com_kunena/controller/message/item/actions/display.php
@@ -176,7 +176,7 @@ class ComponentKunenaControllerMessageItemActionsDisplay extends KunenaControlle
 			&& !$config->read_only || !$this->message->isAuthorised('reply') && !$this->topic->locked && $login->enabled()
 			&& !$me->userid && !$this->message->hold && !$config->read_only)
 		{
-			$loginurl = $login->getLoginURL() . '?return=' . base64_encode((string)JUri::getInstance());
+			$loginurl = JRoute::_('index.php?option=com_users&view=login&return=' . base64_encode((string)JUri::getInstance()));
 			$logintext = sprintf('<a class="btn-link" href="%s" rel="nofollow">%s</a>', $loginurl, JText::_('JLOGIN'));
 
 			if ($login->getRegistrationUrl())

--- a/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
@@ -162,7 +162,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 								<input type="text" id="kauthorname" name="authorname" size="35" placeholder="<?php echo JText::_('COM_KUNENA_TOPIC_EDIT_PLACEHOLDER_AUTHORNAME') ?>" class="input-xxlarge" maxlength="35" tabindex="4" value="<?php echo $this->escape($this->message->name); ?>"/>
 						<!-- Encourage guest user to login or register -->
 						<?php
-			            $login =  '<a class="btn-link" href="index.php?option=com_users&view=login"> ' . JText::_('JLOGIN') . '</a>';
+			            $login =  '<a class="btn-link" href="' . KunenaLogin::getInstance()->getLoginURL() . '?return=' . base64_encode((string)JUri::getInstance()) . '"> ' . JText::_('JLOGIN') . '</a>';
 			            $register =  ' ' . JText::_('COM_KUNENA_LOGIN_OR') . ' <a class="btn-link" href="index.php?option=com_users&view=registration">' . JText::_('JREGISTER') . '</a>';
 						echo JText::sprintf('COM_KUNENA_LOGIN_PLEASE_SKIP', $login, $register) ;
 			            ?>

--- a/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
@@ -162,7 +162,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 								<input type="text" id="kauthorname" name="authorname" size="35" placeholder="<?php echo JText::_('COM_KUNENA_TOPIC_EDIT_PLACEHOLDER_AUTHORNAME') ?>" class="input-xxlarge" maxlength="35" tabindex="4" value="<?php echo $this->escape($this->message->name); ?>"/>
 						<!-- Encourage guest user to login or register -->
 						<?php
-			            $login =  '<a class="btn-link" href="' . KunenaLogin::getInstance()->getLoginURL() . '?return=' . base64_encode((string)JUri::getInstance()) . '"> ' . JText::_('JLOGIN') . '</a>';
+			            $login =  '<a class="btn-link" href="' . JRoute::_('index.php?option=com_users&view=login&return=' . base64_encode((string)JUri::getInstance())) . '"> ' . JText::_('JLOGIN') . '</a>';
 			            $register =  ' ' . JText::_('COM_KUNENA_LOGIN_OR') . ' <a class="btn-link" href="index.php?option=com_users&view=registration">' . JText::_('JREGISTER') . '</a>';
 						echo JText::sprintf('COM_KUNENA_LOGIN_PLEASE_SKIP', $login, $register) ;
 			            ?>

--- a/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
@@ -144,7 +144,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 								<input type="text" id="kauthorname" name="authorname"  placeholder="<?php echo JText::_('COM_KUNENA_TOPIC_EDIT_PLACEHOLDER_AUTHORNAME') ?>" class="form-control" maxlength="35" tabindex="4" value="<?php echo $this->escape($this->message->name); ?>" required />
 							<!-- Encourage guest user to login or register -->
 						<?php
-			            $login =  '<a class="btn-link" href="index.php?option=com_users&view=login"> ' . JText::_('JLOGIN') . '</a>';
+			            $login =  '<a class="btn-link" href="' . KunenaLogin::getInstance()->getLoginURL() . '?return=' . base64_encode((string)JUri::getInstance()) . '"> ' . JText::_('JLOGIN') . '</a>';
 			            $register =  ' ' . JText::_('COM_KUNENA_LOGIN_OR') . ' <a class="btn-link" href="index.php?option=com_users&view=registration">' . JText::_('JREGISTER') . '</a>';
 						echo JText::sprintf('COM_KUNENA_LOGIN_PLEASE_SKIP', $login, $register) ;
 			            ?>

--- a/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
@@ -144,7 +144,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 								<input type="text" id="kauthorname" name="authorname"  placeholder="<?php echo JText::_('COM_KUNENA_TOPIC_EDIT_PLACEHOLDER_AUTHORNAME') ?>" class="form-control" maxlength="35" tabindex="4" value="<?php echo $this->escape($this->message->name); ?>" required />
 							<!-- Encourage guest user to login or register -->
 						<?php
-			            $login =  '<a class="btn-link" href="' . KunenaLogin::getInstance()->getLoginURL() . '?return=' . base64_encode((string)JUri::getInstance()) . '"> ' . JText::_('JLOGIN') . '</a>';
+			            $login =  '<a class="btn-link" href="' . JRoute::_('index.php?option=com_users&view=login&return=' . base64_encode((string)JUri::getInstance())) . '"> ' . JText::_('JLOGIN') . '</a>';
 			            $register =  ' ' . JText::_('COM_KUNENA_LOGIN_OR') . ' <a class="btn-link" href="index.php?option=com_users&view=registration">' . JText::_('JREGISTER') . '</a>';
 						echo JText::sprintf('COM_KUNENA_LOGIN_PLEASE_SKIP', $login, $register) ;
 			            ?>


### PR DESCRIPTION
The option to hide right nav position introduced recently, https://github.com/Kunena/Kunena-Forum/pull/5021 causes that the login links in messages ("Please Log in or Create an account to join the conversation") could point to a non existing login module, so it's necessary to generalise them to use the system login component.
