### PR TITLE
Fix invalid HTML in Twitter widget

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/bbcode/twitter/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/bbcode/twitter/default.php
@@ -109,5 +109,6 @@ use Joomla\CMS\Factory;
 					</li>
 				</ul>
 			</div>
+		</div>
 	</blockquote>
 </div>

--- a/src/components/com_kunena/template/crypsisb3/layouts/bbcode/twitter/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/bbcode/twitter/default.php
@@ -109,5 +109,6 @@ use Joomla\CMS\Factory;
 					</li>
 				</ul>
 			</div>
+		</div>
 	</blockquote>
 </div>


### PR DESCRIPTION
Pull Request for Issue # N/A

When using Kunena discuss on my websites, I noticed that when there was a discussion, the layout of the template was 'corrupted' (sidebar showing up below kunena discuss content instead of as sidebar).
I found that I could reproduce this issue when there was an embedden tweet in the displayed dicussion.

As it turned out, the widget that renders the tweet misses a closing div, rendering the HTML invalid. I have a plugin that do a complete DOM saveHTML on the page before it is displayed. This 'fixes' broken HTML, but in this case the fix was not good as it corrupted the page.

Fixing the twitter widget layout solved the issue :)
 
#### Summary of Changes 
 Fixing layout of both crypsis and crypsysb3 bbcode twitter widget layout

#### Testing Instructions
create adiscussion with a link to a tweet in it. The discussion should render as before (but now passing HTML validation)