### PR TITLE
Fix sort by title not working as expected

### DIFF
--- a/src/libraries/kunena/forum/category/helper.php
+++ b/src/libraries/kunena/forum/category/helper.php
@@ -727,6 +727,7 @@ abstract class KunenaForumCategoryHelper
 						}
 						break;
 					case 'name' :
+					case 'p.title' :
 						if ($params['direction'] > 0)
 						{
 							uksort($cats, array(__CLASS__, 'compareByNameAsc'));


### PR DESCRIPTION
Pull Request for Issue #5275

Not sure if this is source of the issue but the alternative is to update templates.

eg. /administrator/components/com_kunena/template/j3/categories/default.php

from 
```php
<?php echo HTMLHelper::_('grid.sort', 'JGLOBAL_TITLE', 'p.title', $this->listDirection, $this->listOrdering); ?>
```
to
```php
<?php echo HTMLHelper::_('grid.sort', 'JGLOBAL_TITLE', 'name', $this->listDirection, $this->listOrdering); ?>
```
Whichever works better for you.