### PR TITLE
Set date in article:published_time to ISO 8601 format

### DIFF
--- a/src/components/com_kunena/controller/topic/item/display.php
+++ b/src/components/com_kunena/controller/topic/item/display.php
@@ -489,7 +489,7 @@ class ComponentKunenaControllerTopicItemDisplay extends KunenaControllerDisplay
 
 		$doc->setMetaData('og:description', $first, 'property');
 		$doc->setMetaData('og:image', $image, 'property');
-		$doc->setMetaData('article:published_time', $this->topic->getFirstPostTime()->toKunena('config_post_dateformat'), 'property');
+		$doc->setMetaData('article:published_time', $this->topic->getFirstPostTime()->toISO8601(), 'property');
 		$doc->setMetaData('article:section', $this->topic->getCategory()->name, 'property');
 		$doc->setMetaData('twitter:card', 'summary', 'name');
 		$doc->setMetaData('twitter:title', $this->topic->displayField('subject'), 'name');


### PR DESCRIPTION
Pull Request for Issue # . 
 
In opengraph the date set in article:published_time should be in ISO 8601 format

#### Summary of Changes 

See : https://www.kunena.org/forum/k5-1-support/151197-sharing-to-facebook-not-working-correctly-anymore#200271
 
#### Testing Instructions