### PR TITLE
Update FA to 5.9.0

### DIFF
--- a/src/components/com_kunena/template/aurelia/template.php
+++ b/src/components/com_kunena/template/aurelia/template.php
@@ -137,8 +137,8 @@ class KunenaTemplateAurelia extends KunenaTemplate
 
 		if ($fontawesome)
 		{
-			$this->addScript('https://use.fontawesome.com/releases/v5.8.2/js/all.js', array(), array('defer' => true));
-			$this->addScript('https://use.fontawesome.com/releases/v5.8.2/js/v4-shims.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.9.0/js/all.js', array(), array('defer' => true));
+			$this->addScript('https://use.fontawesome.com/releases/v5.9.0/js/v4-shims.js', array(), array('defer' => true));
 		}
 
 		$icons = $this->ktemplate->params->get('icons');


### PR DESCRIPTION
#### Summary of Changes 
 
**Added**
•	An assortment of voted icons, updated icons, and new icons
•	New icons and updates to the text editor category
•	A flipped version of the phone and phone-alt icon

**Changed**
•	Removed the nintendo-switch icon by request of Nintendo
•	Sorted out the sort icons FortAwesome/Font-Awesome-Pro
•	De-crevassed the brain icons

**Fixed**
•	Proportions corrected on facebook-messenger brand icon

**Minor version upgrade notice:** 
there are some backward-incompatible changes to this release. See the
UPGRADING.md guide for more information.