### PR TITLE
Decouple Mobile menu from Login

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/widget/login/login/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/widget/login/login/default.php
@@ -18,11 +18,6 @@ $config = KunenaFactory::getTemplate()->params;
 	<?php endif; ?>
 </div>
 <div class="hidden-desktop">
-	<div class="nav navbar-nav pull-left">
-		<div><a class="btn btn-link" data-toggle="collapse"
-		        data-target=".knav-collapse"><?php echo KunenaIcons::hamburger(); ?></a></div>
-		<div class="knav-collapse"><?php echo $this->subRequest('Widget/Menu'); ?></div>
-	</div>
 	<?php if ($config->get('displayDropdownMenu')) : ?>
 		<?php echo $this->setLayout('mobile'); ?>
 	<?php endif; ?>

--- a/src/components/com_kunena/template/crypsis/layouts/widget/login/logout/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/widget/login/logout/default.php
@@ -21,11 +21,6 @@ $status         = $config->user_status;
 $config         = KunenaFactory::getTemplate()->params;
 ?>
 <div class="klogout">
-	<div class="nav navbar-nav pull-left hidden-desktop">
-		<div><a class="btn btn-link" data-toggle="collapse"
-		        data-target=".knav-collapse"><?php echo KunenaIcons::hamburger(); ?></a></div>
-		<div class="knav-collapse"><?php echo $this->subRequest('Widget/Menu'); ?></div>
-	</div>
 	<?php if ($config->get('displayDropdownMenu')) : ?>
 		<ul class="nav pull-right">
 			<li class="dropdown mobile-user">

--- a/src/components/com_kunena/template/crypsis/layouts/widget/menubar/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/widget/menubar/default.php
@@ -16,7 +16,14 @@ defined('_JEXEC') or die;
 		<div class="visible-desktop">
 			<?php echo $this->subRequest('Widget/Menu'); ?>
 		</div>
+		<div class="hidden-desktop">
+			<div class="nav navbar-nav pull-left">
+				<div>
+					<a class="btn btn-link" data-toggle="collapse" data-target=".knav-collapse"><?php echo KunenaIcons::hamburger(); ?></a>
+				</div>
+				<div class="knav-collapse"><?php echo $this->subRequest('Widget/Menu'); ?></div>
+			</div>
+		</div>
 		<?php echo $this->subRequest('Widget/Login'); ?>
 	</div>
 </div>
-

--- a/src/components/com_kunena/template/crypsisb3/layouts/widget/login/login/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/widget/login/login/default.php
@@ -19,11 +19,6 @@ defined('_JEXEC') or die;
 	<?php endif; ?>
 </div>
 <div class="visible-xs-block">
-	<div class="nav navbar-nav pull-left">
-		<div><a class="btn btn-link" data-toggle="collapse"
-		        data-target=".knav-collapse"><?php echo KunenaIcons::hamburger(); ?></a></div>
-		<div class="knav-collapse"><?php echo $this->subRequest('Widget/Menu'); ?></div>
-	</div>
 	<?php if (KunenaFactory::getTemplate()->params->get('displayDropdownMenu'))
 		:
 		?>

--- a/src/components/com_kunena/template/crypsisb3/layouts/widget/login/logout/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/widget/login/logout/default.php
@@ -22,12 +22,6 @@ $config         = KunenaFactory::getTemplate()->params;
 ?>
 
 <div class="klogout">
-	<div class="nav navbar-nav pull-left visible-xs-block">
-		<div><a class="btn btn-link" data-toggle="collapse"
-		        data-target=".knav-collapse"><?php echo KunenaIcons::hamburger(); ?></a></div>
-		<div class="knav-collapse"><?php echo $this->subRequest('Widget/Menu'); ?></div>
-	</div>
-
 	<?php if ($config->get('displayDropdownMenu')) : ?>
 		<ul class="nav pull-right">
 			<li class="dropdown mobile-user">

--- a/src/components/com_kunena/template/crypsisb3/layouts/widget/menubar/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/widget/menubar/default.php
@@ -16,6 +16,14 @@ defined('_JEXEC') or die;
 		<div class="visible-lg">
 			<?php echo $this->subRequest('Widget/Menu'); ?>
 		</div>
+		<div class="hidden-desktop">
+			<div class="nav navbar-nav pull-left">
+				<div>
+					<a class="btn btn-link" data-toggle="collapse" data-target=".knav-collapse"><?php echo KunenaIcons::hamburger(); ?></a>
+				</div>
+				<div class="knav-collapse"><?php echo $this->subRequest('Widget/Menu'); ?></div>
+			</div>
+		</div>
 		<?php echo $this->subRequest('Widget/Login'); ?>
 	</div>
 </nav>


### PR DESCRIPTION
Pull Request for Issue # . https://github.com/Kunena/Kunena-Forum/issues/6131
 
#### Summary of Changes 
decoupled mobile menu from login / logout widget
 
#### Testing Instructions

1. in plugin kunena - joomla integration, switch off joomla login
2. on kunena forum in mobile view navbar is empty

Apply patch
on kunena forum in mobile view, the manu hamburger is shown

also test with when logged in
