### PR TITLE
[K5.2] Cannot access protected property KunenaBbcode::$tag_rules

### DIFF
--- a/src/libraries/kunena/bbcode/bbcode.php
+++ b/src/libraries/kunena/bbcode/bbcode.php
@@ -1441,7 +1441,8 @@ class KunenaBbcodeLibrary extends Nbbc\BBCodeLibrary
 
 		if (!$default)
 		{
-			$default = $bbcode->tag_rules [$name] ['default'] ['_default'];
+			$tag_rule = $bbcode->getRule($name);
+			$default = $tag_rule ['default'] ['_default'];
 		}
 
 		if ($action == Nbbc\BBCode::BBCODE_CHECK)


### PR DESCRIPTION
Pull Request for Issue # . 
 
Rendering Error in layout Category/Index: Cannot access protected property KunenaBbcode::$tag_rules in /components/com_kunena/template/crypsis/layouts/category/index/default.php on line 141
Layout was rendered in /libraries/kunena/external/nbbc/src/BBCode.php on line 2305

If needed close # 
 
#### Summary of Changes 
 
#### Testing Instructions
