### PR TITLE
Update FA to 5.4.0

### DIFF
--- a/src/administrator/components/com_kunena/views/user/view.html.php
+++ b/src/administrator/components/com_kunena/views/user/view.html.php
@@ -41,7 +41,7 @@ class KunenaAdminViewUser extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.3.1/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.4.0/js/all.js', array(), array('defer' => true));
 		}
 
 		// Make the select list for the moderator flag

--- a/src/administrator/components/com_kunena/views/users/view.html.php
+++ b/src/administrator/components/com_kunena/views/users/view.html.php
@@ -51,7 +51,7 @@ class KunenaAdminViewUsers extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.3.1/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.4.0/js/all.js', array(), array('defer' => true));
 		}
 
 		$this->display();

--- a/src/components/com_kunena/template/crypsis/template.php
+++ b/src/components/com_kunena/template/crypsis/template.php
@@ -98,8 +98,8 @@ class KunenaTemplateCrypsis extends KunenaTemplate
 
 		if ($fontawesome)
 		{
-			$this->addScript('https://use.fontawesome.com/releases/v5.3.1/js/all.js', array(), array('defer' => true));
-			$this->addScript('https://use.fontawesome.com/releases/v5.3.1/js/v4-shims.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.4.0/js/all.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.4.0/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		// Load template colors settings

--- a/src/components/com_kunena/template/crypsisb3/template.php
+++ b/src/components/com_kunena/template/crypsisb3/template.php
@@ -136,8 +136,8 @@ class KunenaTemplateCrypsisb3 extends KunenaTemplate
 
 		if ($fontawesome)
 		{
-			$this->addScript('https://use.fontawesome.com/releases/v5.3.1/js/all.js', array(), array('defer' => true));
-			$this->addScript('https://use.fontawesome.com/releases/v5.3.1/js/v4-shims.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.4.0/js/all.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.4.0/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		$icons = $this->ktemplate->params->get('icons');


### PR DESCRIPTION
#### Summary of Changes 
 
**Added**
New Tabletop Gaming, Holiday, Seasonal category
7 tabletop gaming brands (acquisitions-incorporated, critical-role, d-and-d, d-and-d-beyond, fantasy-flight-games, penny-arcade, wizards-of-the-coast)
25 new animals (and all of them are real you Disbelievers)
Sponsorship of volume-mute by Pulse-Eight
creative-commons-zero added to Free version
DEV brand icon
Search terms "positive" and "negative" added to applicable icons
Sponsorship of chess-knight by Inspira bvba
Sponsorship of blender-phone by Joe Emison
Icons chair, chair-office, file-csv, hammer, head-side, head-vr, house-damage, hryvnia, network-wired, running, slash, user-injured, and vr-cardboard

**Changed**
Using masks with SVG and JavaScript now use nanoid generated IDs instead of a simple counter
Updated speakap brand icon
Revised menorah icon and added hanukiah

**Fixed**
Slight distortion in book-heart
Bad search terms for folder icon
Set license for @fortawesome/free-brands-svg-icons NPM package
