### PR TITLE
Update FA to 5.1.1

### DIFF
--- a/src/administrator/components/com_kunena/views/user/view.html.php
+++ b/src/administrator/components/com_kunena/views/user/view.html.php
@@ -39,7 +39,7 @@ class KunenaAdminViewUser extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.1.0/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.1.1/js/all.js', array(), array('defer' => true));
 		}
 
 		// Make the select list for the moderator flag

--- a/src/administrator/components/com_kunena/views/users/view.html.php
+++ b/src/administrator/components/com_kunena/views/users/view.html.php
@@ -50,7 +50,7 @@ class KunenaAdminViewUsers extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.1.0/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.1.1/js/all.js', array(), array('defer' => true));
 		}
 
 		$this->display();

--- a/src/components/com_kunena/template/crypsis/template.php
+++ b/src/components/com_kunena/template/crypsis/template.php
@@ -107,8 +107,8 @@ class KunenaTemplateCrypsis extends KunenaTemplate
 
 		if ($fontawesome)
 		{
-			$doc->addScript('https://use.fontawesome.com/releases/v5.1.0/js/all.js', array(), array('defer' => true));
-			$doc->addScript('https://use.fontawesome.com/releases/v5.1.0/js/v4-shims.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.1.1/js/all.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.1.1/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		// Load template colors settings

--- a/src/components/com_kunena/template/crypsisb3/template.php
+++ b/src/components/com_kunena/template/crypsisb3/template.php
@@ -145,8 +145,8 @@ class KunenaTemplateCrypsisb3 extends KunenaTemplate
 		if ($fontawesome)
 		{
 			/** @noinspection PhpDeprecationInspection */
-			$doc->addScript('https://use.fontawesome.com/releases/v5.1.0/js/all.js', array(), array('defer' => true));
-			$doc->addScript('https://use.fontawesome.com/releases/v5.1.0/js/v4-shims.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.1.1/js/all.js', array(), array('defer' => true));
+			$doc->addScript('https://use.fontawesome.com/releases/v5.1.1/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		$icons = $this->ktemplate->params->get('icons');


### PR DESCRIPTION
#### Summary of Changes 

**Added**
Additional search terms for various icons FortAwesome/Font-Awesome 13429

**Changed**
Marked the font-awesome-logo-full as a "private" icon
Consistently named and minified CSS and JS files in the CDN, npm packages, and zip files

**Fixed**
Removed "fa-" prefix from Less and Sass style bundles filenames
Unable to use brand icons with pseudo-elements and SVG with JS
Adding icons explicitly using the library were not available when using pseudo-elements and SVG with JS
smile-plus search terms in icons.yml incorrectly formatted
kiss and grin-wink icons having incorrect weight / style FortAwesome/Font-Awesome 13361 FortAwesome/Font-Awesome 13363
Missing underscore in filenames in the less/v4-shims.less FortAwesome/Font-Awesome 13415
Light style for code-commit
Including rev brand icon in the Font Awesome Free version

