### PR TITLE
[K5.2] Error message when not possible to get the xml file of templates

### DIFF
--- a/src/administrator/components/com_kunena/models/templates.php
+++ b/src/administrator/components/com_kunena/models/templates.php
@@ -335,7 +335,7 @@ class KunenaAdminModelTemplates extends \Joomla\CMS\MVC\Model\AdminModel
 		try
 		{
 			$transport = new Joomla\CMS\Http\Transport\StreamTransport($options);
-		} 
+		}
 		catch (Exception $e) 
 		{
 			$this->app->enqueueMessage($e->getMessage(), 'error');
@@ -346,7 +346,16 @@ class KunenaAdminModelTemplates extends \Joomla\CMS\MVC\Model\AdminModel
 		// Create a 'stream' transport.
 		$http = new Joomla\CMS\Http\Http($options, $transport);
 
-		$response = $http->get($url);
+		try
+		{
+			$response = $http->get($url);
+		}
+		catch (Exception $e)
+		{
+			$this->app->enqueueMessage($e->getMessage(), 'error');
+
+			return false;
+		}
 
 		if ($response->code == '200')
 		{


### PR DESCRIPTION
Pull Request for Issue # . 
 
when trying to open Templates Tab, error blocks all the page : 0 Could not connect to resource: update.kunena.org/templates.xml
C:\wamp\www\sitejoomla\libraries\src\Http\Transport\StreamTransport.php:199

If needed close # 
 
#### Summary of Changes 
 
#### Testing Instructions
