### PR TITLE
[K5.2] Setting in templates to load fontawesome from CDN was not working

### DIFF
--- a/src/libraries/kunena/template/template.php
+++ b/src/libraries/kunena/template/template.php
@@ -1929,7 +1929,7 @@ HTML;
 	public function loadFontawesome()
 	{
 		$ktemplate = KunenaFactory::getTemplate();
-		$fontawesome = $ktemplate->params->get('topicicontype');
+		$fontawesome = $ktemplate->params->get('fontawesome');
 
 		if ($fontawesome)
 		{


### PR DESCRIPTION
Pull Request for Issue # . 
 
See : https://github.com/Kunena/Kunena-Forum/issues/7442

#### Summary of Changes 
 
Setting in templates to load fontawesome from external CDN was not working since change made in Kunena 5.1.18

#### Testing Instructions