### PR TITLE
fix kunena vs jot cache conflict 

### DIFF
--- a/src/components/com_kunena/kunena.php
+++ b/src/components/com_kunena/kunena.php
@@ -147,6 +147,10 @@ echo $contents;
 // Remove custom error handlers.
 KunenaError::cleanup();
 
+// kunena conflicts with jot_cache, due to huge object message in app-inputs.
+//  this huje object causes crash. so, need to cleanup app-inputs before exit here.
+$app->input->set('message', NULL);
+
 // Display profiler information.
 if (KUNENA_PROFILER)
 {


### PR DESCRIPTION
Reason: JotCache component makes cache index from app.input contents.
kunena infer in input[message] field, that contains almost all app seance data. (viia db, it exposes   all page contents, and qyery requests).  Jot Cache try to save this object as index for cache  to db. And crushes, since this object is huge.

Changes: here is provided drop [message] from app.input after render completess. And so Jot cache works with original app.input well
 