### PR TITLE
Additional css class "locked" for category-, topic- and lastPostLink

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/widget/login/logout/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/widget/login/logout/default.php
@@ -19,17 +19,20 @@ $status = $config->user_status;
 <ul class="nav pull-right">
 	<li class="dropdown mobile-user">
 		<a href="#" class="dropdown-toggle" data-toggle="dropdown">
-			<?php if ($this->me->getStatus() == 0 && $status) : ?>
-				<?php echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' green', 20, 20); ?>
-			<?php elseif ($this->me->getStatus() == 1 && $status) : ?>
-				<?php echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' yellow', 20, 20); ?>
-			<?php elseif ($this->me->getStatus() == 2 && $status) : ?>
-				<?php echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' red', 20, 20); ?>
-			<?php elseif ($this->me->getStatus() == 3 && $status) : ?>
-				<?php echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' grey', 20, 20); ?>
-			<?php else : ?>
-				<?php echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' none', 20, 20); ?>
-			<?php endif; ?>
+			<?php
+			$showOnlineStatus = ($this->me->showOnline == 1) ? true : false;  
+			
+			if ($this->me->getStatus() == 0 && $status && $showOnlineStatus) :
+				echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' green', 20, 20);
+			elseif ($this->me->getStatus() == 1 && $status && $showOnlineStatus) :
+				echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' yellow', 20, 20);
+			elseif ($this->me->getStatus() == 2 && $status && $showOnlineStatus) :
+				echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' red', 20, 20);
+			elseif ($this->me->getStatus() == 3 && $status || !$showOnlineStatus) :
+				echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' grey', 20, 20);
+			else :
+				echo $this->me->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType') . ' none', 20, 20);
+			endif; ?>
 			<b class="caret"></b>
 		</a>
 

--- a/src/libraries/kunena/layout/layout.php
+++ b/src/libraries/kunena/layout/layout.php
@@ -192,6 +192,11 @@ class KunenaLayout extends KunenaLayoutBase
 		{
 			$con = $rel;
 		}
+		
+		if ($category->locked)
+		{
+			$class .= ' locked';
+		}
 
 		$link = JHtml::_('kunenaforum.link', $category->getUrl(), $content, $title, $class, $con);
 
@@ -273,6 +278,11 @@ class KunenaLayout extends KunenaLayoutBase
 			$con = $rel;
 		}
 
+		if ($topic->locked)
+		{
+			$class .= ' locked';
+		}
+		
 		$link = JHtml::_('kunenaforum.link', $url, $content, $title, $class, $con);
 
 		KUNENA_PROFILER ? KunenaProfiler::instance()->stop('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
@@ -337,6 +347,11 @@ class KunenaLayout extends KunenaLayoutBase
 		else
 		{
 			$con = $rel;
+		}
+		
+		if ($lastTopic->locked)
+		{
+			$class .= ' locked';
 		}
 
 		return JHtml::_('kunenaforum.link', $uri, $content, $title, $class, $con);


### PR DESCRIPTION
Pull Request for Issue #5548

#### Summary of Changes
- src/libraries/kunena/layout/layout.php:
Functions: `getCategoryLink`, `getTopicLink` and `getLastPostLink` expanded with setting class "locked" if "locked" property of object is set

- Category
![grafik](https://user-images.githubusercontent.com/4742603/31852804-b70566be-b67e-11e7-881e-2892c06be799.png)

- Topic
![grafik](https://user-images.githubusercontent.com/4742603/31852830-4e265828-b67f-11e7-907b-c709e5296354.png)

#### Testing Instructions
Lock a categegory / topic and check its classes on href in frontend

closes #5548

