### PR TITLE
Update FA to 5.8.2

### DIFF
--- a/src/administrator/components/com_kunena/views/user/view.html.php
+++ b/src/administrator/components/com_kunena/views/user/view.html.php
@@ -41,7 +41,7 @@ class KunenaAdminViewUser extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.8.1/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.8.2/js/all.js', array(), array('defer' => true));
 		}
 
 		// Make the select list for the moderator flag

--- a/src/administrator/components/com_kunena/views/users/view.html.php
+++ b/src/administrator/components/com_kunena/views/users/view.html.php
@@ -51,7 +51,7 @@ class KunenaAdminViewUsers extends KunenaView
 
 		if (KunenaFactory::getTemplate()->params->get('fontawesome'))
 		{
-			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.8.1/js/all.js', array(), array('defer' => true));
+			Factory::getDocument()->addScript('https://use.fontawesome.com/releases/v5.8.2/js/all.js', array(), array('defer' => true));
 		}
 
 		$this->display();

--- a/src/components/com_kunena/template/aurelia/template.php
+++ b/src/components/com_kunena/template/aurelia/template.php
@@ -137,8 +137,8 @@ class KunenaTemplateAurelia extends KunenaTemplate
 
 		if ($fontawesome)
 		{
-			$this->addScript('https://use.fontawesome.com/releases/v5.8.1/js/all.js', array(), array('defer' => true));
-			$this->addScript('https://use.fontawesome.com/releases/v5.8.1/js/v4-shims.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.8.2/js/all.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.8.2/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		$icons = $this->ktemplate->params->get('icons');


### PR DESCRIPTION
#### Summary of Changes 
 
**Added**
New brand icon stackpath

**Changed**
Updated redhat, mailchimp brand icons
Updated Facebook brand icons in accordance with facebookbrand.com (facebook, facebook-f, facebook-square)
Updated Git brand icons (git, git-square, git-alt)
Removing the "at" character to prevent overlap with the at icon

**Fixed**
Missing version for the route icon
Corrected the orientation of radiation and radiation-alt icons
Alignment fixed for check-double
Moved the notch into the correct location for sim-card
Allow the role attribute to be specified
Prevent IE11 CSS selector error from crashing SVG with JS execution
