### PR TITLE
[K6.0] Not possible to ban an user because method return has wrong type

### DIFF
--- a/src/libraries/kunena/src/User/KunenaBan.php
+++ b/src/libraries/kunena/src/User/KunenaBan.php
@@ -159,12 +159,19 @@ class KunenaBan extends parentAlias
 		$table = $this->getTable();
 
 		// Load the KunenaTableUser object based on the user id
-		$exists = $table->load($id);
+		try 
+		{
+			$exists = $table->load($id);
+		} 
+		catch (Exception $e)
+		{
+			KunenaError::displayDatabaseError($e);
+		}
 
 		$this->bind($table->getProperties());
 		$this->_exists = $exists;
 
-		return $exists;
+		return (bool) $exists;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # . 
 
If needed close # 
 
#### Summary of Changes 
 
#### Testing Instructions
