### PR TITLE
Avoid duplicate meta description on replies

### DIFF
--- a/src/components/com_kunena/controller/topic/item/display.php
+++ b/src/components/com_kunena/controller/topic/item/display.php
@@ -604,7 +604,7 @@ class ComponentKunenaControllerTopicItemDisplay extends KunenaControllerDisplay
 					$small = $headerText;
 				}
 
-				$this->setDescription(Text::_('COM_KUNENA_PAGES') . " {$page}" . ": " . $small);
+				$this->setDescription($small . " - " . Text::_('COM_KUNENA_PAGES') . " {$page}");
 			}
 			else
 			{

--- a/src/components/com_kunena/controller/topic/item/display.php
+++ b/src/components/com_kunena/controller/topic/item/display.php
@@ -604,7 +604,7 @@ class ComponentKunenaControllerTopicItemDisplay extends KunenaControllerDisplay
 					$small = $headerText;
 				}
 
-				$this->setDescription($small . " - " . Text::_('COM_KUNENA_PAGES') . " {$page}");
+				$this->setDescription(Text::_('COM_KUNENA_PAGES') . " {$page}" . ": " . $small);
 			}
 			else
 			{

--- a/src/components/com_kunena/controller/topic/item/display.php
+++ b/src/components/com_kunena/controller/topic/item/display.php
@@ -597,7 +597,7 @@ class ComponentKunenaControllerTopicItemDisplay extends KunenaControllerDisplay
 
 			if ($total > 1 && $page > 1)
 			{
-				$small = KunenaHtmlParser::stripBBCode($this->topic->first_post_message, 140);
+				$small = KunenaHtmlParser::stripBBCode($this->topic->first_post_message, 130);
 
 				if (empty($small))
 				{


### PR DESCRIPTION
#### Summary of Changes 
This small change will prevent duplicate meta description only on replies pages.
This is in cases where google and other search engines shorten description before reach 140 characters.
 
