### PR TITLE
set forum messages in own div container

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/topic/item/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/item/default.php
@@ -122,6 +122,8 @@ if ($topic->locked)
 		echo $this->subLayout('Widget/Module')->set('position', 'kunena_poll');
 	}
 
+	echo '<div class="topic-item-messages">';
+
 	$count = 1;
 	foreach ($this->messages as $id => $message)
 	{
@@ -135,6 +137,8 @@ if ($topic->locked)
 				->set('position', 'kunena_msg_row_' . $count++);
 		}
 	}
+
+	echo '</div>';
 
 	if ($quick == 2 && KunenaConfig::getInstance()->quickreply)
 	{

--- a/src/components/com_kunena/template/crypsisb3/layouts/topic/item/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/topic/item/default.php
@@ -119,6 +119,8 @@ if ($topic->locked)
 		echo $this->subLayout('Widget/Module')->set('position', 'kunena_poll');
 	}
 
+	echo '<div class="topic-item-messages">';
+
 	$count = 1;
 	foreach ($this->messages as $id => $message)
 	{
@@ -132,6 +134,8 @@ if ($topic->locked)
 				->set('position', 'kunena_msg_row_' . $count++);
 		}
 	}
+
+	echo '</div>';
 
 	if ($quick == 2 && KunenaConfig::getInstance()->quickreply)
 	{


### PR DESCRIPTION
In order for Infinite scrolling to work correct on items view, all items should be listed in its own div container oppesed to as it is now (in container with all other elements, like search, etc.)