### PR TITLE
[bbcode] Allowing ',' in font name

### DIFF
--- a/src/libraries/kunena/bbcode/bbcode.php
+++ b/src/libraries/kunena/bbcode/bbcode.php
@@ -614,7 +614,7 @@ class KunenaBbcodeLibrary extends Nbbc\BBCodeLibrary
 
 		'font' => array(
 			'mode'     => Nbbc\BBCode::BBCODE_MODE_LIBRARY,
-			'allow'    => array('_default' => '/^[a-zA-Z0-9._ -]+$/'),
+			'allow'    => array('_default' => '/^[a-zA-Z0-9._, -]+$/'),
 			'method'   => 'DoFont',
 			'class'    => 'inline',
 			'allow_in' => array('listitem', 'block', 'columns', 'inline', 'link'),


### PR DESCRIPTION
[bbcode] Allowing ',' in font name

Pull Request for Personnal Issue.


Summary of Changes

Some font name may include the comma character, which is not currently supported by "font" bbcode.
Font name example : Times New Roman, serif


Testing Instructions

Checking regex doesn't exclude any currently supported font.