### PR TITLE
Add UTM Tracking to Email Notifications

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/email/report/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/email/report/default.php
@@ -176,7 +176,7 @@ if (!$config->plain_email) :
 										    style="padding: 12px 24px; margin: 0; text-decoration: underline; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
 										    bgcolor="#0072C6"><a target="_blank" style="text-decoration: underline;
 					color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;"
-										                         href="<?php echo $this->messageLink; ?>">
+										                         href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Report'; ?>">
 												<?php echo Text::_('COM_KUNENA_REPORT_POST_LINK'); ?>
 											</a>
 										</td>

--- a/src/components/com_kunena/template/crypsis/layouts/email/subscription/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/email/subscription/default.php
@@ -168,7 +168,7 @@ if (!$config->plain_email) :
 								<p><?php echo Text::_('COM_KUNENA_VIEW_POSTED') . " : " . $author->getName('???', false); ?></p>
 
 								<p>URL :
-									<a href="<?php echo $this->messageLink; ?>"><b><?php echo $this->messageLink; ?></b></a>
+									<a href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>"><b><?php echo $this->messageLink; ?></b></a>
 								</p>
 							</div>
 
@@ -198,7 +198,7 @@ if (!$config->plain_email) :
 										    bgcolor="#0072C6">
 											<a target="_blank" style="text-decoration: underline;
 					color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;"
-											   href="<?php echo $this->messageLink; ?>">
+											   href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>">
 												<?php echo Text::_('COM_KUNENA_READMORE'); ?>
 											</a>
 										</td>

--- a/src/components/com_kunena/template/crypsis/layouts/email/subscription/moderator.php
+++ b/src/components/com_kunena/template/crypsis/layouts/email/subscription/moderator.php
@@ -173,7 +173,7 @@ if (!$config->plain_email) :
 								<p><?php echo Text::_('COM_KUNENA_VIEW_POSTED') . " : " . $author->getName('???', false); ?></p>
 
 								<p>URL :
-									<a href="<?php echo $this->messageLink; ?>"><b><?php echo $this->messageLink; ?></b></a>
+									<a href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>"><b><?php echo $this->messageLink; ?></b></a>
 								</p>
 							</div>
 
@@ -202,7 +202,7 @@ if (!$config->plain_email) :
 										    style="padding: 12px 24px; margin: 0; text-decoration: underline; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
 										    bgcolor="#0072C6"><a target="_blank" style="text-decoration: underline;
 					color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;"
-										                         href="<?php echo $this->messageLink; ?>">
+										                         href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>">
 												<?php echo Text::_('COM_KUNENA_READMORE'); ?>
 											</a>
 										</td>

--- a/src/components/com_kunena/template/crypsisb3/layouts/email/report/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/email/report/default.php
@@ -176,7 +176,7 @@ if (!$config->plain_email) :
 										    style="padding: 12px 24px; margin: 0; text-decoration: underline; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
 										    bgcolor="#0072C6"><a target="_blank" style="text-decoration: underline;
 					color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;"
-										                         href="<?php echo $this->messageLink; ?>">
+										                         href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Report'; ?>">
 												<?php echo Text::_('COM_KUNENA_REPORT_POST_LINK'); ?>
 											</a>
 										</td>

--- a/src/components/com_kunena/template/crypsisb3/layouts/email/subscription/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/email/subscription/default.php
@@ -168,7 +168,7 @@ if (!$config->plain_email) :
 								<p><?php echo Text::_('COM_KUNENA_VIEW_POSTED') . " : " . $author->getName('???', false); ?></p>
 
 								<p>URL :
-									<a href="<?php echo $this->messageLink; ?>"><b><?php echo $this->messageLink; ?></b></a>
+									<a href="<?php echo $this->messageLink  . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>"><b><?php echo $this->messageLink; ?></b></a>
 								</p>
 							</div>
 
@@ -198,7 +198,7 @@ if (!$config->plain_email) :
 										    bgcolor="#0072C6">
 											<a target="_blank" style="text-decoration: underline;
 					color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;"
-											   href="<?php echo $this->messageLink; ?>">
+											   href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>">
 												<?php echo Text::_('COM_KUNENA_READMORE'); ?>
 											</a>
 										</td>

--- a/src/components/com_kunena/template/crypsisb3/layouts/email/subscription/moderator.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/email/subscription/moderator.php
@@ -173,7 +173,7 @@ if (!$config->plain_email) :
 								<p><?php echo Text::_('COM_KUNENA_VIEW_POSTED') . " : " . $author->getName('???', false); ?></p>
 
 								<p>URL :
-									<a href="<?php echo $this->messageLink; ?>"><b><?php echo $this->messageLink; ?></b></a>
+									<a href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>"><b><?php echo $this->messageLink; ?></b></a>
 								</p>
 							</div>
 
@@ -202,7 +202,7 @@ if (!$config->plain_email) :
 										    style="padding: 12px 24px; margin: 0; text-decoration: underline; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
 										    bgcolor="#0072C6"><a target="_blank" style="text-decoration: underline;
 					color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;"
-										                         href="<?php echo $this->messageLink; ?>">
+										                         href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>">
 												<?php echo Text::_('COM_KUNENA_READMORE'); ?>
 											</a>
 										</td>

--- a/src/components/com_kunena/template/system/layouts/email/report/default.php
+++ b/src/components/com_kunena/template/system/layouts/email/report/default.php
@@ -176,7 +176,7 @@ if (!$config->plain_email) :
 										    style="padding: 12px 24px; margin: 0; text-decoration: underline; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
 										    bgcolor="#0072C6"><a target="_blank" style="text-decoration: underline;
 					color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;"
-										                         href="<?php echo $this->messageLink; ?>">
+										                         href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Report'; ?>">
 												<?php echo Text::_('COM_KUNENA_REPORT_POST_LINK'); ?>
 											</a>
 										</td>

--- a/src/components/com_kunena/template/system/layouts/email/subscription/default.php
+++ b/src/components/com_kunena/template/system/layouts/email/subscription/default.php
@@ -168,7 +168,7 @@ if (!$config->plain_email) :
 								<p><?php echo Text::_('COM_KUNENA_VIEW_POSTED') . " : " . $author->getName('???', false); ?></p>
 
 								<p>URL :
-									<a href="<?php echo $this->messageLink; ?>"><b><?php echo $this->messageLink; ?></b></a>
+									<a href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>"><b><?php echo $this->messageLink; ?></b></a>
 								</p>
 							</div>
 
@@ -198,7 +198,7 @@ if (!$config->plain_email) :
 										    bgcolor="#0072C6">
 											<a target="_blank" style="text-decoration: underline;
 					color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;"
-											   href="<?php echo $this->messageLink; ?>">
+											   href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>">
 												<?php echo Text::_('COM_KUNENA_READMORE'); ?>
 											</a>
 										</td>

--- a/src/components/com_kunena/template/system/layouts/email/subscription/moderator.php
+++ b/src/components/com_kunena/template/system/layouts/email/subscription/moderator.php
@@ -173,7 +173,7 @@ if (!$config->plain_email) :
 								<p><?php echo Text::_('COM_KUNENA_VIEW_POSTED') . " : " . $author->getName('???', false); ?></p>
 
 								<p>URL :
-									<a href="<?php echo $this->messageLink; ?>"><b><?php echo $this->messageLink; ?></b></a>
+									<a href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>"><b><?php echo $this->messageLink; ?></b></a>
 								</p>
 							</div>
 
@@ -202,7 +202,7 @@ if (!$config->plain_email) :
 										    style="padding: 12px 24px; margin: 0; text-decoration: underline; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
 										    bgcolor="#0072C6"><a target="_blank" style="text-decoration: underline;
 					color: #FFFFFF; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 120%;"
-										                         href="<?php echo $this->messageLink; ?>">
+										                         href="<?php echo $this->messageLink . '?utm_source=' . $config->board_title . '&utm_medium=Email&utm_campaign=Subscription'; ?>">
 												<?php echo Text::_('COM_KUNENA_READMORE'); ?>
 											</a>
 										</td>


### PR DESCRIPTION
Pull Request for Issue https://github.com/Kunena/Kunena-Forum/issues/4781
 
This change will add UTM tracking to URL in notification email.
The main idea for this, is to be able to identify and track traffic source in Google Analytics and other reporting tools.

After applying this change, people will be able to view all the traffic coming from email notifications.

In Google Analytics they will the traffic as these:
Source = Site name
Medium = Email
Campaign = Subscription (and Report in case of report emails)

 
<img width="161" alt="good" src="https://user-images.githubusercontent.com/12942731/57202242-c85bf200-6f70-11e9-9fa7-9b0f6004dc41.PNG">
