### PR TITLE
Malformed URL in topic preview

### DIFF
--- a/src/components/com_kunena/template/crypsis/assets/js/edit.js
+++ b/src/components/com_kunena/template/crypsis/assets/js/edit.js
@@ -14,18 +14,10 @@ var previewActive = false;
 
 function kPreviewHelper(previewActive) {
 	var editor = jQuery('#editor');
-	if (Joomla.getOptions('com_kunena.suffixpreview'))
-	{
-		var url = 'index.php?option=com_kunena&view=topic&layout=edit&format=raw';
-	}
-	else
-	{
-		var url = jQuery('#kpreview_url').val();
-	}
 	if (editor.val() !== null) {
 		jQuery.ajax({
 			type: 'POST',
-			url: url,
+			url: jQuery('#kpreview_url').val(),
 			async: true,
 			dataType: 'json',
 			data: {body: editor.val()}

--- a/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
@@ -102,9 +102,6 @@ $this->addScriptOptions('com_kunena.icons.upload', KunenaIcons::upload());
 $this->addScriptOptions('com_kunena.icons.trash', KunenaIcons::delete());
 $this->addScriptOptions('com_kunena.icons.attach', KunenaIcons::attach());
 
-$suffix = Joomla\CMS\Application\CMSApplication::getInstance('site')->get('sef_suffix');
-$this->addScriptOptions('com_kunena.suffixpreview', $suffix ? true : false);
-
 // If polls are enabled, load also poll JavaScript.
 $this->ktemplate = KunenaFactory::getTemplate();
 $topicicontype   = $this->ktemplate->params->get('topicicontype');
@@ -170,7 +167,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 		       value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=categorytemplatetext&format=raw', false); ?>"/>
 		<input id="kcategory_poll" type="hidden" name="kcategory_poll" value="<?php echo $this->message->catid; ?>"/>
 		<input id="kpreview_url" type="hidden" name="kpreview_url"
-		       value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=edit&format=raw', false) ?>"/>
+		       value="<?php echo JUri::root(true) . '/index.php?option=com_kunena&view=topic&layout=edit&format=raw' ?>"/>
 		<?php if (!$this->config->allow_change_subject)
 			:
 			?>

--- a/src/components/com_kunena/template/crypsisb3/assets/js/edit.js
+++ b/src/components/com_kunena/template/crypsisb3/assets/js/edit.js
@@ -14,18 +14,10 @@ var previewActive = false;
 
 function kPreviewHelper(previewActive) {
 	var editor = jQuery('#editor');
-	if (Joomla.getOptions('com_kunena.suffixpreview'))
-	{
-		var url = 'index.php?option=com_kunena&view=topic&layout=edit&format=raw';
-	}
-	else
-	{
-		var url = jQuery('#kpreview_url').val();
-	}
 	if (editor.val() !== null) {
 		jQuery.ajax({
 			type: 'POST',
-			url: url,
+			url: jQuery('#kpreview_url').val(),
 			async: true,
 			dataType: 'json',
 			data: {body: editor.val()}

--- a/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
@@ -102,9 +102,6 @@ $this->addScriptOptions('com_kunena.icons.upload', KunenaIcons::upload());
 $this->addScriptOptions('com_kunena.icons.trash', KunenaIcons::delete());
 $this->addScriptOptions('com_kunena.icons.attach', KunenaIcons::attach());
 
-$suffix = Joomla\CMS\Application\CMSApplication::getInstance('site')->get('sef_suffix');
-$this->addScriptOptions('com_kunena.suffixpreview', $suffix ? true : false);
-
 $this->ktemplate = KunenaFactory::getTemplate();
 $topicicontype   = $this->ktemplate->params->get('topicicontype');
 $editor          = $this->ktemplate->params->get('editor');
@@ -173,7 +170,7 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 		       value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=categorytemplatetext&format=raw', false); ?>"/>
 		<input id="kcategory_poll" type="hidden" name="kcategory_poll" value="<?php echo $this->message->catid; ?>"/>
 		<input id="kpreview_url" type="hidden" name="kpreview_url"
-		       value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=edit&format=raw', false) ?>"/>
+		       value="<?php echo JUri::root(true) . '/index.php?option=com_kunena&view=topic&layout=edit&format=raw' ?>"/>
 		<?php if (!$this->config->allow_change_subject)
 			:
 			?>


### PR DESCRIPTION
Pull Request for Issue #6291. 
This is the correct version of a previous PR [5070](https://github.com/Kunena/Kunena-Forum/pull/5070) which was not implemented completely in Kunena master branch, because the PR was not fully working.
 
#### Summary of Changes 
1. Fixed the URL stored by kpreview_url for the reasons explained in the [PR](https://github.com/Kunena/Kunena-Forum/pull/5070) and [issue](https://github.com/Kunena/Kunena-Forum/issues/6291) mentioned.
2. Used the URL above in the related JavaScript unconditionally.
3. Removed the reference to Joomla global config value "sef_suffix", which at this point is useless.

#### Testing Instructions
Check the Ajax call when doing Topic Preview action.
Before this PR the URL triggered is
/forum/5-category/topic/index.php, which does not exists in the filesystem
After this PR it is 
"Joomla root URI" + '/index.php?option=com_kunena&view=topic&layout=edit&format=raw'
which is fine and it works