### PR TITLE
Issue in query near 'IS NULL AND ut.topic_id=2' at line 5

### DIFF
--- a/src/libraries/kunena/forum/topic/user/helper.php
+++ b/src/libraries/kunena/forum/topic/user/helper.php
@@ -466,7 +466,7 @@ abstract class KunenaForumTopicUserHelper
 			->leftJoin($db->quoteName('#__kunena_messages', 'm') . ' ON ' . $db->quoteName('ut.last_post_id') . ' = ' . $db->quoteName('m.id') . ' AND ' . $db->quoteName('m.hold') . ' = 0')
 			->set($db->quoteName('posts') . ' = 0')
 			->set($db->quoteName('last_post_id') . ' = 0')
-			->where($db->quoteName('m.id') . ' =  IS NULL ' . $where2);
+			->where($db->quoteName('m.id') . ' IS NULL ' . $where2);
 		$db->setQuery((string) $query);
 
 		try


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
 
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'IS NULL AND ut.topic_id=2' at line 5

#### Testing Instructions