### PR TITLE
When admin edit uers profile, let see him the tab to change avatar

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/user/edit/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/user/edit/default.php
@@ -28,19 +28,19 @@ $this->me = KunenaUserHelper::getMyself();
 
 	<div class="tabs">
 		<ul id="KunenaUserEdit" class="nav nav-tabs">
-			<?php if ($this->profile->userid == $this->me->userid): ?>
+			<?php if ($this->profile->userid == $this->me->userid || $this->me->isAdmin() || $this->me->isModerator()): ?>
 			<li class="active">
 				<a href="#home" data-toggle="tab">
 					<?php echo JText::_('COM_KUNENA_PROFILE_EDIT_USER'); ?>
 				</a>
 			</li>
 			<?php endif; ?>
-			<li <?php if ($this->profile->userid != $this->me->userid) { echo 'class="active"'; }?>>
+			<li <?php if ($this->profile->userid != $this->me->userid && !$this->me->isAdmin() && !$this->me->isModerator()) { echo 'class="active"'; }?>>
 				<a href="#editprofile" data-toggle="tab">
 					<?php echo JText::_('COM_KUNENA_PROFILE_EDIT_PROFILE'); ?>
 				</a>
 			</li>
-			<?php if ($this->profile->userid == $this->me->userid): ?>
+			<?php if ($this->profile->userid == $this->me->userid || $this->me->isAdmin() || $this->me->isModerator()): ?>
 			<li>
 				<a href="#editavatar" data-toggle="tab">
 					<?php echo JText::_('COM_KUNENA_PROFILE_EDIT_AVATAR'); ?>
@@ -55,7 +55,7 @@ $this->me = KunenaUserHelper::getMyself();
 		</ul>
 
 		<div id="KunenaUserEdit" class="tab-content">
-			<?php if ($this->profile->userid == $this->me->userid): ?>
+			<?php if ($this->profile->userid == $this->me->userid || $this->me->isAdmin() || $this->me->isModerator()): ?>
 			<div class="tab-pane fade in active" id="home">
 				<?php echo $this->subRequest('User/Edit/User'); ?>
 			</div>
@@ -63,7 +63,7 @@ $this->me = KunenaUserHelper::getMyself();
 			<div class="tab-pane fade <?php if ($this->profile->userid != $this->me->userid) { echo 'in active'; }?>" id="editprofile">
 				<?php echo $this->subRequest('User/Edit/Profile'); ?>
 			</div>
-			<?php if ($this->profile->userid == $this->me->userid): ?>
+			<?php if ($this->profile->userid == $this->me->userid || $this->me->isAdmin() || $this->me->isModerator()): ?>
 			<div class="tab-pane fade" id="editavatar">
 				<?php echo $this->subRequest('User/Edit/Avatar'); ?>
 			</div>

--- a/src/components/com_kunena/template/crypsis/layouts/user/item/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/user/item/default.php
@@ -19,7 +19,7 @@ $tabs = $this->getTabs();
 </h1>
 
 <h2 class="pull-right">
-	<?php if ($this->profile->isAuthorised('edit') || $this->me->isAdmin()) : ?>
+	<?php if ($this->profile->isAuthorised('edit') || $this->me->isAdmin() || $this->me->isModerator()) : ?>
 		<?php echo $this->profile->getLink(
 			KunenaIcons::edit() . ' ' . JText::_('COM_KUNENA_EDIT'),
 			JText::_('COM_KUNENA_EDIT'), 'nofollow', 'edit', 'btn'

--- a/src/components/com_kunena/template/crypsisb3/layouts/user/item/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/user/item/default.php
@@ -19,7 +19,7 @@ $tabs = $this->getTabs();
 </h1>
 
 <h2 class="pull-right">
-	<?php if ($this->profile->isAuthorised('edit') || $this->me->isAdmin()) : ?>
+	<?php if ($this->profile->isAuthorised('edit') || $this->me->isAdmin() || $this->me->isModerator()) : ?>
 		<?php echo $this->profile->getLink(
 			KunenaIcons::edit() . ' ' . JText::_('COM_KUNENA_EDIT'),
 			JText::_('COM_KUNENA_EDIT'), 'nofollow', 'edit', 'btn btn-default'

--- a/src/libraries/kunena/user/user.php
+++ b/src/libraries/kunena/user/user.php
@@ -204,7 +204,7 @@ class KunenaUser extends JObject
 				}
 				break;
 			case 'edit' :
-				if (!isset($this->registerDate) || !$this->isMyself() && !$user->isAdmin())
+				if (!isset($this->registerDate) || !$this->isMyself() && !$user->isAdmin() && !$user->isModerator())
 				{
 					$exception = new KunenaExceptionAuthorise(JText::sprintf('COM_KUNENA_VIEW_USER_EDIT_AUTH_FAILED', $this->getName()), $user->exists() ? 403 : 401);
 				}


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes

This change allow when go on profile on users on edit part, to see see the tabs : avatar and user details


#### Testing Instructions

By example on K5.1,, when i'am connected as admin and i open the profile of user nammed jack, without this change i can see only this : 

![ff](https://user-images.githubusercontent.com/876395/29465050-27c8ee76-8438-11e7-9514-788469d3064d.jpg)
