### PR TITLE
Remove height: 100% from .kmsg ...

### DIFF
--- a/src/components/com_kunena/template/crypsis/assets/less/general.less
+++ b/src/components/com_kunena/template/crypsis/assets/less/general.less
@@ -398,7 +398,6 @@ form {
 }
 
 .kmsg {
-  height: 100%;
   margin: 20px 0;
   word-wrap: break-word;
   font-family: "Segoe UI", "Segoe UI Emoji", "Segoe UI Symbol", Helvetica , Arial, sans-serif;

--- a/src/components/com_kunena/template/crypsisb3/assets/less/general.less
+++ b/src/components/com_kunena/template/crypsisb3/assets/less/general.less
@@ -394,7 +394,6 @@ form {
 }
 
 .kmsg {
-  height: 100%;
   margin: 20px 0;
   word-wrap: break-word;
   font-family: "Segoe UI", "Segoe UI Emoji", "Segoe UI Symbol", Helvetica , Arial, sans-serif;


### PR DESCRIPTION
... because it makes every topic / reply the same height as the browser window / screen!!!!!

#### Summary of Changes

Remove `height: 100%` from general.less .kmsg

#### Testing Instructions

Create a topic with several posts. View on high res monitor full screen - lots of white space at the bottom of posts.

Apply fix. Whitespace disappears.