### PR TITLE
Update FA to 5.7.2

### DIFF
--- a/src/administrator/components/com_kunena/views/user/view.html.php
+++ b/src/administrator/components/com_kunena/views/user/view.html.php
@@ -41,7 +41,7 @@ class KunenaAdminViewUser extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.6.3/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.7.2/js/all.js', array(), array('defer' => true));
 		}
 
 		// Make the select list for the moderator flag

--- a/src/administrator/components/com_kunena/views/users/view.html.php
+++ b/src/administrator/components/com_kunena/views/users/view.html.php
@@ -51,7 +51,7 @@ class KunenaAdminViewUsers extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.6.3/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.7.2/js/all.js', array(), array('defer' => true));
 		}
 
 		$this->display();

--- a/src/components/com_kunena/template/crypsis/template.php
+++ b/src/components/com_kunena/template/crypsis/template.php
@@ -98,8 +98,8 @@ class KunenaTemplateCrypsis extends KunenaTemplate
 
 		if ($fontawesome)
 		{
-			$this->addScript('https://use.fontawesome.com/releases/v5.6.3/js/all.js', array(), array('defer' => true));
-			$this->addScript('https://use.fontawesome.com/releases/v5.6.3/js/v4-shims.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.7.2/js/all.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.7.2/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		// Load template colors settings

--- a/src/components/com_kunena/template/crypsisb3/template.php
+++ b/src/components/com_kunena/template/crypsisb3/template.php
@@ -136,8 +136,8 @@ class KunenaTemplateCrypsisb3 extends KunenaTemplate
 
 		if ($fontawesome)
 		{
-			$this->addScript('https://use.fontawesome.com/releases/v5.6.3/js/all.js', array(), array('defer' => true));
-			$this->addScript('https://use.fontawesome.com/releases/v5.6.3/js/v4-shims.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.7.2/js/all.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.7.2/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		$icons = $this->ktemplate->params->get('icons');


### PR DESCRIPTION
#### Summary of Changes 
 

//5.7.2 
**Fixed**
Vertical alignment issues using OTF and TTF files in desktop applications that differ from previous
Font Awesome versions (< 5.7.0)


//5.7.1
**Fixed**
The @fortawesome/fontawesome-pro package had a corrupted SVG webfont file for the solid style
IE11 error reporting Promise as undefined or finally() not a function
The cheese has been moved under the patty for cheeseburger


//5.7.0
**Added**
New Food category
More Medical icons
More icons from the leaderboard
Added tasks-alt
New CSS class fa-flip-both that applies fa-flip-horizontal and fa-flip-vertical together
CSS now defaults to font-display: auto
Sass and Less files contain a variable that can be changed to alter the font-display value

**Changed**
Updated slack brand icon
Reverted calendar-alt to previous design before 5.6.0

**Fixed**
Safari fails to process pseudo elements if the font-weight is "normal"
Renamed internal method to keep from confusing rJS 
Corrected font weights in TTF files 
XCode now correctly displays different styles when using TTF files
Support for Turbolinks without modifying the dom.watch() call 
Add focusable=false for SVG elements to prevent IE11 double-focus bug 