### PR TITLE
InfiniteScroll: add missing tbody and tbody classes K6.0

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/category/item/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/category/item/default.php
@@ -87,6 +87,7 @@ $this->addStyleSheet('assets/css/rating.css');
 				<?php endif; ?>
 			</tr>
 			</thead>
+			<tbody class="category-item">
 			<?php
 			/** @var KunenaForumTopic $previous */
 			$previous = null;
@@ -102,6 +103,7 @@ $this->addStyleSheet('assets/css/rating.css');
 				$previous = $topic;
 			}
 			?>
+			</tbody>
 			<tfoot>
 			<?php if ($this->topics) : ?>
 				<tr>

--- a/src/components/com_kunena/template/crypsis/layouts/message/list/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/message/list/default.php
@@ -150,7 +150,7 @@ $view    = Factory::getApplication()->input->getWord('view');
 		<?php endif; ?>
 		</tfoot>
 
-		<tbody>
+		<tbody class="message-list">
 		<?php
 		foreach ($this->messages as $i => $message)
 		{

--- a/src/components/com_kunena/template/crypsis/layouts/topic/list/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/list/default.php
@@ -143,7 +143,7 @@ if ($this->config->enableforumjump && !$this->embedded && $this->topics)
 			</td>
 		</tr>
 		</tfoot>
-		<tbody>
+		<tbody class="topic-list">
 		<?php if (empty($this->topics) && empty($this->subcategories)) : ?>
 			<tr>
 				<td colspan="4" class="center"><?php echo Text::_('COM_KUNENA_VIEW_NO_TOPICS') ?></td>

--- a/src/components/com_kunena/template/crypsis/layouts/user/list/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/user/list/default.php
@@ -135,7 +135,7 @@ $this->addScript('assets/js/search.js');
 			<?php endif; ?>
 		</tr>
 		</thead>
-		<tbody>
+		<tbody class="user-list">
 		<?php
 		$i = $this->pagination->limitstart;
 

--- a/src/components/com_kunena/template/crypsisb3/layouts/category/item/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/category/item/default.php
@@ -88,6 +88,7 @@ $this->addStyleSheet('assets/css/rating.css');
 				<?php endif; ?>
 			</tr>
 			</thead>
+			<tbody class="category-item">
 			<?php
 			/** @var KunenaForumTopic $previous */
 			$previous = null;
@@ -103,6 +104,7 @@ $this->addStyleSheet('assets/css/rating.css');
 				$previous = $topic;
 			}
 			?>
+			</tbody>
 			<tfoot>
 			<?php if ($this->topics) : ?>
 				<tr>

--- a/src/components/com_kunena/template/crypsisb3/layouts/message/list/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/message/list/default.php
@@ -153,7 +153,7 @@ $view    = Factory::getApplication()->input->getWord('view');
 		<?php endif; ?>
 		</tfoot>
 
-		<tbody>
+		<tbody class="message-list">
 		<?php
 		foreach ($this->messages as $i => $message)
 		{

--- a/src/components/com_kunena/template/crypsisb3/layouts/topic/list/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/topic/list/default.php
@@ -151,7 +151,7 @@ if ($this->config->enableforumjump && !$this->embedded && $this->topics)
 			</td>
 		</tr>
 		</tfoot>
-		<tbody>
+		<tbody class="topic-list">
 		<?php if (empty($this->topics) && empty($this->subcategories)) : ?>
 			<tr>
 				<td colspan="4" class="center"><?php echo Text::_('COM_KUNENA_VIEW_NO_TOPICS') ?></td>

--- a/src/components/com_kunena/template/crypsisb3/layouts/user/list/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/user/list/default.php
@@ -137,7 +137,7 @@ $this->addScript('assets/js/search.js');
 			<?php endif; ?>
 		</tr>
 		</thead>
-		<tbody>
+		<tbody class="user-list">
 		<?php
 		$i               = $this->pagination->limitstart;
 		$this->ktemplate = KunenaFactory::getTemplate();

--- a/src/components/com_kunena/template/crypsisb4/layouts/category/item/default.php
+++ b/src/components/com_kunena/template/crypsisb4/layouts/category/item/default.php
@@ -88,6 +88,7 @@ $this->addStyleSheet('assets/css/rating.css');
 				<?php endif; ?>
 			</tr>
 			</thead>
+			<tbody class="category-item">
 			<?php
 			/** @var KunenaForumTopic $previous */
 			$previous = null;
@@ -103,6 +104,7 @@ $this->addStyleSheet('assets/css/rating.css');
 				$previous = $topic;
 			}
 			?>
+			</tbody>
 			<tfoot>
 			<?php if ($this->topics) : ?>
 				<tr>

--- a/src/components/com_kunena/template/crypsisb4/layouts/message/list/default.php
+++ b/src/components/com_kunena/template/crypsisb4/layouts/message/list/default.php
@@ -149,7 +149,7 @@ $view    = Factory::getApplication()->input->getWord('view');
 		<?php endif; ?>
 		</tfoot>
 
-		<tbody>
+		<tbody class="message-list">
 		<?php
 		foreach ($this->messages as $i => $message)
 		{

--- a/src/components/com_kunena/template/crypsisb4/layouts/topic/list/default.php
+++ b/src/components/com_kunena/template/crypsisb4/layouts/topic/list/default.php
@@ -150,7 +150,7 @@ if ($this->config->enableforumjump && !$this->embedded && $this->topics)
 			</td>
 		</tr>
 		</tfoot>
-		<tbody>
+		<tbody class="topic-list">
 		<?php if (empty($this->topics) && empty($this->subcategories)) : ?>
 			<tr>
 				<td colspan="4" class="center"><?php echo Text::_('COM_KUNENA_VIEW_NO_TOPICS') ?></td>

--- a/src/components/com_kunena/template/crypsisb4/layouts/user/list/default.php
+++ b/src/components/com_kunena/template/crypsisb4/layouts/user/list/default.php
@@ -137,7 +137,7 @@ $this->addScript('assets/js/search.js');
 			<?php endif; ?>
 		</tr>
 		</thead>
-		<tbody>
+		<tbody class="user-list">
 		<?php
 		$i               = $this->pagination->limitstart;
 		$this->ktemplate = KunenaFactory::getTemplate();


### PR DESCRIPTION
Hi, working on Infinite Scroll functionality for Kunena. Infinite Scroll will replace the 'pagination' and when there are multiple pages, they will automatically load and append to the page.

For this to work, the infinite-scroll script needs to be able to identify the container where the rows reside and where the loaded rows will be appended.

Identifying the 'container' works via a class name.
#### Summary of Changes

add missing to ./category/item/default.php
add class names on tags for list views that use pagination
#### Testing Instructions

Here you can see it working (note: work in progress) :)
https://office.onlinecommunityhub.nl/och_test/forum/jssocials