### PR TITLE
[K5.2] Wrong path to the check of new skin of CKeditor in tmpl settings

### DIFF
--- a/src/administrator/components/com_kunena/controllers/templates.php
+++ b/src/administrator/components/com_kunena/controllers/templates.php
@@ -856,7 +856,7 @@ class KunenaAdminControllerTemplates extends KunenaController
 
 		if (!empty($params['nameskinckeditor']))
 		{
-			if (!JFolder::exists(KPATH_MEDIA . '/kunena/core/js/skins/' . $params['nameskinckeditor']))
+			if (!JFolder::exists(KPATH_MEDIA . '/core/js/skins/' . $params['nameskinckeditor']))
 			{
 				$params['nameskinckeditor'] = '';
 				$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_CANNOT_FIND_CKEDITOR_SKIN'),'error');


### PR DESCRIPTION
Pull Request for Issue # . 
 
Wrong path to the check of new skin of CKeditor in template settings on check in backend

If needed close # 
 
#### Summary of Changes 
 
#### Testing Instructions
