### PR TITLE
Remove duplicate label on mobile

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/topic/row/category.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/row/category.php
@@ -129,17 +129,6 @@ if (!empty($this->spacing)) : ?>
 				<?php echo  $topic->getLastPostTime()->toKunena('config_post_dateformat'); ?> <br>
 			<?php endif; ?>
 			<?php echo JText::_('COM_KUNENA_BY') . ' ' . $this->topic->getLastPostAuthor()->getLink();?>
-			<div class="pull-right">
-				<?php /** TODO: New Feature - LABELS
-				<span class="label label-info">
-				<?php echo JText::_('COM_KUNENA_TOPIC_ROW_TABLE_LABEL_QUESTION'); ?>
-				</span>	*/ ?>
-				<?php if ($topic->locked != 0) : ?>
-					<span class="label label-important">
-						<?php echo KunenaIcons::lock(); ?> <?php echo JText::_('COM_KUNENA_LOCKED'); ?>
-					</span>
-				<?php endif; ?>
-			</div>
 		</div>
 
 		<div class="pull-left">

--- a/src/components/com_kunena/template/crypsis/layouts/topic/row/category.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/row/category.php
@@ -110,7 +110,7 @@ if (!empty($this->spacing)) : ?>
 			<?php endif; ?>
 			<?php echo JText::_('COM_KUNENA_BY') ?>
 			<?php echo $topic->getAuthor()->getLink(null, JText::sprintf('COM_KUNENA_VIEW_USER_LINK_TITLE', $this->topic->getLastPostAuthor()->getName()), '', '', KunenaTemplate::getInstance()->tooltips(), $category->id); ?>
-			<div class="pull-right">
+			<div class="pull-right hidden-phone">
 				<?php /** TODO: New Feature - LABELS
 				<span class="label label-info">
 				<?php echo JText::_('COM_KUNENA_TOPIC_ROW_TABLE_LABEL_QUESTION'); ?>

--- a/src/components/com_kunena/template/crypsis/layouts/topic/row/category.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/row/category.php
@@ -129,6 +129,17 @@ if (!empty($this->spacing)) : ?>
 				<?php echo  $topic->getLastPostTime()->toKunena('config_post_dateformat'); ?> <br>
 			<?php endif; ?>
 			<?php echo JText::_('COM_KUNENA_BY') . ' ' . $this->topic->getLastPostAuthor()->getLink();?>
+			<div class="pull-right">
+				<?php /** TODO: New Feature - LABELS
+				<span class="label label-info">
+				<?php echo JText::_('COM_KUNENA_TOPIC_ROW_TABLE_LABEL_QUESTION'); ?>
+				</span>	*/ ?>
+				<?php if ($topic->locked != 0) : ?>
+					<span class="label label-important">
+						<?php echo KunenaIcons::lock(); ?> <?php echo JText::_('COM_KUNENA_LOCKED'); ?>
+					</span>
+				<?php endif; ?>
+			</div>
 		</div>
 
 		<div class="pull-left">

--- a/src/components/com_kunena/template/crypsis/layouts/topic/row/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/row/default.php
@@ -107,7 +107,7 @@ if (!empty($this->spacing)) : ?>
 			<?php echo $topic->getFirstPostTime()->toKunena('config_post_dateformat'); ?>,
 			<?php echo JText::_('COM_KUNENA_BY') ?>
 			<?php echo $topic->getAuthor()->getLink(null, JText::sprintf('COM_KUNENA_VIEW_USER_LINK_TITLE', $this->topic->getFirstPostAuthor()->getName()), '', '', KunenaTemplate::getInstance()->tooltips(), $category->id); ?>
-			<div class="pull-right">
+			<div class="pull-right hidden-phone">
 				<?php /** TODO: New Feature - LABELS
 				<span class="label label-info">
 				<?php echo JText::_('COM_KUNENA_TOPIC_ROW_TABLE_LABEL_QUESTION'); ?>

--- a/src/components/com_kunena/template/crypsis/layouts/topic/row/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/row/default.php
@@ -124,17 +124,6 @@ if (!empty($this->spacing)) : ?>
 			<?php echo $this->getTopicLink($this->topic, 'last', JText::_('COM_KUNENA_GEN_LAST_POST'), null, null, $category, false, true); ?>
 			<?php echo  $topic->getLastPostTime()->toKunena('config_post_dateformat'); ?> <br>
 			<?php echo JText::_('COM_KUNENA_BY') . ' ' . $this->topic->getLastPostAuthor()->getLink(null, null, '', '', null, $category->id);?>
-			<div class="pull-right">
-				<?php /** TODO: New Feature - LABELS
-				<span class="label label-info">
-				<?php echo JText::_('COM_KUNENA_TOPIC_ROW_TABLE_LABEL_QUESTION'); ?>
-				</span>	*/ ?>
-				<?php if ($topic->locked != 0) : ?>
-					<span class="label label-important">
-						<?php echo KunenaIcons::lock(); ?> <?php echo JText::_('COM_KUNENA_LOCKED'); ?>
-					</span>
-				<?php endif; ?>
-			</div>
 		</div>
 
 		<div class="pull-left">

--- a/src/components/com_kunena/template/crypsis/layouts/topic/row/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/row/default.php
@@ -124,6 +124,17 @@ if (!empty($this->spacing)) : ?>
 			<?php echo $this->getTopicLink($this->topic, 'last', JText::_('COM_KUNENA_GEN_LAST_POST'), null, null, $category, false, true); ?>
 			<?php echo  $topic->getLastPostTime()->toKunena('config_post_dateformat'); ?> <br>
 			<?php echo JText::_('COM_KUNENA_BY') . ' ' . $this->topic->getLastPostAuthor()->getLink(null, null, '', '', null, $category->id);?>
+			<div class="pull-right">
+				<?php /** TODO: New Feature - LABELS
+				<span class="label label-info">
+				<?php echo JText::_('COM_KUNENA_TOPIC_ROW_TABLE_LABEL_QUESTION'); ?>
+				</span>	*/ ?>
+				<?php if ($topic->locked != 0) : ?>
+					<span class="label label-important">
+						<?php echo KunenaIcons::lock(); ?> <?php echo JText::_('COM_KUNENA_LOCKED'); ?>
+					</span>
+				<?php endif; ?>
+			</div>
 		</div>
 
 		<div class="pull-left">

--- a/src/components/com_kunena/template/crypsis/layouts/topic/row/user.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/row/user.php
@@ -126,17 +126,6 @@ if (!empty($this->spacing)) : ?>
 			<?php echo  $topic->getLastPostTime()->toKunena('config_post_dateformat'); ?> <br>
 			<?php endif; ?>
 			<?php echo JText::_('COM_KUNENA_BY') . ' ' . $this->topic->getLastPostAuthor()->getLink(null, null, '', '', null, $category->id);?>
-			<div class="pull-right">
-				<?php /** TODO: New Feature - LABELS
-				<span class="label label-info">
-				<?php echo JText::_('COM_KUNENA_TOPIC_ROW_TABLE_LABEL_QUESTION'); ?>
-				</span>	*/ ?>
-				<?php if ($topic->locked != 0) : ?>
-					<span class="label label-important">
-						<?php echo KunenaIcons::lock(); ?> <?php echo JText::_('COM_KUNENA_LOCKED'); ?>
-					</span>
-				<?php endif; ?>
-			</div>
 		</div>
 
 		<div class="pull-left">

--- a/src/components/com_kunena/template/crypsis/layouts/topic/row/user.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/row/user.php
@@ -107,7 +107,7 @@ if (!empty($this->spacing)) : ?>
 			<br />
 				<?php echo $topic->getFirstPostTime()->toKunena('config_post_dateformat'); ?>
 			<?php endif; ?>
-			<div class="pull-right">
+			<div class="pull-right hidden-phone">
 				<?php /** TODO: New Feature - LABELS
 				<span class="label label-info">
 				<?php echo JText::_('COM_KUNENA_TOPIC_ROW_TABLE_LABEL_QUESTION'); ?>

--- a/src/components/com_kunena/template/crypsis/layouts/topic/row/user.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/row/user.php
@@ -126,6 +126,17 @@ if (!empty($this->spacing)) : ?>
 			<?php echo  $topic->getLastPostTime()->toKunena('config_post_dateformat'); ?> <br>
 			<?php endif; ?>
 			<?php echo JText::_('COM_KUNENA_BY') . ' ' . $this->topic->getLastPostAuthor()->getLink(null, null, '', '', null, $category->id);?>
+			<div class="pull-right">
+				<?php /** TODO: New Feature - LABELS
+				<span class="label label-info">
+				<?php echo JText::_('COM_KUNENA_TOPIC_ROW_TABLE_LABEL_QUESTION'); ?>
+				</span>	*/ ?>
+				<?php if ($topic->locked != 0) : ?>
+					<span class="label label-important">
+						<?php echo KunenaIcons::lock(); ?> <?php echo JText::_('COM_KUNENA_LOCKED'); ?>
+					</span>
+				<?php endif; ?>
+			</div>
 		</div>
 
 		<div class="pull-left">


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes
The label "Locked" is duplicate on mobile, this pr is for keep only one version of the label for all devices.
 
![duplicate](https://cloud.githubusercontent.com/assets/12942731/24527964/7b99ecd8-1572-11e7-9e55-879a4a24284c.PNG)



![nonduplicate](https://cloud.githubusercontent.com/assets/12942731/24527773/b7b3631c-1571-11e7-806f-c7fbf0315c4d.PNG)

#### Testing Instructions
