### PR TITLE
RSS: Add value "None" to Characters Per Item

### DIFF
--- a/src/administrator/components/com_kunena/models/config.php
+++ b/src/administrator/components/com_kunena/models/config.php
@@ -91,6 +91,7 @@ class KunenaAdminModelConfig extends KunenaModel
 
 			$rss_word_count    = array();
 			$rss_word_count [] = HTMLHelper::_('select.option', '0', Text::_('COM_KUNENA_A_RSS_WORD_COUNT_ALL'));
+			$rss_word_count [] = HTMLHelper::_('select.option', '-1', JText::_('JNONE'));
 			$rss_word_count [] = HTMLHelper::_('select.option', '50', '50');
 			$rss_word_count [] = HTMLHelper::_('select.option', '100', '100');
 			$rss_word_count [] = HTMLHelper::_('select.option', '250', '250');

--- a/src/components/com_kunena/views/category/view.feed.php
+++ b/src/components/com_kunena/views/category/view.feed.php
@@ -92,18 +92,25 @@ class KunenaViewCategory extends KunenaView
 			$title .= ' - ' . Text::_('COM_KUNENA_BY') . ': ' . $username;
 		}
 
-		$description = preg_replace('/\[confidential\](.*?)\[\/confidential\]/s', '', $description);
-		$description = preg_replace('/\[hide\](.*?)\[\/hide\]/s', '', $description);
-		$description = preg_replace('/\[spoiler\](.*?)\[\/spoiler\]/s', '', $description);
-		$description = preg_replace('/\[code\](.*?)\[\/code]/s', '', $description);
-
-		if ((bool) $this->config->rss_allow_html)
+		if ((int) $this->config->rss_word_count === -1)
 		{
-			$description = KunenaHtmlParser::parseBBCode($description, null, (int) $this->config->rss_word_count);
+			$description = '';
 		}
 		else
 		{
-			$description = KunenaHtmlParser::parseText($description, (int) $this->config->rss_word_count);
+			$description = preg_replace('/\[confidential\](.*?)\[\/confidential\]/s', '', $description);
+			$description = preg_replace('/\[hide\](.*?)\[\/hide\]/s', '', $description);
+			$description = preg_replace('/\[spoiler\](.*?)\[\/spoiler\]/s', '', $description);
+			$description = preg_replace('/\[code\](.*?)\[\/code]/s', '', $description);
+
+			if ((bool) $this->config->rss_allow_html)
+			{
+				$description = KunenaHtmlParser::parseBBCode($description, null, (int) $this->config->rss_word_count);
+			}
+			else
+			{
+				$description = KunenaHtmlParser::parseText($description, (int) $this->config->rss_word_count);
+			}
 		}
 
 		// Assign values to feed item

--- a/src/components/com_kunena/views/topics/view.feed.php
+++ b/src/components/com_kunena/views/topics/view.feed.php
@@ -287,18 +287,25 @@ class KunenaViewTopics extends KunenaView
 			$title .= ' - ' . Text::_('COM_KUNENA_BY') . ': ' . $username;
 		}
 
-		$description = preg_replace('/\[confidential\](.*?)\[\/confidential\]/s', '', $description);
-		$description = preg_replace('/\[hide\](.*?)\[\/hide\]/s', '', $description);
-		$description = preg_replace('/\[spoiler\](.*?)\[\/spoiler\]/s', '', $description);
-		$description = preg_replace('/\[code\](.*?)\[\/code]/s', '', $description);
-
-		if ((bool) $this->config->rss_allow_html)
+		if ((int) $this->config->rss_word_count === -1)
 		{
-			$description = KunenaHtmlParser::parseBBCode($description, null, (int) $this->config->rss_word_count);
+			$description = '';
 		}
 		else
 		{
-			$description = KunenaHtmlParser::parseText($description, (int) $this->config->rss_word_count);
+			$description = preg_replace('/\[confidential\](.*?)\[\/confidential\]/s', '', $description);
+			$description = preg_replace('/\[hide\](.*?)\[\/hide\]/s', '', $description);
+			$description = preg_replace('/\[spoiler\](.*?)\[\/spoiler\]/s', '', $description);
+			$description = preg_replace('/\[code\](.*?)\[\/code]/s', '', $description);
+
+			if ((bool) $this->config->rss_allow_html)
+			{
+				$description = KunenaHtmlParser::parseBBCode($description, null, (int) $this->config->rss_word_count);
+			}
+			else
+			{
+				$description = KunenaHtmlParser::parseText($description, (int) $this->config->rss_word_count);
+			}
 		}
 
 		// Assign values to feed item


### PR DESCRIPTION
Pull Request for Issue #6002

#### Summary of Changes 
* Added "None" option to "Characters Per Item" rss config
* Handling of the option in two view.feed.php
 
#### Testing Instructions
* Set "RSS > Characters Per Item" to "None"
** RSS feeds should have no description, just titles
* Set back to eg. 50
** RSS feeds should have description, up to 50 characters
