### PR TITLE
[K5.2] Limit allowed BBCode for the new users (no urls, images) #278

### DIFF
--- a/src/administrator/components/com_kunena/language/en-GB/en-GB.com_kunena.views.ini
+++ b/src/administrator/components/com_kunena/language/en-GB/en-GB.com_kunena.views.ini
@@ -612,6 +612,10 @@ COM_KUNENA_DISABLE_RE="Disable Re: on subject"
 COM_KUNENA_DISABLE_RE_DESC="When you enable the option, the Re: will be hidden on the subject."
 COM_KUNENA_CONFIG_DISPLAY_FILENAME_ATTACHMENT="Display attachment filename"
 COM_KUNENA_CONFIG_DISPLAY_FILENAME_ATTACHMENT_DESC="Display attachment filename next to the image or file in messages"
+COM_KUNENA_ADMIN_CONFIG_PREVENT_NEW_USERS_POST_URL_IMAGE = "Set if you want that new users are able to add url and image in his messages or profile"
+COM_KUNENA_ADMIN_CONFIG_PREVENT_NEW_USERS_POST_URL_IMAGE_DESC = "Set if you want that new users are able to add url and image in his messages or profile description. You need to define with the other setting the number minimum of user posts."
+COM_KUNENA_ADMIN_CONFIG_MINIMAL_NUMBER_OF_USER_POSTS_TO_ADD_URL_IMAGE = "Set the number minimun of user posts to able to add url and image"
+COM_KUNENA_ADMIN_CONFIG_MINIMAL_NUMBER_OF_USER_POSTS_TO_ADD_URL_IMAGE_DESC = "Set the number minimun of user posts for teh new users to be able to add url and image in his message and in his profile description"
 
 ; JROOT/administrator/components/com_kunena/views/config/tmpl/modal.php
 

--- a/src/administrator/components/com_kunena/models/config.php
+++ b/src/administrator/components/com_kunena/models/config.php
@@ -532,7 +532,10 @@ class KunenaAdminModelConfig extends KunenaModel
 
 		// K 5.1.19
 		$lists ['display_filename_attachment'] = HTMLHelper::_('select.genericlist', $yesno, 'cfg_display_filename_attachment', 'class="inputbox" size="1"', 'value', 'text', $this->config->display_filename_attachment);
-		
+
+		// K5.2.0
+		$lists ['new_users_prevent_post_url_images'] = HTMLHelper::_('select.genericlist', $yesno, 'cfg_new_users_prevent_post_url_images', 'class="inputbox" size="1"', 'value', 'text', $this->config->new_users_prevent_post_url_images);
+
 		return $lists;
 	}
 }

--- a/src/administrator/components/com_kunena/template/j3/config/default.php
+++ b/src/administrator/components/com_kunena/template/j3/config/default.php
@@ -780,6 +780,19 @@ Check back soon!') : echo 'class="changed"'; endif; ?>>
 													<td><?php echo $this->lists['moderator_permdelete'] ?> </td>
 													<td><?php echo Text::_('COM_KUNENA_ADMIN_CONFIG_MOD_PERDELETE_DESC') ?></td>
 												</tr>
+												<tr <?php if ($this->config->new_users_prevent_post_url_images != 0) : echo 'class="changed"'; endif; ?>>
+													<td><?php echo Text::_('COM_KUNENA_ADMIN_CONFIG_PREVENT_NEW_USERS_POST_URL_IMAGE') ?></td>
+													<td><?php echo $this->lists['new_users_prevent_post_url_images'] ?> </td>
+													<td><?php echo Text::_('COM_KUNENA_ADMIN_CONFIG_PREVENT_NEW_USERS_POST_URL_IMAGE_DESC') ?></td>
+												</tr>
+												<tr <?php if ($this->config->minimal_user_posts_add_url_image != 10) : echo 'class="changed"'; endif; ?>>
+													<td><?php echo Text::_('COM_KUNENA_ADMIN_CONFIG_MINIMAL_NUMBER_OF_USER_POSTS_TO_ADD_URL_IMAGE') ?></td>
+													<td>
+														<input type="text" name="cfg_minimal_user_posts_add_url_image"
+														       value="<?php echo $this->escape($this->config->minimal_user_posts_add_url_image) ?>"/>
+													</td>
+													<td><?php echo Text::_('COM_KUNENA_ADMIN_CONFIG_MINIMAL_NUMBER_OF_USER_POSTS_TO_ADD_URL_IMAGE_DESC') ?></td>
+												</tr>
 												</tbody>
 											</table>
 										</fieldset>

--- a/src/components/com_kunena/controllers/topic.php
+++ b/src/components/com_kunena/controllers/topic.php
@@ -659,6 +659,16 @@ class KunenaControllerTopic extends KunenaController
 			return;
 		}
 
+		$message->message = $this->removeLinksInMessage($text);
+
+		if (!$message->message)
+		{
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_MESSAGE_EMPTY_LINKS_IMAGES_REMOVED_NOT_ALLOWED'), 'error');
+			$this->setRedirectBack();
+
+			return;
+		}
+
 		$maxlinks = $this->checkMaxLinks($text, $topic);
 
 		if (!$maxlinks)
@@ -981,6 +991,16 @@ class KunenaControllerTopic extends KunenaController
 			return;
 		}
 
+		$message->message = $this->removeLinksInMessage($text);
+
+		if (!$message->message)
+		{
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_MESSAGE_EMPTY_LINKS_IMAGES_REMOVED_NOT_ALLOWED'), 'error');
+			$this->setRedirectBack();
+
+			return;
+		}
+
 		$maxlinks = $this->checkMaxLinks($text, $topic);
 
 		if (!$maxlinks)
@@ -1179,6 +1199,23 @@ class KunenaControllerTopic extends KunenaController
 
 		return true;
 	}
+	
+	/**
+	 * Remove links in message content
+	 * 
+	 * @param $text
+	 * 
+	 * @since Kunena 5.2.0
+	 */
+	protected function removeLinksInMessage($text)
+	{
+		if ($this->config->new_users_prevent_post_url_images && $this->me->posts <= $this->config->minimal_user_posts_add_url_image)
+		{
+			$text = preg_replace('/(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)/i', '', $text);
+
+			return $text;
+		}
+	}
 
 	/**
 	 * Check in the text the max links
@@ -1188,7 +1225,7 @@ class KunenaControllerTopic extends KunenaController
 	 *
 	 * @return boolean
 	 * @throws Exception
-	 * @since Kunena
+	
 	 */
 	protected function checkMaxLinks($text, $topic)
 	{

--- a/src/components/com_kunena/controllers/user.php
+++ b/src/components/com_kunena/controllers/user.php
@@ -984,7 +984,17 @@ class KunenaControllerUser extends KunenaController
 
 		if ($this->config->signature)
 		{
-			$user->signature = $input->$method->get('signature', '', 'raw');
+			$signature = $input->$method->get('signature', '', 'raw');
+
+			if ($this->config->new_users_prevent_post_url_images && $this->me->posts <= $this->config->minimal_user_posts_add_url_image)
+			{
+				$signature = preg_replace('/\[url=(.*?)\](.*?)\[\/url\]/su', '', $signature);
+				$signature = preg_replace('/\[img=(.*?)\](.*?)\[\/img\]/su', '', $signature);
+
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_SAVED_WITHOUT_LINKS_IMAGES'));
+			}
+
+			$user->signature = $signature;
 		}
 
 		$user->personalText = $input->$method->get('personaltext', '', 'string');

--- a/src/components/com_kunena/language/en-GB/en-GB.com_kunena.controllers.ini
+++ b/src/components/com_kunena/language/en-GB/en-GB.com_kunena.controllers.ini
@@ -87,6 +87,7 @@ COM_KUNENA_TOPIC_VOTE_SUCCESS = "You have given your vote!"
 COM_KUNENA_TOPIC_SPAM_LINK_PROTECTION = "You have too many links in your message, please decrease them!"
 COM_KUNENA_TOPIC_MESSAGES_ERROR_URL_IN_SUBJECT = "You cannot put an URL in the subject of the topic or message."
 COM_KUNENA_EMAIL_MESSAGE_LINK_URL="URL"
+COM_KUNENA_TOPIC_MESSAGE_EMPTY_LINKS_IMAGES_REMOVED_NOT_ALLOWED = "The links and images in your message has been removed, because your aren't allowed to use them, but your message is ended empty so it can't be saved"
 
 ; JROOT/components/com_kunena/controllers/topics.php
 

--- a/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsis/layouts/topic/edit/default.php
@@ -339,7 +339,13 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 						<?php endif; ?>
 
 						<?php
-						echo $this->subLayout('Widget/Editor')->setLayout('ckeditor')->set('message', $this->message)->set('config', $this->config)->set('poll', $this->message->getTopic()->getPoll())->set('allow_polls', $this->topic->getCategory()->allow_polls)->set('template', $this->ktemplate);
+						echo $this->subLayout('Widget/Editor')
+							->setLayout('ckeditor')->set('message', $this->message)
+							->set('config', $this->config)
+							->set('poll', $this->message->getTopic()->getPoll())
+							->set('allow_polls', $this->topic->getCategory()->allow_polls)
+							->set('template', $this->ktemplate)
+							->set('me', $this->me);
 						?>
 
 						<?php if ($this->message->exists() && $this->config->editmarkup)

--- a/src/components/com_kunena/template/crypsis/layouts/widget/editor/ckeditor.php
+++ b/src/components/com_kunena/template/crypsis/layouts/widget/editor/ckeditor.php
@@ -15,6 +15,31 @@ use Joomla\CMS\Language\Text;
 $this->addScript('ckeditor.js');
 $this->addScriptOptions('com_kunena.ckeditor_config', 'ckeditor_config.js');
 $this->addScriptOptions('com_kunena.ckeditor_base', JUri::root());
+
+// TODO: move this logic outside of the template
+if (KunenaConfig::getInstance()->new_users_prevent_post_url_images && KunenaConfig::getInstance()->minimal_user_posts_add_url_image <= $this->me->posts)
+{
+	$this->addScriptOptions('com_kunena.ckeditor_remove_buttons_url_image', KunenaConfig::getInstance()->new_users_prevent_post_url_images);
+	$editorbuttons = $this->template->params->get('editorButtons');
+	
+	if (empty($editorbuttons))
+	{
+		$this->template->params->set('editorButtons', 'Image,Link,Unlink');
+	}
+	else
+	{
+		if(strstr($editorbuttons, 'Image')!==false && strstr($editorbuttons, 'Link,Unlink')===false)
+		{
+			$editorbuttons .= ',Link,Unlink';
+			$this->template->params->set('editorButtons', $editorbuttons);
+		}
+		elseif(strstr($editorbuttons, 'Link,Unlink')!==false && strstr($editorbuttons, 'Image')==false)
+		{
+			$editorbuttons .= ',Image';
+			$this->template->params->set('editorButtons', $editorbuttons);
+		}
+	}
+}
 $this->addScriptOptions('com_kunena.ckeditor_buttons_configuration', $this->template->params->get('editorButtons'));
 
 $this->addScript('edit.js');

--- a/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/topic/edit/default.php
@@ -340,7 +340,13 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 						<?php endif; ?>
 
 						<?php
-						echo $this->subLayout('Widget/Editor')->setLayout('ckeditor')->set('message', $this->message)->set('config', $this->config)->set('poll', $this->message->getTopic()->getPoll())->set('allow_polls', $this->topic->getCategory()->allow_polls)->set('template', $this->ktemplate);
+						echo $this->subLayout('Widget/Editor')
+							->setLayout('ckeditor')->set('message', $this->message)
+							->set('config', $this->config)
+							->set('poll', $this->message->getTopic()->getPoll())
+							->set('allow_polls', $this->topic->getCategory()->allow_polls)
+							->set('template', $this->ktemplate)
+							->set('me', $this->me);
 						?>
 
 						<?php if ($this->message->exists() && $this->config->editmarkup)

--- a/src/components/com_kunena/template/crypsisb3/layouts/widget/editor/ckeditor.php
+++ b/src/components/com_kunena/template/crypsisb3/layouts/widget/editor/ckeditor.php
@@ -15,6 +15,31 @@ use Joomla\CMS\Language\Text;
 $this->addScript('ckeditor.js');
 $this->addScriptOptions('com_kunena.ckeditor_config', 'ckeditor_config.js');
 $this->addScriptOptions('com_kunena.ckeditor_base', JUri::root());
+
+// TODO: move this logic outside of the template
+if (KunenaConfig::getInstance()->new_users_prevent_post_url_images && KunenaConfig::getInstance()->minimal_user_posts_add_url_image <= $this->me->posts)
+{
+	$this->addScriptOptions('com_kunena.ckeditor_remove_buttons_url_image', KunenaConfig::getInstance()->new_users_prevent_post_url_images);
+	$editorbuttons = $this->template->params->get('editorButtons');
+
+	if (empty($editorbuttons))
+	{
+		$this->template->params->set('editorButtons', 'Image,Link,Unlink');
+	}
+	else
+	{
+		if(strstr($editorbuttons, 'Image')!==false && strstr($editorbuttons, 'Link,Unlink')===false)
+		{
+			$editorbuttons .= ',Link,Unlink';
+			$this->template->params->set('editorButtons', $editorbuttons);
+		}
+		elseif(strstr($editorbuttons, 'Link,Unlink')!==false && strstr($editorbuttons, 'Image')==false)
+		{
+			$editorbuttons .= ',Image';
+			$this->template->params->set('editorButtons', $editorbuttons);
+		}
+	}
+}
 $this->addScriptOptions('com_kunena.ckeditor_buttons_configuration', $this->template->params->get('editorButtons'));
 
 $this->addScript('edit.js');

--- a/src/components/com_kunena/template/crypsisb4/layouts/topic/edit/default.php
+++ b/src/components/com_kunena/template/crypsisb4/layouts/topic/edit/default.php
@@ -319,7 +319,13 @@ if (KunenaFactory::getTemplate()->params->get('formRecover'))
 			<?php endif; ?>
 
 			<?php
-			echo $this->subLayout('Widget/Editor')->setLayout('ckeditor')->set('message', $this->message)->set('config', $this->config)->set('poll', $this->message->getTopic()->getPoll())->set('allow_polls', $this->topic->getCategory()->allow_polls)->set('template', $this->ktemplate);
+				echo $this->subLayout('Widget/Editor')
+					->setLayout('ckeditor')->set('message', $this->message)
+					->set('config', $this->config)
+					->set('poll', $this->message->getTopic()->getPoll())
+					->set('allow_polls', $this->topic->getCategory()->allow_polls)
+					->set('template', $this->ktemplate)
+					->set('me', $this->me);
 			?>
 		</div>
 

--- a/src/components/com_kunena/template/crypsisb4/layouts/widget/editor/ckeditor.php
+++ b/src/components/com_kunena/template/crypsisb4/layouts/widget/editor/ckeditor.php
@@ -15,6 +15,31 @@ use Joomla\CMS\Language\Text;
 $this->addScript('ckeditor.js');
 $this->addScriptOptions('com_kunena.ckeditor_config', 'ckeditor_config.js');
 $this->addScriptOptions('com_kunena.ckeditor_base', JUri::root());
+
+// TODO: move this logic outside of the template
+if (KunenaConfig::getInstance()->new_users_prevent_post_url_images && KunenaConfig::getInstance()->minimal_user_posts_add_url_image <= $this->me->posts)
+{
+	$this->addScriptOptions('com_kunena.ckeditor_remove_buttons_url_image', KunenaConfig::getInstance()->new_users_prevent_post_url_images);
+	$editorbuttons = $this->template->params->get('editorButtons');
+
+	if (empty($editorbuttons))
+	{
+		$this->template->params->set('editorButtons', 'Image,Link,Unlink');
+	}
+	else
+	{
+		if(strstr($editorbuttons, 'Image')!==false && strstr($editorbuttons, 'Link,Unlink')===false)
+		{
+			$editorbuttons .= ',Link,Unlink';
+			$this->template->params->set('editorButtons', $editorbuttons);
+		}
+		elseif(strstr($editorbuttons, 'Link,Unlink')!==false && strstr($editorbuttons, 'Image')==false)
+		{
+			$editorbuttons .= ',Image';
+			$this->template->params->set('editorButtons', $editorbuttons);
+		}
+	}
+}
 $this->addScriptOptions('com_kunena.ckeditor_buttons_configuration', $this->template->params->get('editorButtons'));
 
 $this->addScript('edit.js');

--- a/src/libraries/kunena/config.php
+++ b/src/libraries/kunena/config.php
@@ -1362,6 +1362,18 @@ class KunenaConfig extends CMSObject
 	 * @since  K5.1.19
 	 */
 	public $display_filename_attachment = 0;
+	
+	/**
+	 * @var integer
+	 * @since  K5.2.0
+	 */
+	public $new_users_prevent_post_url_images = 0;
+	
+	/**
+	 * @var integer
+	 * @since  K5.2.0
+	 */
+	public $minimal_user_posts_add_url_image = 10;
 
 	/**
 	 * @since Kunena

--- a/src/media/kunena/core/js/ckeditor_config.js
+++ b/src/media/kunena/core/js/ckeditor_config.js
@@ -27,13 +27,21 @@ CKEDITOR.editorConfig = function( config ) {
 		{ name: 'about', groups: [ 'about' ] }
 	];
 
+	var remove_buttons_url_image = Joomla.getOptions('com_kunena.ckeditor_remove_buttons_url_image');
 	if(Joomla.getOptions('com_kunena.ckeditor_buttons_configuration') !== undefined)
 	{
 		config.removeButtons = 'Anchor,Paste,' + Joomla.getOptions('com_kunena.ckeditor_buttons_configuration');
 	}
 	else
 	{
-		config.removeButtons = 'Anchor,Paste';
+		if (remove_buttons_url_image)
+		{
+			config.removeButtons = 'Anchor,Paste,Image,Link,Unlink';
+		}
+		else
+		{
+			config.removeButtons = 'Anchor,Paste';
+		}
 	}
 
 	config.extraPlugins = 'ebay,twitter,instagram,map,soundcloud,video,confidential,hidetext,spoiler,code,polls';
@@ -47,13 +55,4 @@ CKEDITOR.editorConfig = function( config ) {
 
 	config.smiley_path = '/media/kunena/emoticons/';
 	config.smiley_images = list_emoticons;
-	/*config.smiley_descriptions = [
-	 'B)', '8)', '8-)', ':-(', ':(', ':sad:', ':cry:', ':)', ':-)', ':cheer:', ';)', ';-)', 
-       ':wink:', ';-)', ':P', ':p', ':-p', ':-P', ':razz:', ':angry:', ':mad:', ':unsure:', ':o', 
-       ':-o', ':O', ':-O', ':eek:', ':ohmy:', ':huh:', ':?', ':-?', ':???', ':dry:', ':ermm:', ':lol:', 
-       ':X', ':x', ':sick:', ':silly:', ':y32b4:', ':blink:', ':blush:', ':oops:', ':kiss:', ':rolleyes:', 
-       ':roll:', ':woohoo:', ':side:', ':S', ':s', ':evil:', ':twisted:', ':whistle:', ':pinch:', 
-       ':D', ':-D', ':grin:', ':laugh:', ':|', ':-|', ':neutral:', ':mrgreen:', ':?:',
-       ':!:', ':arrow:', ':idea:'
-	];*/
 };


### PR DESCRIPTION
Pull Request for Issue #278.
 
#### Summary of Changes 
 
When setting enabled in Kunena configuration, it removes links on new message, edit and signature in profile only if the user has less posts thant defined in Kunena configuration

#### Testing Instructions