### PR TITLE
Fix for lock / sticky / delete changing original Topic Label text

### DIFF
--- a/src/libraries/kunena/template/template.php
+++ b/src/libraries/kunena/template/template.php
@@ -1829,16 +1829,6 @@ HTML;
 			if ($topiclabels == 1)
 			{
 				$id = $topic->icon_id;
-
-				if ($topic->locked)
-				{
-					$id = 12;
-				}
-
-				if ($topic->hold == 2 || $topic->hold == 3)
-				{
-					$id = 10;
-				}
 			}
 			else
 			{


### PR DESCRIPTION
Pull Request for Issue # https://github.com/Kunena/Kunena-Forum/issues/6194
 
#### Summary of Changes 
 remove code that changes Topic labels to 'Question'
#### Testing Instructions
set topic label on topic to something else then Question.
-> check if topic label text is displayed correct on topic
lock topic
-> check if topic is locked (padlock icon) AND that topic label is NOT changed to 'Question'
do the same for delete topic and sticky

Topic label should remain the topic label that was set for the topic