### PR TITLE
fix grammar: "Aktuelle Beiträge von $Person"

### DIFF
--- a/src/components/com_kunena/language/de-DE/de-DE.com_kunena.views.ini
+++ b/src/components/com_kunena/language/de-DE/de-DE.com_kunena.views.ini
@@ -155,7 +155,7 @@ COM_KUNENA_VIEW_TOPICS_USERS_MODE_FAVORITES = "Favorisierte Themen"
 COM_KUNENA_VIEW_TOPICS_USERS_MODE_POSTED = "Teilgenommene Themen"
 COM_KUNENA_VIEW_TOPICS_USERS_MODE_STARTED = "Thema gestartet"
 COM_KUNENA_VIEW_TOPICS_USERS_MODE_SUBSCRIPTIONS = "Themenabonnements"
-COM_KUNENA_VIEW_TOPICS_POSTS_MODE_DEFAULT_NEW = "%s%s aktuelle Beiträge"
+COM_KUNENA_VIEW_TOPICS_POSTS_MODE_DEFAULT_NEW = "Aktuelle Beiträge von %s"
 ; JROOT/components/com_kunena/views/user/view.html.php
 
 COM_KUNENA_DEFAULT_GALLERY = "Standard Galerie"


### PR DESCRIPTION
This PR fixes a common grammatical error in the German Language file.
The German language does NOT permit the ‚possessive Apostrophe“
See https://german.stackexchange.com/questions/2550/does-german-language-have-possessive-apostrophe

#### Summary of Changes [German]

Auf der Übersichtsseite zu jeder Nutzerin werden die aktuellen Beiträge in folgender Form überschrieben:
„Aktuelle Beiträge von Vorname Nachname“

Dies ersetzt die vorherige und grammatikalisch zwielichtige Formulierung
„Vorname Nachname’s Aktuelle Beiträge“

Siebe auch: http://www.deppenapostroph.info/

#### Testing Instructions

1. Check a forum user page of a user with recent activity
2. expected behavior: „Aktuelle Beiträge von Firstname Lastname“
