### PR TITLE
Update FA to 5.0.11

### DIFF
--- a/src/components/com_kunena/template/crypsis/template.php
+++ b/src/components/com_kunena/template/crypsis/template.php
@@ -107,7 +107,7 @@ class KunenaTemplateCrypsis extends KunenaTemplate
 
 		if ($fontawesome)
 		{
-			$doc->addScript('https://use.fontawesome.com/releases/v5.0.10/js/all.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.0.11/js/all.js', array(), array('defer' => true));
 		}
 
 		// Load template colors settings

--- a/src/components/com_kunena/template/crypsisb3/template.php
+++ b/src/components/com_kunena/template/crypsisb3/template.php
@@ -145,7 +145,7 @@ class KunenaTemplateCrypsisb3 extends KunenaTemplate
 		if ($fontawesome)
 		{
 			/** @noinspection PhpDeprecationInspection */
-			$doc->addScript('https://use.fontawesome.com/releases/v5.0.10/js/all.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.0.11/js/all.js', array(), array('defer' => true));
 		}
 
 		$icons = $this->ktemplate->params->get('icons');


### PR DESCRIPTION
#### Summary of Changes

**Added**
16 new user icons
Full set of Creative Commons symbols
Regular style comment-dots used for v4 comment-alt in shim
Top 6 brand icons: r, ebay, mastodon, researchgate, keybase, teamspeak

**Changed**
Revised slider icons FortAwesome/Font-Awesome#11872
Make desktop typeface easier to find in apps that support ligature previews

**Fixed**
Remove errant XML entity from the lastfm-square icon FortAwesome/Font-Awesome#12847
Correcting paths in cloud icons FortAwesome/Font-Awesome-Pro#920

