### PR TITLE
[K5.2] Add more checks when try to access template diretories

### DIFF
--- a/src/administrator/components/com_kunena/views/templates/view.html.php
+++ b/src/administrator/components/com_kunena/views/templates/view.html.php
@@ -94,9 +94,9 @@ class KunenaAdminViewTemplates extends KunenaView
 
 		$this->templatefile = KPATH_SITE . '/template/' . $this->templatename . '/config/params.ini';
 
-		if (!JFile::exists($this->templatefile))
+		if (!JFile::exists($this->templatefile) && JFolder::exists(KPATH_SITE . '/template/' . $this->templatename . '/config/'))
 		{
-			$ourFileHandle = @fopen($this->templatefile, 'w');
+			$ourFileHandle = fopen($this->templatefile, 'w');
 
 			if ($ourFileHandle)
 			{
@@ -137,7 +137,7 @@ class KunenaAdminViewTemplates extends KunenaView
 
 		$file = KPATH_SITE . '/template/' . $this->templatename . '/assets/less/custom.less';
 
-		if (!file_exists($file))
+		if (!file_exists($file) && JFolder::exists(KPATH_SITE . '/template/' . $this->templatename . '/assets/less/'))
 		{
 			$fp = fopen($file, "w");
 			fwrite($fp, "");
@@ -206,7 +206,7 @@ class KunenaAdminViewTemplates extends KunenaView
 
 		$file = KPATH_SITE . '/template/' . $this->templatename . '/assets/css/custom.css';
 
-		if (!file_exists($file))
+		if (!file_exists($file) && JFolder::exists(KPATH_SITE . '/template/' . $this->templatename . '/assets/css/'))
 		{
 			$fp = fopen($file, "w");
 			fwrite($fp, "");


### PR DESCRIPTION
Pull Request for Issue # . 
 
After a certain amount of time, the template name into session wasn't found and i can see this error on template edit when reloading the page : 

fopen(\joomla-cms-39/components/com_kunena/template//config/params.ini): Failed to open stream: No such file or directory in \Kunena-forum\src\administrator\components\com_kunena\views\templates\view.html.php on line 99

If needed close # 
 
#### Summary of Changes 
 
#### Testing Instructions
