### PR TITLE
[K5.1] Separate fields in plain text email

### DIFF
--- a/src/components/com_kunena/template/crypsis/layouts/email/subscription/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/email/subscription/default.php
@@ -249,7 +249,9 @@ if (!$config->plain_email) :
 {$msg1} {$config->board_title}
 
 {$this->text('COM_KUNENA_MESSAGE_SUBJECT')} : {$subject}
+
 {$this->text('COM_KUNENA_CATEGORY')} : {$this->message->getCategory()->name}
+
 {$this->text('COM_KUNENA_VIEW_POSTED')} : {$author->getName('???', false)}
 
 URL: {$this->messageLink}


### PR DESCRIPTION
#### Summary of Changes 
This change is to place subject, category and author in different lines
3 lines instead of 1