### PR TITLE
Issue in query on J! 4.0 : Field 'params' doesn't have a default value

### DIFF
--- a/src/libraries/kunena/session.php
+++ b/src/libraries/kunena/session.php
@@ -245,6 +245,7 @@ class KunenaSession extends CMSObject
 
 		if ($userCategory->allreadtime != $this->allreadtime)
 		{
+			$userCategory->params = '';
 			$userCategory->allreadtime = $this->allreadtime;
 			$userCategory->save();
 		}


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
 
#### Testing Instructions

When you are on J!4.0 frontend and goes on Kunena and you try to login at this moment you have the error

>  Field 'params' doesn't have a default