### PR TITLE
Ignore internal links in checkMaxLinks() #6039

### DIFF
--- a/src/components/com_kunena/controllers/topic.php
+++ b/src/components/com_kunena/controllers/topic.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die();
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Kunena Topic Controller
@@ -1121,6 +1122,19 @@ class KunenaControllerTopic extends KunenaController
 			}
 
 			$countlink = count($matches[0]);
+
+			// Ignore internal links
+			foreach ($matches[1] as $link)
+			{
+				$uri = Uri::getInstance($link);
+				$host = $uri->getHost();
+
+				// The cms will catch most of these well
+				if (empty($host) || Uri::isInternal($link))
+				{
+					$countlink--;
+				}
+			}
 
 			if (!$topic->isAuthorised('approve') && $countlink >= $this->config->max_links + 1)
 			{


### PR DESCRIPTION
Pull Request for Issue #6039
Slightly different approach than originally proposed.
 
#### Summary of Changes

Removes internal links from checkMaxLinks() checks which will covers attachments, auto-linked internal images and all other goods added by 3rd party plugins.
 
#### Testing Instructions

* As described in ticket #6039
* Additionally non-image attachements should not trigger the error
* Any other internal links should not trigger the error. Examples of internal links
** /home
** /index.php/home
** http://[LIVE_SITE]/home
