### PR TITLE
[K5.2] When allow_fopen_url is disabled not access page manage template

### DIFF
--- a/src/administrator/components/com_kunena/models/templates.php
+++ b/src/administrator/components/com_kunena/models/templates.php
@@ -332,7 +332,16 @@ class KunenaAdminModelTemplates extends \Joomla\CMS\MVC\Model\AdminModel
 
 		$options = new Joomla\Registry\Registry;
 
-		$transport = new Joomla\CMS\Http\Transport\StreamTransport($options);
+		try
+		{
+			$transport = new Joomla\CMS\Http\Transport\StreamTransport($options);
+		} 
+		catch (Exception $e) 
+		{
+			$this->app->enqueueMessage($e->getMessage(), 'error')
+
+			return false;
+		}
 
 		// Create a 'stream' transport.
 		$http = new Joomla\CMS\Http\Http($options, $transport);


### PR DESCRIPTION
Pull Request for Issue # . 
 
allow_fopen_url needs to be enabled else it can't loads the xml file which contains the list of premium templates from k.org and blocks completly the page to manage Kunena templates

If needed close # 
 
#### Summary of Changes 
 
#### Testing Instructions
