### PR TITLE
Remove board title from subject on emails

### DIFF
--- a/src/libraries/kunena/forum/message/message.php
+++ b/src/libraries/kunena/forum/message/message.php
@@ -394,7 +394,7 @@ class KunenaForumMessage extends KunenaDatabaseObject
 			}
 
 			$mailsender = JMailHelper::cleanAddress($config->board_title);
-			$mailsubject = JMailHelper::cleanSubject ( $config->board_title . ' ' . $topic->subject . " (" . $this->getCategory()->name . ")" );
+			$mailsubject = JMailHelper::cleanSubject ( $topic->subject . " (" . $this->getCategory()->name . ")" );
 			$subject = $this->subject ? $this->subject : $topic->subject;
 
 			// Create email.


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes
This will remove the board title from subject on notification emails

#### Testing Instructions
