### PR TITLE
[K6.0] Can't get the category alias in Service\Router

### DIFF
--- a/src/site/src/Service/Router.php
+++ b/src/site/src/Service/Router.php
@@ -420,7 +420,7 @@ class Router extends RouterView
 				continue;
 			}
 
-			if ($sefcats && class_exists('KunenaRoute') && method_exists('KunenaRoute', 'resolveAlias'))
+			if ($sefcats && class_exists('Kunena\Forum\Libraries\Route\KunenaRoute') && method_exists('Kunena\Forum\Libraries\Route\KunenaRoute', 'resolveAlias'))
 			{
 				// Find out if we have SEF alias (category, view or layout)
 				$alias     = strtr($segment, ':', '-');


### PR DESCRIPTION
Pull Request for Issue # . 
 
If needed close # 
 
#### Summary of Changes 
 
Can't get the category alias in Service\Router because it can't call the namespaced class KunenaRoute

#### Testing Instructions
