### PR TITLE
fix for generated kunena-custom.css pointing to wrong location

### DIFF
--- a/src/components/com_kunena/template/crypsis/template.php
+++ b/src/components/com_kunena/template/crypsis/template.php
@@ -77,7 +77,7 @@ class KunenaTemplateCrypsis extends KunenaTemplate
 		if (file_exists($filenameless) && 0 != filesize($filenameless))
 		{
 			$this->compileLess('assets/less/custom.less', 'kunena-custom.css');
-			$this->addStyleSheet('kunena-custom.css');
+			$this->addLessSheet('kunena-custom.css');
 		}
 
 		$filename = JPATH_SITE . '/components/com_kunena/template/crypsis/assets/css/custom.css';


### PR DESCRIPTION
custom.less issue, after update to 5.1.3 non-existing file (kunena-custom.css location) is loaded...

Pull Request for Issue # . 
 
#### Summary of Changes 
 
#### Testing Instructions