### PR TITLE
Bug: Fix empty action dropdown

### DIFF
--- a/src/components/com_kunena/models/category.php
+++ b/src/components/com_kunena/models/category.php
@@ -460,7 +460,7 @@ class KunenaModelCategory extends KunenaAdminModelCategories
 			$actionDropdown[] = HTMLHelper::_('select.option', 'restore', JText::_('COM_KUNENA_BUTTON_UNDELETE_LONG'));
 		}
 
-		if ($actionDropdown == 1)
+		if (count($actionDropdown) == 1)
 		{
 			return;
 		}
@@ -498,7 +498,7 @@ class KunenaModelCategory extends KunenaAdminModelCategories
 		$actionDropdown[] = HTMLHelper::_('select.option', 'none', JText::_('COM_KUNENA_BULK_CHOOSE_ACTION'));
 		$actionDropdown[] = HTMLHelper::_('select.option', 'unsubscribe', JText::_('COM_KUNENA_UNSUBSCRIBE_SELECTED'));
 
-		if ($actionDropdown == 1)
+		if (count($actionDropdown) == 1)
 		{
 			return;
 		}

--- a/src/components/com_kunena/models/topics.php
+++ b/src/components/com_kunena/models/topics.php
@@ -627,7 +627,7 @@ class KunenaModelTopics extends KunenaModel
 			$actionDropdown[] = HTMLHelper::_('select.option', 'restore', JText::_('COM_KUNENA_BUTTON_UNDELETE_LONG'));
 		}
 
-		if ($actionDropdown == 1)
+		if (count($actionDropdown) == 1)
 		{
 			return;
 		}
@@ -695,7 +695,7 @@ class KunenaModelTopics extends KunenaModel
 			$actionDropdown[] = HTMLHelper::_('select.option', 'restore_posts', JText::_('COM_KUNENA_BUTTON_UNDELETE_LONG'));
 		}
 
-		if ($actionDropdown == 1)
+		if (count($actionDropdown) == 1)
 		{
 			return;
 		}


### PR DESCRIPTION
**Describe the bug**
Empty dropdown appears for unprivileged users.

**To Reproduce**
Steps to reproduce the behavior:
1. Use regular/unprivileged account
2. Go to list of topics
3. "Select Action" dropdown is empty and has no use

**Expected behavior**
The dropdown should be hidden.

**Actual result**
It has only "- Chose action -" option

**Screenshots**
![chooseaction](https://user-images.githubusercontent.com/2228236/42629507-cf61cb42-85d3-11e8-8791-5b087d499ee4.png)

**System information (please complete the following information)**

Joomla version: 3.8
Kunena version: 5.1.1
Php version: 7
