### PR TITLE
[K5.1] Add Twitter Summary Card Image in Recent Topics

### DIFF
--- a/src/components/com_kunena/controller/topic/list/recent/display.php
+++ b/src/components/com_kunena/controller/topic/list/recent/display.php
@@ -351,6 +351,7 @@ class ComponentKunenaControllerTopicListRecentDisplay extends ComponentKunenaCon
 		{
 			$image = Uri::base() . KunenaConfig::getInstance()->emailheader;
 			$this->setMetaData('og:image', $image, 'property');
+			$this->setMetaData('twitter:image', $image, 'property');
 		}
 
 		if ($robots == 'noindex, follow')


### PR DESCRIPTION
Pull Request for Issue # . None / Skipped / Direct PR
 
#### Summary of Changes 
Twitter Summary Card Image is already implemented in topics, this small change is for additionally add it to recent topics.