### PR TITLE
fix for error handling saveUser function

### DIFF
--- a/src/components/com_kunena/controllers/user.php
+++ b/src/components/com_kunena/controllers/user.php
@@ -948,13 +948,9 @@ class KunenaControllerUser extends KunenaController
 		$user     = new Joomla\CMS\User\User($this->user->id);
 
 		// Bind the form fields to the user table and save.
-		try
+		if (!$user->bind($post) || !$user->save(true))
 		{
-			$user->bind($post) && $user->save(true);
-		}
-		catch (\Exception $e)
-		{
-			$this->app->enqueueMessage($e->getMessage(), 'notice');
+			Factory::getApplication()->enqueueMessage($user->getError(), 'error');
 
 			return false;
 		}


### PR DESCRIPTION
Pull Request for Issue # new 
 
#### Summary of Changes 
the current implementation of saving the (joomla) user is not handling any errors correct.
It tries a try / catch to catch all errors generated by the User object bind and save or by user plugins (onUserbeforeSave) but the Joomla User object catches any errors itself and sets these in the User object. It then returns with a false. Therefore the catch will never be executed.

this PR corrects the error handling by testing for a false (both bind and save) and if one of these returned false, it enqueues the error message that is set in the Joomla User object.

When the user saving now fails due to Joomla or a plugin, the correct error message is displayed instead of the profile saved message.
 
#### Testing Instructions
In a (existing) system plugin, create the folowing function:
```
	public function onUserBeforeSave($user, $isNew, $data)
	{
		throw new InvalidArgumentException('Oepsie...');
		return false;
	}
```
Now when saving your user profile in the front-end you should see the correct error 'Oepsie...' preventing the saving of the profile.