### PR TITLE
fix sanitize for access to user->timestamp by forum/avatar

### DIFF
--- a/src/libraries/kunena/user/user.php
+++ b/src/libraries/kunena/user/user.php
@@ -2170,6 +2170,11 @@ class KunenaUser extends CMSObject
 			case 'id':
 
 				return $this->userid;
+
+			case 'timestamp':
+			    // TODO: kunena forum avatar use this field.
+			    // need to implement this, of remove access in forum avatar
+			    return NULL;
 		}
 
 		if (version_compare(JVERSION, '4.0', '<'))


### PR DESCRIPTION
this patch rejects emiting error trace events for access to library/user->timestamp field, since forum/avatar surely use it

* kunena forum avatar use `timestamp` field, but library/user not implemened it.
Therefore library/user infers error events on forum. this events shows when joomla in debug mode.
This patch supress one errors, by price of TODO in code
 
