### PR TITLE
Modify php update for banned column in users table to avoid fails

### DIFF
--- a/src/administrator/components/com_kunena/install/kunena.install.upgrade.xml
+++ b/src/administrator/components/com_kunena/install/kunena.install.upgrade.xml
@@ -929,11 +929,6 @@
             <query mode="silenterror">ALTER TABLE `#__kunena_users` MODIFY COLUMN `wechat` VARCHAR(75) NULL DEFAULT NULL;</query>
             <query mode="silenterror">ALTER TABLE `#__kunena_users` MODIFY COLUMN `yim` VARCHAR(75) NULL DEFAULT NULL;</query>
         </version>
-        <version version="6.0.0-ALPHA3"
-                 versiondate="2019-05-31"
-                 versionname="Internal">
-            <query mode="silenterror">ALTER TABLE `#__kunena_users` MODIFY COLUMN `banned` DATETIME NOT NULL DEFAULT '1000-01-01 00:00:00';</query>
-        </version>
         <version version="6.0.0-ALPHA4"
                  versiondate="2019-06-01"
                  versionname="Internal">

--- a/src/administrator/components/com_kunena/install/sql/updates/php/6.0.0-2019-05-31_banneddatetimedefault.php
+++ b/src/administrator/components/com_kunena/install/sql/updates/php/6.0.0-2019-05-31_banneddatetimedefault.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Language\Text;
  * @throws Exception
  * @since Kunena
  */
-function kunena_600_2019_31_banneddatetimedefault($parent)
+function kunena_600_2019_05_31_banneddatetimedefault($parent)
 {
 	$db  = Factory::getDbo();
 
@@ -36,6 +36,30 @@ function kunena_600_2019_31_banneddatetimedefault($parent)
 	{
 		throw new KunenaInstallerException($e->getMessage(), $e->getCode());
 	}
+	
+	$query    = "UPDATE `#___kunena_users` SET banned='1000-01-01 00:00:00' WHERE banned='null'";
+	$db->setQuery($query);
+	
+	try
+	{
+	    $db->execute();
+	}
+	catch (Exception $e)
+	{
+	    throw new KunenaInstallerException($e->getMessage(), $e->getCode());
+	}
 
+	$query    = "ALTER TABLE `#__kunena_users` MODIFY COLUMN `banned` DATETIME NOT NULL DEFAULT '1000-01-01 00:00:00';";
+	$db->setQuery($query);
+	
+	try
+	{
+		$db->execute();
+	}
+	catch (Exception $e)
+	{
+		throw new KunenaInstallerException($e->getMessage(), $e->getCode());
+	}
+	
 	return array('action' => '', 'name' => Text::_('COM_KUNENA_INSTALL_600_BANNED_DATETIME_DEFAULT'), 'success' => true);
 }


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
 
If in the table there are some rows with null value for banned column, the alter table to modify this column will fails (Error 1138: Invalid use of NULL value). So, the value null on banned column should be updated before that.

#### Testing Instructions