### PR TITLE
Update FA to 5.1.0

### DIFF
--- a/src/administrator/components/com_kunena/views/user/view.html.php
+++ b/src/administrator/components/com_kunena/views/user/view.html.php
@@ -39,7 +39,7 @@ class KunenaAdminViewUser extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.0.13/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.1.0/js/all.js', array(), array('defer' => true));
 		}
 
 		// Make the select list for the moderator flag

--- a/src/administrator/components/com_kunena/views/users/view.html.php
+++ b/src/administrator/components/com_kunena/views/users/view.html.php
@@ -50,7 +50,7 @@ class KunenaAdminViewUsers extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.0.13/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.1.0/js/all.js', array(), array('defer' => true));
 		}
 
 		$this->display();

--- a/src/components/com_kunena/template/crypsis/template.php
+++ b/src/components/com_kunena/template/crypsis/template.php
@@ -107,8 +107,8 @@ class KunenaTemplateCrypsis extends KunenaTemplate
 
 		if ($fontawesome)
 		{
-			$doc->addScript('https://use.fontawesome.com/releases/v5.0.13/js/all.js', array(), array('defer' => true));
-			$doc->addScript('https://use.fontawesome.com/releases/v5.0.13/js/v4-shims.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.1.0/js/all.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.1.0/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		// Load template colors settings

--- a/src/components/com_kunena/template/crypsisb3/template.php
+++ b/src/components/com_kunena/template/crypsisb3/template.php
@@ -145,8 +145,8 @@ class KunenaTemplateCrypsisb3 extends KunenaTemplate
 		if ($fontawesome)
 		{
 			/** @noinspection PhpDeprecationInspection */
-			$doc->addScript('https://use.fontawesome.com/releases/v5.0.13/js/all.js', array(), array('defer' => true));
-			$doc->addScript('https://use.fontawesome.com/releases/v5.0.13/js/v4-shims.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.1.0/js/all.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.1.0/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		$icons = $this->ktemplate->params->get('icons');


### PR DESCRIPTION
Pull Request for Issue https://github.com/Kunena/Kunena-Forum/issues/6005
 
#### Summary of Changes 
**Added**
New Emoji, Design, and Travel category pack
Another group of requested and commissioned icons
Version 4 shim for Web Fonts with CSS
New simplified download and NPM packages
@fortawesome/fontawesome-free and @fortawesome/fontawesome-pro NPM packages that match what's available in the CDN and .ZIP files
Brand icons rev, nimblr, megaport, mailchimp, hornbill, wix, weebly, themeco, squarespace, aws, shopware
API method toHtml() for converting abstract objects to HTML
API method counter() to generate Layers Counters
API method watch() to configure MutationObserver and watch DOM for icon changes and additions

**Changed**
Relocating sponsor data to a separate sponsors.yml
Updated teamspeak brand icon
No more default exports in the CommonJS/ES packages (anything installed from NPM)
Greatly improved performance and rendering of CSS pseudo-elements with SVG and JavaScript
Configuration of SVG with JavaScript can now be done with attributes on the script tag
SVG with JavaScript pseudo-elements now match syntax (font-family, font-weight) of Web Fonts with CSS

**Fixed**
Tree shaking of all NPM packages by default
Alignment of the book-open and dice-six icon
Correcting creative-commons
Incorrect license on the fontawesome-common-types package
Improve ligatures that share a base name with another ligature
Correcting solid style of the digital-tachograph icon
Prevent duplicating classes in some scenarios with SVG with JavaScript
Duplicate insertion of CSS when insertCss() method was called
Missing TypeScript definitions for the free-brands-svg-icons package
 
#### Testing Instructions