### PR TITLE
[K5.2] BBCode debugger show debug info even if not enabled

### DIFF
--- a/src/libraries/kunena/external/nbbc/src/Debugger.php
+++ b/src/libraries/kunena/external/nbbc/src/Debugger.php
@@ -82,11 +82,7 @@ class Debugger
 	 */
 	public static function log($level, $string, $logAll = false)
 	{
-		if ($level >= static::$level && $logAll === false)
-		{
-			SELF::storeLog($string);
-		}
-		else
+		if ($level >= static::$level)
 		{
 			SELF::storeLog($string);
 		}


### PR DESCRIPTION
Pull Request for Issue # . 
 
If needed close # 
 
#### Summary of Changes 
 
#### Testing Instructions
