### PR TITLE
Improved language string for recent posts (Profile)

### DIFF
--- a/src/components/com_kunena/controller/message/list/recent/display.php
+++ b/src/components/com_kunena/controller/message/list/recent/display.php
@@ -233,7 +233,23 @@ class ComponentKunenaControllerMessageListRecentDisplay extends ComponentKunenaC
 				break;
 			case 'recent':
 			default:
-				$this->headerText = JText::_('COM_KUNENA_VIEW_TOPICS_POSTS_MODE_DEFAULT');
+				$userName = '';
+				if ($user->getName() != '')
+				{
+					$userName = $user->getName();
+					$charMapApostropheOnly = array('s','S','z','Z');
+					
+					if (in_array(substr($userName, -1), $charMapApostropheOnly))
+					{
+						$userName .= "' ";
+					}
+					else 
+					{
+						$userName .= "'s ";
+					}
+				}
+				
+				$this->headerText = $userName . JText::_('COM_KUNENA_VIEW_TOPICS_POSTS_MODE_DEFAULT');
 				$actions = array('approve', 'delete', 'move', 'permdelete');
 		}
 


### PR DESCRIPTION
Pull Request for Issue #5438 .

#### Summary of Changes
Added username of current view profile to recent posts headline
Check for following characters, which require apostrophe without trailing "s" according to german grammar
- s,S,z,Z
- other characters must be added if there are further rules in other languages

#### Testing Instructions
- Log in to forum
- visit profil page of user with "s" at the end of username
![grafik](https://user-images.githubusercontent.com/4742603/31861071-54355280-b726-11e7-8b20-c8608d2df2d9.png)

- visit profil page of user without "s" at the end of username
![grafik](https://user-images.githubusercontent.com/4742603/31861077-7ffef844-b726-11e7-8bb4-afcfd8b20cd1.png)

closes #5438