### PR TITLE
[K5.2] The menu item Recent Topics shows either all or nothing #7945

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.2.4-dev]
 ### Fixed
+* [#7945](https://github.com/Kunena/Kunena-Forum/issues/7945): The menu item Recent Topics shows either all or nothing
 * Rendering Error in layout User/Ban/History: Call to a member function getName() on string in /libraries/kunena/layout/base.php on line 168
 * Users always showing as "online" even when offline on the crypsisb4 template
 * When integration with easysocial is enabled, get displayname setting from easysocial configuration to know what to display

--- a/src/administrator/components/com_kunena/install/kunena.install.upgrade.xml
+++ b/src/administrator/components/com_kunena/install/kunena.install.upgrade.xml
@@ -853,6 +853,11 @@
                  versionname="Internal">
             <phpfile name="5.2.0-2020-08-20_updaterankstitle"/>
         </version>
+        <version version="5.2.4-DEV"
+                 versiondate="2020-03-24"
+                 versionname="Internal">
+            <phpfile name="5.2.0-2021-03-24_configuration"/>
+        </version>
         <version version="@kunenaversion@"
                  versiondate="@kunenaversiondate@"
                  versionname="@kunenaversionname@">

--- a/src/administrator/components/com_kunena/install/sql/updates/php/5.2.0-2021-03-24_configuration.php
+++ b/src/administrator/components/com_kunena/install/sql/updates/php/5.2.0-2021-03-24_configuration.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Kunena Component
+ *
+ * @package        Kunena.Installer
+ *
+ * @copyright      Copyright (C) 2008 - 2021 Kunena Team. All rights reserved.
+ * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
+ * @link           https://www.kunena.org
+ **/
+defined('_JEXEC') or die();
+
+use Joomla\CMS\Language\Text;
+
+// Kunena 5.2.0: Convert configuration options which was wrong default value
+/**
+ * @param $parent
+ *
+ * @return array
+ * @throws Exception
+ * @since Kunena 5.2.4
+ */
+function kunena_520_2021_03_24_configuration($parent)
+{
+	$config = KunenaFactory::getConfig();
+
+	$latestcategory = $config->latestcategory;
+
+	if (!is_array($latestcategory))
+	{
+		unset($config->latestcategory);
+
+		$config->latestcategory = 0;
+
+		// Save configuration
+		$config->save();
+
+		return array('action' => '', 'name' => Text::_('COM_KUNENA_INSTALL_520_UPDATE_CONFIGURATION'), 'success' => true);
+	}
+}

--- a/src/administrator/components/com_kunena/language/en-GB/en-GB.com_kunena.install.ini
+++ b/src/administrator/components/com_kunena/language/en-GB/en-GB.com_kunena.install.ini
@@ -190,6 +190,10 @@ COM_KUNENA_INSTALL_200_PUBWRITE = "Converting public write access"
 
 COM_KUNENA_INSTALL_520_RANKS_TITLE_VALUE_IN_TABLES = "Update ranks title value to have string which can be translated"
 
+; JROOT/administrator/components/com_kunena/install/updates/php/5.2.0-2021-03-24_configuration.php
+
+COM_KUNENA_INSTALL_520_UPDATE_CONFIGURATION = "Update Kunena configuration to change the default value of following parameter : Category List in Recent Topics"
+
 ; JROOT/administrator/components/com_kunena/install/version.php
 
 COM_KUNENA_VERSION_ALPHA = "Alpha Release"

--- a/src/components/com_kunena/controller/topic/list/recent/display.php
+++ b/src/components/com_kunena/controller/topic/list/recent/display.php
@@ -101,7 +101,7 @@ class ComponentKunenaControllerTopicListRecentDisplay extends ComponentKunenaCon
 		// Get categories for the filter.
 		$categoryIds = $this->state->get('list.categories');
 
-		if(is_array($categoryIds))
+		if (!isset($categoryIds))
 		{
 			$categoryIds = false;
 		}

--- a/src/libraries/kunena/config.php
+++ b/src/libraries/kunena/config.php
@@ -404,10 +404,10 @@ class KunenaConfig extends CMSObject
 	public $userlist_userhits = 1;
 
 	/**
-	 * @var    string  Latest category; select, integer multiple
+	 * @var    integer  Latest category; select, integer multiple
 	 * @since  1.0.0
 	 */
-	public $latestcategory = '';
+	public $latestcategory = 0;
 
 	/**
 	 * @var    integer  Show stats; select, boolean


### PR DESCRIPTION
Pull Request for Issue #7945. 
 
If needed close #
 
#### Summary of Changes 
 
#### Testing Instructions

@rich20 : can-you give a try before i merge it ?

After install the build with this fix, in tab frontend of Kunena configuration, if the setting "Category List in Recent Topics" wasn't set, you should have that now : 

![image](https://user-images.githubusercontent.com/876395/112385223-a4823080-8cef-11eb-9749-94eeb46dfd8c.png)

Try to change the setting "Category List in Recent Topics" and check if it behave like it should on recent discussions

In Kunena menu, it's the same :  
![image](https://user-images.githubusercontent.com/876395/112385552-0cd11200-8cf0-11eb-9c79-334928b966e1.png)
