### PR TITLE
Remove parent share div for customsharetag

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/widget/socialcustomtag/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/widget/socialcustomtag/default.php
@@ -14,4 +14,4 @@ $this->ktemplate = KunenaFactory::getTemplate();
 $socialsharetag = $this->ktemplate->params->get('socialsharetag');
 ?>
 
-<div id="share"><?php echo JHtml::_('content.prepare', $socialsharetag); ?></div>
+<?php echo JHtml::_('content.prepare', $socialsharetag); ?>

--- a/src/components/com_kunena/template/crypsisb3/layouts/widget/socialcustomtag/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/widget/socialcustomtag/default.php
@@ -14,4 +14,4 @@ $this->ktemplate = KunenaFactory::getTemplate();
 $socialsharetag = $this->ktemplate->params->get('socialsharetag');
 ?>
 
-<div id="share"><?php echo JHtml::_('content.prepare', $socialsharetag); ?></div>
+<?php echo JHtml::_('content.prepare', $socialsharetag); ?>


### PR DESCRIPTION
Pull Request for Issue # .
Just ran into this issue with a client site utilizing the new customsharetag and {jssocials}.

<div id="share"> is not a Kunena div to identify the 'share position' but a jssocials div id to replace with the sharing buttons.
Keeping this div id interferes with the jssocials script is this is added via a customsharetag :(

#### Summary of Changes
the widget layouts for customsocialshares are 'stripped' of the surrounding div share id

#### Testing Instructions
When using {jssocials}  the correct sharing buttons should appear and not the default sharing buttons that are created by the jssocials script.
