### PR TITLE
[K6.0] Convert some jQuery to vanilla JS

### DIFF
--- a/src/libraries/kunena/src/Template/KunenaTemplate.php
+++ b/src/libraries/kunena/src/Template/KunenaTemplate.php
@@ -320,10 +320,11 @@ class KunenaTemplate
 			if (KunenaFactory::getConfig()->activeMenuItem)
 			{
 				$id = htmlspecialchars(KunenaFactory::getConfig()->activeMenuItem, ENT_COMPAT, 'UTF-8');
-				$this->addScriptDeclaration(
-					"
-		jQuery(function($){ $(\"$id\").addClass('active')});"
-				);
+				$this->addScriptDeclaration("
+					document.addEventListener('DOMContentLoaded', () => {
+						document.querySelector('" . $id . "').classList.add('active');
+					});
+				");
 			}
 			else
 			{
@@ -333,10 +334,11 @@ class KunenaTemplate
 				if ($items)
 				{
 					$id = htmlspecialchars('.item-' . $items[0]->id, ENT_COMPAT, 'UTF-8');
-					$this->addScriptDeclaration(
-						"
-		jQuery(function($){ $(\"$id\").addClass('active')});"
-					);
+					$this->addScriptDeclaration("
+						document.addEventListener('DOMContentLoaded', () => {
+							document.querySelector('" . $id . "').classList.add('active');
+						});
+					");
 				}
 			}
 		}
@@ -529,13 +531,14 @@ class KunenaTemplate
 
 		if ($isForumActive)
 		{
-			$this->addScriptDeclaration(
-				'jQuery(document).ready(function ($) {
-				$(".current").addClass("active alias-parent-active");
-				$(".alias-parent-active").addClass("active alias-parent-active");
-			});
-			'
-			);
+			$this->addScriptDeclaration('
+				document.addEventListener("DOMContentLoaded", () => {
+					document.querySelector(".current").classList.add("active");
+					document.querySelector(".current").classList.add("alias-parent-active");
+					document.querySelector(".alias-parent-active").classList.add("active");
+					document.querySelector(".alias-parent-active").classList.add("alias-parent-active");
+				});
+			');
 		}
 	}
 

--- a/src/site/template/aurelia/layouts/topic/edit/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/default.php
@@ -527,7 +527,7 @@ Text::script('COM_KUNENA_POLL_TITLE');
 		<?php
 		if (!$this->message->name)
 		{
-			echo '<script type="text/javascript">document.postform.authorname.focus();</script>';
+			echo '<script>document.postform.authorname.focus();</script>';
 		}
 		else
 		{
@@ -535,12 +535,12 @@ Text::script('COM_KUNENA_POLL_TITLE');
 			{
 				if ($this->config->allowChangeSubject)
 				{
-					echo '<script type="text/javascript">document.postform.subject.focus();</script>';
+					echo '<script >document.postform.subject.focus();</script>';
 				}
 			}
 			else
 			{
-				echo '<script type="text/javascript">document.postform.message.focus();</script>';
+				echo '<script>document.postform.message.focus();</script>';
 			}
 		}
 		?>

--- a/src/site/template/aurelia/layouts/widget/forumjump/default.php
+++ b/src/site/template/aurelia/layouts/widget/forumjump/default.php
@@ -21,8 +21,11 @@ use function defined;
 $catid = Factory::getApplication()->input->getInt('catid', 0);
 ?>
 <script>
-	jQuery(function ($) {
-		$("#jumpto option[value=<?php echo $catid;?>]").prop("selected", "selected");
+	document.addEventListener('DOMContentLoaded', () => {
+		const jumpTo = document.querySelector('#jumpto option[value=<?php echo $catid;?>]');
+		if (jumpTo !== null) {
+			jumpTo.selected = true;
+		}
 	})
 </script>
 <form action="<?php echo KunenaRoute::_('index.php?option=com_kunena'); ?>" id="jumpto" name="jumpto" method="post"

--- a/src/site/template/aurelia/layouts/widget/login/logout/default.php
+++ b/src/site/template/aurelia/layouts/widget/login/logout/default.php
@@ -228,14 +228,18 @@ $config         = KunenaFactory::getTemplate()->params;
     <input type="hidden" name="task" value="statustext"/>
 	<?php echo HTMLHelper::_('form.token'); ?>
 </form>
-<script type='text/javascript'>
-    jQuery(document).ready(function ($) {
-        $("input[name=status]").change(function () {
-            $("#status-form").submit();
+<script>
+    const status = document.querySelector('input[name=status]')
+    if (status !== null)
+        status.addEventListener('change', () => {
+            document.getElementById('status-form').submit();
         });
+    }
 
-        $("btn_statustext").click(function () {
-            $("#status-text-form").submit();
+    const btnStatusText = document.getElementById('btn_statustext')
+    if (btnStatusText)
+        btnStatusText.addEventListener('click', () => {
+            document.getElementById('status-text-form').submit();
         });
-    });
+    }
 </script>

--- a/src/site/template/aurelia/layouts/widget/login/logout/default.php
+++ b/src/site/template/aurelia/layouts/widget/login/logout/default.php
@@ -230,14 +230,14 @@ $config         = KunenaFactory::getTemplate()->params;
 </form>
 <script>
     const status = document.querySelector('input[name=status]')
-    if (status !== null)
+    if (status !== null) {
         status.addEventListener('change', () => {
             document.getElementById('status-form').submit();
         });
     }
 
     const btnStatusText = document.getElementById('btn_statustext')
-    if (btnStatusText)
+    if (btnStatusText) {
         btnStatusText.addEventListener('click', () => {
             document.getElementById('status-text-form').submit();
         });


### PR DESCRIPTION
#### Summary of Changes 

This PR converts some of the inline jQuery snippets to vanilla JS.
 
#### Why?

Deferring JS is now the preferred method, therefore inline jQuery code will throw errors because it's trying to execute before everything else is loaded.
Using native JS will prevent this from happening.

Ideally you'll want to eventually move these inline snippets to dedicated `.js` files, but this is a start.
