### PR TITLE
Add div and class to confidential text for guests

### DIFF
--- a/src/libraries/kunena/bbcode/bbcode.php
+++ b/src/libraries/kunena/bbcode/bbcode.php
@@ -1460,7 +1460,7 @@ class KunenaBbcodeLibrary extends BBCodeLibrary
 		}
 		else
 		{
-			return '<br />' . JText::_('COM_KUNENA_BBCODE_CONFIDENTIAL_TEXT_GUESTS') . '<br />';
+			return '<div class="kmsgtext-confidentialguests">' . JText::_('COM_KUNENA_BBCODE_CONFIDENTIAL_TEXT_GUESTS') . '</div>';
 		}
 	}
 


### PR DESCRIPTION
Currently the text for guests that the message contains confidential information is formatted as regular text in the message. This makes it confusing for quests as they do not understand what this means / why the author typed that.
With this patch the confidential text for guests is placed in a div with class kmsgtext-confidentialguests and by doing that the text can be styled via css to make it look different then the rest of the message.

Pull Request for Issue # .

#### Summary of Changes

#### Testing Instructions
