### PR TITLE
Mail subscription sending delay to after response

### DIFF
--- a/src/components/com_kunena/controllers/topic.php
+++ b/src/components/com_kunena/controllers/topic.php
@@ -574,14 +574,16 @@ class KunenaControllerTopic extends KunenaController
 			}
 		}
 
+		if ( $this->config->url_subject_topic ) {
 		$url_subject = $this->checkURLInSubject($message->subject);
 
-		if ($url_subject && $this->config->url_subject_topic)
+		if ($url_subject)
 		{
 			$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_MESSAGES_ERROR_URL_IN_SUBJECT'), 'error');
 			$this->setRedirectBack();
 
 			return;
+		}
 		}
 
 		// Make sure that message has visible content (text, images or objects) to be shown.

--- a/src/components/com_kunena/controllers/topic.php
+++ b/src/components/com_kunena/controllers/topic.php
@@ -25,10 +25,10 @@ use Joomla\Utilities\ArrayHelper;
 class KunenaControllerTopic extends KunenaController
 {
 	/**
-	 * @param   array $config config
+	 * @param   array  $config  config
 	 *
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function __construct($config = array())
 	{
@@ -43,8 +43,8 @@ class KunenaControllerTopic extends KunenaController
 	 * Get attachments attached to a message with AJAX.
 	 *
 	 * @return void
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 * @throws null
 	 */
 	public function loadattachments()
@@ -99,8 +99,8 @@ class KunenaControllerTopic extends KunenaController
 	 * Set inline to 0 on the attachment object.
 	 *
 	 * @return void
-	 * @throws Exception
 	 * @since Kunena 5.1
+	 * @throws Exception
 	 */
 	public function removeinline()
 	{
@@ -158,8 +158,8 @@ class KunenaControllerTopic extends KunenaController
 	 * Remove files with AJAX.
 	 *
 	 * @return void
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function removeattachments()
 	{
@@ -207,8 +207,8 @@ class KunenaControllerTopic extends KunenaController
 	/**
 	 * Upload files with AJAX.
 	 *
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
 	 */
 	public function upload()
 	{
@@ -361,9 +361,9 @@ class KunenaControllerTopic extends KunenaController
 	}
 
 	/**
-	 * @throws Exception
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function post()
 	{
@@ -574,16 +574,17 @@ class KunenaControllerTopic extends KunenaController
 			}
 		}
 
-		if ( $this->config->url_subject_topic ) {
-		$url_subject = $this->checkURLInSubject($message->subject);
-
-		if ($url_subject)
+		if ($this->config->url_subject_topic)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_MESSAGES_ERROR_URL_IN_SUBJECT'), 'error');
-			$this->setRedirectBack();
+			$url_subject = $this->checkURLInSubject($message->subject);
 
-			return;
-		}
+			if ($url_subject)
+			{
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_MESSAGES_ERROR_URL_IN_SUBJECT'), 'error');
+				$this->setRedirectBack();
+
+				return;
+			}
 		}
 
 		// Make sure that message has visible content (text, images or objects) to be shown.
@@ -761,9 +762,9 @@ class KunenaControllerTopic extends KunenaController
 	}
 
 	/**
-	 * @throws Exception
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function edit()
 	{
@@ -1081,10 +1082,11 @@ class KunenaControllerTopic extends KunenaController
 	/**
 	 * Check if title of topic or message contains URL to limit part of spam
 	 *
+	 * @internal param string $usbject
+	 *
 	 * @param $subject
 	 *
 	 * @return boolean
-	 * @internal param string $usbject
 	 * @since    Kunena
 	 */
 	protected function checkURLInSubject($subject)
@@ -1116,8 +1118,8 @@ class KunenaControllerTopic extends KunenaController
 	 * @param $topic
 	 *
 	 * @return boolean
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function checkMaxLinks($text, $topic)
 	{
@@ -1184,9 +1186,9 @@ class KunenaControllerTopic extends KunenaController
 	}
 
 	/**
-	 * @throws Exception
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function thankyou()
 	{
@@ -1195,9 +1197,9 @@ class KunenaControllerTopic extends KunenaController
 	}
 
 	/**
-	 * @throws Exception
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function unthankyou()
 	{
@@ -1208,9 +1210,9 @@ class KunenaControllerTopic extends KunenaController
 	/**
 	 * @param $type
 	 *
-	 * @throws Exception
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
+	 * @throws Exception
 	 */
 	protected function setThankyou($type)
 	{
@@ -1897,8 +1899,8 @@ class KunenaControllerTopic extends KunenaController
 	}
 
 	/**
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 * @throws null
 	 */
 	public function move()
@@ -2024,8 +2026,8 @@ class KunenaControllerTopic extends KunenaController
 	}
 
 	/**
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 * @throws null
 	 */
 	public function report()
@@ -2198,9 +2200,9 @@ class KunenaControllerTopic extends KunenaController
 	}
 
 	/**
-	 * @throws Exception
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function vote()
 	{

--- a/src/libraries/kunena/error.php
+++ b/src/libraries/kunena/error.php
@@ -187,6 +187,9 @@ abstract class KunenaError
 	{
 		if (error_reporting() == 0 || !strstr($errfile, 'kunena'))
 		{
+		    if (strpos ( $errstr, "mail()") !== FALSE ){
+		        return KunenaEmail::on_mail_error($errno, $errstr, $errfile, $errline);
+		    }
 			return false;
 		}
 

--- a/src/libraries/kunena/error.php
+++ b/src/libraries/kunena/error.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Kunena Component
+ *
  * @package        Kunena.Framework
  *
  * @copyright      Copyright (C) 2008 - 2019 Kunena Team. All rights reserved.
@@ -14,6 +15,7 @@ use Joomla\CMS\Language\Text;
 
 /**
  * Class KunenaError
+ *
  * @since Kunena
  */
 abstract class KunenaError
@@ -102,8 +104,8 @@ abstract class KunenaError
 	}
 
 	/**
-	 * @param   string $msg   msg
-	 * @param   string $where where
+	 * @param   string  $msg    msg
+	 * @param   string  $where  where
 	 *
 	 * @return void
 	 * @since Kunena
@@ -119,8 +121,8 @@ abstract class KunenaError
 	}
 
 	/**
-	 * @param   string $msg   msg
-	 * @param   string $where where
+	 * @param   string  $msg    msg
+	 * @param   string  $where  where
 	 *
 	 * @return void
 	 * @since Kunena
@@ -138,7 +140,7 @@ abstract class KunenaError
 	/**
 	 * Return different error if it's an admin or a simple user
 	 *
-	 * @param   void $exception exception
+	 * @param   void  $exception  exception
 	 *
 	 * @return void
 	 * @since 5.0
@@ -155,7 +157,7 @@ abstract class KunenaError
 
 		if (Factory::getApplication()->isClient('administrator'))
 		{
-		    $app->enqueueMessage('Exception throw at line '  . $exception->getLine(). ' in file '.$exception->getFile(). ' with message '.$exception->getMessage(), 'error');
+			$app->enqueueMessage('Exception throw at line ' . $exception->getLine() . ' in file ' . $exception->getFile() . ' with message ' . $exception->getMessage(), 'error');
 		}
 		elseif (!JDEBUG && !KunenaFactory::getConfig()->debug && !self::$admin)
 		{
@@ -164,21 +166,21 @@ abstract class KunenaError
 		}
 		elseif (KunenaFactory::getUser()->isAdmin() && Factory::getApplication()->isClient('site'))
 		{
-		    $app->enqueueMessage('Exception throw at line '  . $exception->getLine(). ' in file '.$exception->getFile(). ' with message '.$exception->getMessage(), 'error');
+			$app->enqueueMessage('Exception throw at line ' . $exception->getLine() . ' in file ' . $exception->getFile() . ' with message ' . $exception->getMessage(), 'error');
 		}
 		else
 		{
 			$app->enqueueMessage('Kunena ' . Text::_('COM_KUNENA_INTERNAL_ERROR'), 'error');
 		}
 
-		KunenaLog::log(KunenaLog::TYPE_ERROR, KunenaLog::LOG_ERROR_FATAL, 'Exception throw at line '  . $exception->getLine(). ' in file '.$exception->getFile(). ' with message '.$exception->getMessage());
+		KunenaLog::log(KunenaLog::TYPE_ERROR, KunenaLog::LOG_ERROR_FATAL, 'Exception throw at line ' . $exception->getLine() . ' in file ' . $exception->getFile() . ' with message ' . $exception->getMessage());
 	}
 
 	/**
-	 * @param   string $errno   errorno
-	 * @param   string $errstr  errorstr
-	 * @param   string $errfile errorfile
-	 * @param   string $errline errorline
+	 * @param   string  $errno    errorno
+	 * @param   string  $errstr   errorstr
+	 * @param   string  $errfile  errorfile
+	 * @param   string  $errline  errorline
 	 *
 	 * @return boolean
 	 * @since Kunena
@@ -187,9 +189,11 @@ abstract class KunenaError
 	{
 		if (error_reporting() == 0 || !strstr($errfile, 'kunena'))
 		{
-		    if (strpos ( $errstr, "mail()") !== FALSE ){
-		        return KunenaEmail::on_mail_error($errno, $errstr, $errfile, $errline);
-		    }
+			if (strpos($errstr, "mail()") !== false)
+			{
+				return KunenaEmail::on_mail_error($errno, $errstr, $errfile, $errline);
+			}
+
 			return false;
 		}
 
@@ -239,7 +243,7 @@ abstract class KunenaError
 	}
 
 	/**
-	 * @param   mixed $debug debug
+	 * @param   mixed  $debug  debug
 	 *
 	 * @return void
 	 * @since Kunena

--- a/src/libraries/kunena/forum/message/message.php
+++ b/src/libraries/kunena/forum/message/message.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Kunena Component
+ *
  * @package       Kunena.Framework
  * @subpackage    Forum.Message
  *
@@ -18,6 +19,7 @@ use Joomla\CMS\Log\Log;
 /**
  * Class KunenaForumMessage
  *
+ * @since Kunena
  * @property int    $parent
  * @property int    $thread
  * @property int    $catid
@@ -38,7 +40,6 @@ use Joomla\CMS\Log\Log;
  * @property string $modified_reason
  * @property string $params
  * @property string $message
- * @since Kunena
  */
 class KunenaForumMessage extends KunenaDatabaseObject
 {
@@ -131,9 +132,10 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	protected $_authfcache = array();
 
 	/**
-	 * @param   mixed $properties properties
-	 *
 	 * @internal
+	 *
+	 * @param   mixed  $properties  properties
+	 *
 	 * @since Kunena
 	 */
 	public function __construct($properties = null)
@@ -145,8 +147,8 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Returns KunenaForumMessage object.
 	 *
-	 * @param   int  $identifier The message to load - Can be only an integer.
-	 * @param   bool $reload     reload
+	 * @param   int   $identifier  The message to load - Can be only an integer.
+	 * @param   bool  $reload      reload
 	 *
 	 * @return KunenaForumMessage
 	 * @since Kunena
@@ -158,6 +160,7 @@ class KunenaForumMessage extends KunenaDatabaseObject
 
 	/**
 	 * Destruct
+	 *
 	 * @since Kunena
 	 */
 	public function __destruct()
@@ -167,11 +170,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   mixed $user user
+	 * @param   mixed  $user  user
 	 *
 	 * @return boolean
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function isNew($user = null)
 	{
@@ -230,10 +233,10 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   KunenaForumTopic $topic topic
+	 * @param   KunenaForumTopic  $topic  topic
 	 *
-	 * @since Kunena
 	 * @return void
+	 * @since Kunena
 	 */
 	public function setTopic(KunenaForumTopic $topic)
 	{
@@ -269,8 +272,8 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   null|KunenaForumCategory $category Fake category if needed. Used for aliases.
-	 * @param   bool                     $xhtml    xhtml
+	 * @param   null|KunenaForumCategory  $category  Fake category if needed. Used for aliases.
+	 * @param   bool                      $xhtml     xhtml
 	 *
 	 * @return boolean
 	 * @since Kunena
@@ -283,11 +286,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   null|KunenaForumCategory $category Fake category if needed. Used for aliases.
+	 * @param   null|KunenaForumCategory  $category  Fake category if needed. Used for aliases.
 	 *
 	 * @return \Joomla\CMS\Uri\Uri
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 * @throws null
 	 */
 	public function getUri($category = null)
@@ -296,13 +299,13 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   array      $fields     fields
-	 * @param   mixed      $user       user
-	 * @param   null|array $safefields safefields
+	 * @param   array       $fields      fields
+	 * @param   mixed       $user        user
+	 * @param   null|array  $safefields  safefields
 	 *
 	 * @return array
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
 	 */
 	public function newReply($fields = array(), $user = null, $safefields = null)
 	{
@@ -372,48 +375,58 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Send email notifications from the message.
 	 *
-	 * @param   null|string $url url
+	 * @param   null|string  $url  url
 	 *
 	 * @return boolean|null
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 * @throws null
 	 */
 	public function sendNotification($url = null)
 	{
-	    if ($this->hold > 1)
-	    {
-	        return false;
-	    }
-	    
-	    $config = KunenaFactory::getConfig();
-	    
-	    if (!$config->get('send_emails'))
-	    {
-	        return false;
-	    }
-	    
-	    $this->urlNotification = $url;
-	    //Factory::getApplication()->RegisterEvent( 'onBeforeRespond', array($this, 'notificationCloseConnection') );
-	    Factory::getApplication()->RegisterEvent( 'onAfterRespond', array($this, 'notificationPost') );
+		if ($this->hold > 1)
+		{
+			return false;
+		}
+
+		$config = KunenaFactory::getConfig();
+
+		if (!$config->get('send_emails'))
+		{
+			return false;
+		}
+
+		$this->urlNotification = $url;
+		//Factory::getApplication()->RegisterEvent( 'onBeforeRespond', array($this, 'notificationCloseConnection') );
+		Factory::getApplication()->RegisterEvent('onAfterRespond', array($this, 'notificationPost'));
 	}
 
-	static
-	public
-	function notificationCloseConnection( ){
-	    $app = Factory::getApplication();
-	    $app->setHeader('Connection', 'close' );
-	}
-	
-	public 
-	function notificationPost( )
+	/**
+	 *
+	 *
+	 * @since version
+	 * @throws Exception
+	 */
+	static public function notificationCloseConnection()
 	{
+		$app = Factory::getApplication();
+		$app->setHeader('Connection', 'close');
+	}
 
-	    //restore app input context
-	    Factory::getApplication()->input->set('message', $this);
-	    $config = KunenaFactory::getConfig();
+	/**
+	 *
+	 * @return bool
+	 *
+	 * @since version
+	 * @throws \PHPMailer\PHPMailer\Exception
+	 */
+	public function notificationPost()
+	{
+		//restore app input context
+		Factory::getApplication()->input->set('message', $this);
+		$config = KunenaFactory::getConfig();
 
-	    $url = $this->urlNotification;
+		$url = $this->urlNotification;
 
 		if ($this->hold > 1)
 		{
@@ -472,12 +485,14 @@ class KunenaForumMessage extends KunenaDatabaseObject
 			$mailsubs,
 			$mailmods,
 			$mailadmins,
-		    $this->userid
+			$this->userid
 		);
 
 		if (empty($emailToList))
-		    return true;
-
+		{
+			return true;
+		}
+		else
 		{
 			if (!$config->getEmail())
 			{
@@ -524,7 +539,7 @@ class KunenaForumMessage extends KunenaDatabaseObject
 			Factory::getApplication()->getSession()->close();
 			flush();
 
-			$ok = true;
+			$ok         = true;
 			$start_time = microtime(true);
 			// Send email to all subscribers.
 			if (!empty($receivers[1]))
@@ -537,24 +552,24 @@ class KunenaForumMessage extends KunenaDatabaseObject
 			if (!empty($receivers[0]))
 			{
 				$this->attachEmailBody($mail, 0, $subject, $url, $once);
-				if (! KunenaEmail::send($mail, $receivers[0]) )
-				    $ok = false;
+				if (!KunenaEmail::send($mail, $receivers[0]))
+					$ok = false;
 			}
 			$end_time = microtime(true);
-			
-			$time_secs = ($end_time-$start_time);
-			$mid       = $this->thread;
+
+			$time_secs   = ($end_time - $start_time);
+			$mid         = $this->thread;
 			$recv_amount = count($receivers[1]) + count($receivers[0]);
-			Log::add(  "$recv_amount subscriptions for msg $mid sent for {$time_secs} [ms]"
-			    , Log::DEBUG, 'kunena');
-			KunenaLog::log( ($ok)? KunenaLog::TYPE_REPORT : KunenaLog::TYPE_ERROR, 
-			          KunenaLog::LOG_TOPIC_NOTIFY, 
-			         "$recv_amount subscriptions sent for $time_secs sec" ,
-    			    $this->getCategory(),
-    			    $this->getTopic(),
-    			    KunenaFactory::getUser($this->userid)
-			    );
-			
+			Log::add("$recv_amount subscriptions for msg $mid sent for {$time_secs} [ms]"
+				, Log::DEBUG, 'kunena');
+			KunenaLog::log(($ok) ? KunenaLog::TYPE_REPORT : KunenaLog::TYPE_ERROR,
+				KunenaLog::LOG_TOPIC_NOTIFY,
+				"$recv_amount subscriptions sent for $time_secs sec",
+				$this->getCategory(),
+				$this->getTopic(),
+				KunenaFactory::getUser($this->userid)
+			);
+
 			// Update subscriptions.
 			if ($once && $sentusers)
 			{
@@ -589,12 +604,12 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	 * If you want to add domain (for email etc), you can prepend the output with this:
 	 * Uri::getInstance()->toString(array('scheme', 'host', 'port'))
 	 *
-	 * @param   null|KunenaForumCategory $category Fake category if needed. Used for aliases.
-	 * @param   bool                     $xhtml    xhtml
+	 * @param   null|KunenaForumCategory  $category  Fake category if needed. Used for aliases.
+	 * @param   bool                      $xhtml     xhtml
 	 *
 	 * @return boolean
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 * @throws null
 	 */
 	public function getPermaUrl($category = null, $xhtml = true)
@@ -605,7 +620,7 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   null|KunenaForumCategory $category category
+	 * @param   null|KunenaForumCategory  $category  category
 	 *
 	 * @return \Joomla\CMS\Uri\Uri
 	 * @since Kunena
@@ -625,15 +640,15 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   \Joomla\CMS\Mail\Mail $mail         mail
-	 * @param   int                   $subscription subscription
-	 * @param   string                $subject      subject
-	 * @param   string                $url          url
-	 * @param   bool                  $once         once
+	 * @param   \Joomla\CMS\Mail\Mail  $mail          mail
+	 * @param   int                    $subscription  subscription
+	 * @param   string                 $subject       subject
+	 * @param   string                 $url           url
+	 * @param   bool                   $once          once
 	 *
 	 * @return void
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function attachEmailBody($mail, $subscription, $subject, $url, $once)
 	{
@@ -655,12 +670,12 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   int $value value
+	 * @param   int  $value  value
 	 *
 	 * @return boolean
-	 * @throws Exception
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function publish($value = KunenaForum::PUBLISHED)
 	{
@@ -679,8 +694,8 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	 * Method to save the KunenaForumMessage object to the database.
 	 *
 	 * @return    boolean True on success
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 * @throws null
 	 */
 	public function save()
@@ -775,8 +790,8 @@ class KunenaForumMessage extends KunenaDatabaseObject
 
 	/**
 	 * @return boolean
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
 	 */
 	protected function updateAttachments()
 	{
@@ -866,8 +881,8 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	 * Method to delete the KunenaForumMessage object from the database.
 	 *
 	 * @return boolean    True on success
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 * @throws null
 	 */
 	public function delete()
@@ -929,13 +944,13 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   bool|array $ids    ids
-	 * @param   string     $action action
+	 * @param   bool|array  $ids     ids
+	 * @param   string      $action  action
 	 *
 	 * @return KunenaAttachment[]
-	 * @throws Exception
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function getAttachments($ids = false, $action = 'read')
 	{
@@ -960,11 +975,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   bool $newTopic new topic
+	 * @param   bool  $newTopic  new topic
 	 *
-	 * @throws Exception
-	 * @since Kunena
 	 * @return void
+	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function update($newTopic = false)
 	{
@@ -1046,11 +1061,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   mixed $user user
+	 * @param   mixed  $user  user
 	 *
 	 * @return KunenaForumTopicUser
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function getUserTopic($user = null)
 	{
@@ -1059,8 +1074,8 @@ class KunenaForumMessage extends KunenaDatabaseObject
 
 	/**
 	 * @return KunenaForumMessageThankyou
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function getThankyou()
 	{
@@ -1078,8 +1093,8 @@ class KunenaForumMessage extends KunenaDatabaseObject
 
 	/**
 	 * @return KunenaUser
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function getAuthor()
 	{
@@ -1097,8 +1112,8 @@ class KunenaForumMessage extends KunenaDatabaseObject
 
 	/**
 	 * @return KunenaUser
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function getModifier()
 	{
@@ -1117,13 +1132,13 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Display required field from message table
 	 *
-	 * @param   string  $field   field
-	 * @param   boolean $html    html
-	 * @param   string  $context context
+	 * @param   string   $field    field
+	 * @param   boolean  $html     html
+	 * @param   string   $context  context
 	 *
 	 * @return integer|string
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function displayField($field, $html = true, $context = '')
 	{
@@ -1143,14 +1158,14 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Returns true if user is authorised to do the action.
 	 *
-	 * @param   string     $action action
-	 * @param   KunenaUser $user   user
+	 * @param   string      $action  action
+	 * @param   KunenaUser  $user    user
 	 *
 	 * @return boolean
 	 *
-	 * @throws Exception
-	 * @throws null
 	 * @since  K4.0
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function isAuthorised($action = 'read', KunenaUser $user = null)
 	{
@@ -1169,13 +1184,13 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Throws an exception if user isn't authorised to do the action.
 	 *
-	 * @param   string     $action action
-	 * @param   KunenaUser $user   user
-	 * @param   bool       $throw  trow
+	 * @param   string      $action  action
+	 * @param   KunenaUser  $user    user
+	 * @param   bool        $throw   trow
 	 *
 	 * @return mixed
-	 * @throws null
 	 * @since  K4.0
+	 * @throws null
 	 */
 	public function tryAuthorise($action = 'read', KunenaUser $user = null, $throw = true)
 	{
@@ -1240,12 +1255,12 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   array $fields fields
-	 * @param   mixed $user   user
+	 * @param   array  $fields  fields
+	 * @param   mixed  $user    user
 	 *
-	 * @throws null
-	 * @since Kunena
 	 * @return void
+	 * @since Kunena
+	 * @throws null
 	 */
 	public function edit($fields = array(), $user = null)
 	{
@@ -1261,11 +1276,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   mixed $user user
+	 * @param   mixed  $user  user
 	 *
 	 * @return void
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function makeAnonymous($user = null)
 	{
@@ -1293,13 +1308,13 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   int    $tmpid   tmpid
-	 * @param   string $postvar postvar
-	 * @param   null   $catid   catid
+	 * @param   int     $tmpid    tmpid
+	 * @param   string  $postvar  postvar
+	 * @param   null    $catid    catid
 	 *
 	 * @return boolean
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function uploadAttachment($tmpid, $postvar, $catid = null)
 	{
@@ -1317,12 +1332,12 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	 * If attachment is already pointing to the message, this function has no effect.
 	 * Currently only orphan attachments can be added.
 	 *
-	 * @param   array $ids ids
+	 * @param   array  $ids  ids
 	 *
-	 * @since  K4.0
-	 * @throws Exception
-	 * @throws null
 	 * @return void
+	 * @since  K4.0
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function addAttachments(array $ids)
 	{
@@ -1332,13 +1347,13 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Remove listed attachments from the message.
 	 *
-	 * @param   bool|int|array $ids ids
+	 * @param   bool|int|array  $ids  ids
 	 *
-	 * @deprecated K4.0
-	 * @since      Kunena
-	 * @throws Exception
-	 * @throws null
 	 * @return void
+	 * @since      Kunena
+	 * @throws null
+	 * @throws Exception
+	 * @deprecated K4.0
 	 */
 	public function removeAttachment($ids)
 	{
@@ -1357,12 +1372,12 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Remove listed attachments from the message.
 	 *
-	 * @param   array $ids ids
+	 * @param   array  $ids  ids
 	 *
-	 * @since  K4.0
-	 * @throws Exception
-	 * @throws null
 	 * @return void
+	 * @since  K4.0
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function removeAttachments(array $ids)
 	{
@@ -1373,8 +1388,8 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	 * Get the number of attachments into a message
 	 *
 	 * @return array|StdClass
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	public function getNbAttachments()
 	{
@@ -1405,7 +1420,7 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Method to load a KunenaForumMessage object by id.
 	 *
-	 * @param   mixed $id The message id to be loaded
+	 * @param   mixed  $id  The message id to be loaded
 	 *
 	 * @return boolean    True on success
 	 * @since Kunena
@@ -1421,9 +1436,9 @@ class KunenaForumMessage extends KunenaDatabaseObject
 
 	/**
 	 * @return boolean
-	 * @throws Exception
-	 * @throws null
 	 * @since Kunena
+	 * @throws null
+	 * @throws Exception
 	 */
 	public function check()
 	{
@@ -1575,9 +1590,9 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Get the substring
 	 *
-	 * @param   string  $string string
-	 * @param   integer $start  start
-	 * @param   integer $length length
+	 * @param   string   $string  string
+	 * @param   integer  $start   start
+	 * @param   integer  $length  length
 	 *
 	 * @return string
 	 * @since K5.0.2
@@ -1606,11 +1621,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|null
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function authoriseRead(KunenaUser $user)
 	{
@@ -1635,7 +1650,7 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|null
 	 * @since Kunena
@@ -1652,11 +1667,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|null
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function authoriseOwn(KunenaUser $user)
 	{
@@ -1677,11 +1692,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|null
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function authoriseThankyou(KunenaUser $user)
 	{
@@ -1709,11 +1724,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * This function check the edit time from the author of the post and return if the user is allowed to edit his post.
 	 *
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|null
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function authoriseEditTime(KunenaUser $user)
 	{
@@ -1772,11 +1787,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|null
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function authoriseDelete(KunenaUser $user)
 	{
@@ -1813,11 +1828,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Check if user has the right to perm delete the message
 	 *
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|NULL
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function authorisePermdelete(KunenaUser $user)
 	{
@@ -1839,11 +1854,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Check if user has the right to upload image attachment
 	 *
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|NULL
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function authoriseAttachmentsImage(KunenaUser $user)
 	{
@@ -1884,11 +1899,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	/**
 	 * Check if user has the right to upload file attachment
 	 *
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|NULL
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function authoriseAttachmentsFile(KunenaUser $user)
 	{
@@ -1927,11 +1942,11 @@ class KunenaForumMessage extends KunenaDatabaseObject
 	}
 
 	/**
-	 * @param   KunenaUser $user user
+	 * @param   KunenaUser  $user  user
 	 *
 	 * @return KunenaExceptionAuthorise|null
-	 * @throws Exception
 	 * @since Kunena
+	 * @throws Exception
 	 */
 	protected function authoriseGuestWrite(KunenaUser $user)
 	{

--- a/src/libraries/kunena/forum/message/message.php
+++ b/src/libraries/kunena/forum/message/message.php
@@ -545,7 +545,7 @@ class KunenaForumMessage extends KunenaDatabaseObject
 			$time_secs = ($end_time-$start_time);
 			$mid       = $this->thread;
 			$recv_amount = count($receivers[1]) + count($receivers[0]);
-			Log::add(  "$recv_amount subscriptions for msg $mid sent for $time_secs[ms]"
+			Log::add(  "$recv_amount subscriptions for msg $mid sent for {$time_secs} [ms]"
 			    , Log::DEBUG, 'kunena');
 			KunenaLog::log( ($ok)? KunenaLog::TYPE_REPORT : KunenaLog::TYPE_ERROR, 
 			          KunenaLog::LOG_TOPIC_NOTIFY, 

--- a/src/libraries/kunena/log/log.php
+++ b/src/libraries/kunena/log/log.php
@@ -225,9 +225,12 @@ class KunenaLog
 	 * @since Kunena 5.0
 	 */
 	const LOG_TOPIC_REPORT = 'LOG_TOPIC_REPORT';
-	
+
+	/**
+	 * @since Kunena 5.1.16
+	 */
 	const LOG_TOPIC_NOTIFY = 'LOG_TOPIC_NOTIFY';
-	
+
 	/**
 	 * @since Kunena
 	 */

--- a/src/libraries/kunena/log/log.php
+++ b/src/libraries/kunena/log/log.php
@@ -225,7 +225,9 @@ class KunenaLog
 	 * @since Kunena 5.0
 	 */
 	const LOG_TOPIC_REPORT = 'LOG_TOPIC_REPORT';
-
+	
+	const LOG_TOPIC_NOTIFY = 'LOG_TOPIC_NOTIFY';
+	
 	/**
 	 * @since Kunena
 	 */


### PR DESCRIPTION
Reason: if some topic have many subscriptions, mailing them take much time - about 1sec/letter. For 70 subscriptions mailng accupy more then minute. Users don`t wait this time, they just go away from forum.

Changes:
here provided delay of subscription mailing after http request responded. Therefore, subscription placed in event onAfterRespond. before mail, it flushes and close http session -thus response go to browser, and after that starts to mail all the time it need.
