### PR TITLE
Veekee fr topic icon crypsis

### DIFF
--- a/src/components/com_kunena/template/crypsis/assets/less/general.less
+++ b/src/components/com_kunena/template/crypsis/assets/less/general.less
@@ -1217,3 +1217,7 @@ div.krating > label:active {
   height: 24px;
   display: inline-flex;
 }
+
+#iconset_topic_list {
+  display: flex;
+}

--- a/src/components/com_kunena/template/crypsis/assets/less/general.less
+++ b/src/components/com_kunena/template/crypsis/assets/less/general.less
@@ -1212,3 +1212,8 @@ div.krating > label:active {
 .message-unapproved blockquote {
   border-color: #a6a6a6;
 }
+
+.kunena-topic-item h1 {
+  height: 24px;
+  display: inline-flex;
+}


### PR DESCRIPTION
Issue
When displaying topic or creating a topic, on a crypsis theme-based forum, the topic icons are shown as large as possible.
![image](https://user-images.githubusercontent.com/20480977/102701480-b0290b80-4257-11eb-85c3-ee25c3ca68c1.png)

#### Summary of Changes

Forcing topic icon to match the element style it's included on.

#### Testing Instructions

Check topic and topic creation display.
