### PR TITLE
Fix report button in Message/Item/Actions

### DIFF
--- a/src/components/com_kunena/controller/message/item/actions/display.php
+++ b/src/components/com_kunena/controller/message/item/actions/display.php
@@ -304,11 +304,12 @@ class ComponentKunenaControllerMessageItemActionsDisplay extends KunenaControlle
 				{
 					$icon = '';
 				}
-
-				echo KunenaLayout::factory('Widget/Button')
+				
+				$this->messageButtons->set('report',
+					KunenaLayout::factory('Widget/Button')
 					->setProperties(array('url' => '#report'. $mesid .'', 'name' => 'report', 'scope' => 'message',
 					                      'type' => 'user', 'id' => 'btn_report', 'normal' => '', 'icon' => $icon,
-					                      'modal' => 'modal', 'pullright' => 'pullright'));
+					                      'modal' => 'modal', 'pullright' => 'pullright')));
 			}
 		}
 


### PR DESCRIPTION
"Report this" button was echoed directly from controller, rather than passed in to template through messageButtons. This makes it impossible for template developers to modify the display or positioning of the button within the message actions.

Pull Request for Issue #5611.

#### Summary of Changes

Modify message/item/actions controller to include the "report" button in messageButtons, rather than echoing it directly inside the controller.

#### Testing Instructions

- Verify "Report This" button still displays when viewing a thread as a user with adequate permissions.
- Within the template, verify that location and display of the button can be modified.