### PR TITLE
[K6.0]Remove deprecated getDbo() in classes extends KunenaController

### DIFF
--- a/src/admin/src/Controller/CategoriesController.php
+++ b/src/admin/src/Controller/CategoriesController.php
@@ -15,7 +15,6 @@ namespace Kunena\Forum\Administrator\Controller;
 \defined('_JEXEC') or die();
 
 use Exception;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 use Joomla\Utilities\ArrayHelper;
@@ -703,12 +702,11 @@ class CategoriesController extends KunenaController
 			return;
 		}
 
-		$db  = Factory::getDbo();
-		$row = new TableKunenaCategories($db);
+		$row = new TableKunenaCategories($this->db);
 		$row->load($id);
 
 		// Ensure that we have the right ordering
-		$where = 'parentid=' . $db->quote($row->parentid);
+		$where = 'parentid=' . $this->db->quote($row->parentid);
 		$row->reOrder();
 		$row->move($direction, $where);
 	}
@@ -803,21 +801,19 @@ class CategoriesController extends KunenaController
 
 		if ($task == 'move')
 		{
-			$db = Factory::getDBO();
-
 			foreach ($cid as $cat)
 			{
 				if ($catParent != $cat)
 				{
-					$query = $db->getQuery(true);
-					$query->update($db->quoteName('#__kunena_categories'))
-						->set($db->quoteName('parentid') . " = " . $db->quote(\intval($catParent)))
-						->where($db->quoteName('id') . " = " . $db->quote($cat));
-					$db->setQuery($query);
+					$query = $this->db->getQuery(true);
+					$query->update($this->db->quoteName('#__kunena_categories'))
+						->set($this->db->quoteName('parentid') . " = " . $this->db->quote(\intval($catParent)))
+						->where($this->db->quoteName('id') . " = " . $this->db->quote($cat));
+					$this->db->setQuery($query);
 
 					try
 					{
-						$db->execute();
+						$this->db->execute();
 					}
 					catch (RuntimeException $e)
 					{

--- a/src/admin/src/Controller/UsersController.php
+++ b/src/admin/src/Controller/UsersController.php
@@ -60,7 +60,7 @@ class UsersController extends KunenaController
 	 * @throws Exception
 	 * @since   Kunena 2.0
 	 *
-	 * @see     BaseController
+	 * @see     KunenaController
 	 */
 
 	public function __construct($config = array())
@@ -884,7 +884,6 @@ class UsersController extends KunenaController
 			return;
 		}
 
-		$db  = Factory::getDbo();
 		$cid = $this->input->get('cid', [], 'array');
 		$cid = ArrayHelper::toInteger($cid, []);
 
@@ -892,15 +891,15 @@ class UsersController extends KunenaController
 		{
 			foreach ($cid as $userid)
 			{
-				$query = $db->getQuery(true);
-				$query->update($db->quoteName('#__kunena_user_categories'))
-					->set($db->quoteName('subscribed') . ' = 0')
-					->where($db->quoteName('user_id') . ' = ' . $userid);
-				$db->setQuery($query);
+				$query = $this->db->getQuery(true);
+				$query->update($this->db->quoteName('#__kunena_user_categories'))
+					->set($this->db->quoteName('subscribed') . ' = 0')
+					->where($this->db->quoteName('user_id') . ' = ' . $userid);
+				$this->db->setQuery($query);
 
 				try
 				{
-					$db->execute();
+					$this->db->execute();
 				}
 				catch (Exception $e)
 				{
@@ -934,7 +933,6 @@ class UsersController extends KunenaController
 			return;
 		}
 
-		$db  = Factory::getDBO();
 		$cid = $this->input->get('cid', [], 'array');
 		$cid = ArrayHelper::toInteger($cid, []);
 
@@ -942,15 +940,15 @@ class UsersController extends KunenaController
 		{
 			foreach ($cid as $userid)
 			{
-				$query = $db->getQuery(true);
-				$query->update($db->quoteName('#__kunena_user_topics'))
-					->set($db->quoteName('subscribed') . ' = 0')
-					->where($db->quoteName('user_id') . ' = ' . $userid);
-				$db->setQuery($query);
+				$query = $this->db->getQuery(true);
+				$query->update($this->db->quoteName('#__kunena_user_topics'))
+					->set($this->db->quoteName('subscribed') . ' = 0')
+					->where($this->db->quoteName('user_id') . ' = ' . $userid);
+				$this->db->setQuery($query);
 
 				try
 				{
-					$db->execute();
+					$this->db->execute();
 				}
 				catch (Exception $e)
 				{

--- a/src/libraries/kunena/src/Controller/KunenaController.php
+++ b/src/libraries/kunena/src/Controller/KunenaController.php
@@ -69,6 +69,12 @@ class KunenaController extends BaseController
 	public $format;
 
 	/**
+	 * @var     string
+	 * @since   Kunena 6.0
+	 */
+	public $db;
+
+	/**
 	 * @var     CMSApplicationInterface
 	 * @since   Kunena 6.0
 	 */
@@ -89,6 +95,7 @@ class KunenaController extends BaseController
 		$this->me       = KunenaUserHelper::getMyself();
 		$this->app      = Factory::getApplication();
 		$this->config   = KunenaFactory::getConfig();
+		$this->db       = Factory::getContainer()->get('DatabaseDriver');
 
 		// Save user profile if it didn't exist.
 		if ($this->me->userid && !$this->me->exists())

--- a/src/site/src/Controllers/TopicController.php
+++ b/src/site/src/Controllers/TopicController.php
@@ -609,16 +609,15 @@ class TopicController extends KunenaController
 			$timelimit = Factory::getDate()->toUnix() - $this->config->floodProtection;
 			$ip        = KunenaUserHelper::getUserIp();
 
-			$db    = Factory::getDBO();
-			$query = $db->getQuery(true);
+			$query = $this->db->getQuery(true);
 			$query->select('COUNT(*)')
-				->from($db->quoteName('#__kunena_messages'))
-				->where('ip=' . $db->quote($ip) . ' AND time > ' . $db->quote($timelimit));
-			$db->setQuery($query);
+				->from($this->db->quoteName('#__kunena_messages'))
+				->where('ip=' . $this->db->quote($ip) . ' AND time > ' . $this->db->quote($timelimit));
+			$this->db->setQuery($query);
 
 			try
 			{
-				$count = $db->loadResult();
+				$count = $this->db->loadResult();
 			}
 			catch (ExecutionFailureException $e)
 			{

--- a/src/site/src/Controllers/TopicsController.php
+++ b/src/site/src/Controllers/TopicsController.php
@@ -112,17 +112,15 @@ class TopicsController extends KunenaController
 					unset($instance);
 				}
 
-				$db = Factory::getDBO();
-
-				$query = $db->getQuery(true)->select(['a.id'])
-					->from($db->quoteName('#__kunena_attachments', 'a'))
-					->leftJoin($db->quoteName('#__kunena_messages', 'm') . ' ON ' . $db->quoteName('a.mesid') . '=' . $db->quoteName('m.id'))
-					->where($db->quoteName('m.id') . ' IS NULL');
-				$db->setQuery($query);
+				$query = $this->db->getQuery(true)->select(['a.id'])
+					->from($this->db->quoteName('#__kunena_attachments', 'a'))
+					->leftJoin($this->db->quoteName('#__kunena_messages', 'm') . ' ON ' . $this->db->quoteName('a.mesid') . '=' . $this->db->quoteName('m.id'))
+					->where($this->db->quoteName('m.id') . ' IS NULL');
+				$this->db->setQuery($query);
 
 				try
 				{
-					$list = $db->loadObjectList('id');
+					$list = $this->db->loadObjectList('id');
 				}
 				catch (ExecutionFailureException $e)
 				{
@@ -133,12 +131,12 @@ class TopicsController extends KunenaController
 
 				$ids = implode(',', array_keys($list));
 
-				$query = $db->getQuery(true)->delete($db->quoteName('#__kunena_attachments'))->where('id IN (' . $ids . ')');
-				$db->setQuery($query);
+				$query = $this->db->getQuery(true)->delete($this->db->quoteName('#__kunena_attachments'))->where('id IN (' . $ids . ')');
+				$this->db->setQuery($query);
 
 				try
 				{
-					$db->execute();
+					$this->db->execute();
 				}
 				catch (ExecutionFailureException $e)
 				{

--- a/src/site/src/Controllers/UserController.php
+++ b/src/site/src/Controllers/UserController.php
@@ -952,17 +952,16 @@ class UserController extends KunenaController
 		$spammer = Factory::getUser($userid);
 
 		// TODO: remove this query by getting the ip of user by an another way
-		$db    = Factory::getDBO();
-		$query = $db->getQuery(true);
+		$query = $this->db->getQuery(true);
 		$query
-			->select($db->quoteName(['ip']))
-			->from($db->quoteName('#__kunena_messages'))
-			->where($db->quoteName('userid') . ' = ' . $db->quote($userid))
-			->group($db->quoteName('ip'))
+			->select($this->db->quoteName(['ip']))
+			->from($this->db->quoteName('#__kunena_messages'))
+			->where($this->db->quoteName('userid') . ' = ' . $this->db->quote($userid))
+			->group($this->db->quoteName('ip'))
 			->order('time DESC');
 
-		$db->setQuery($query, 0, 1);
-		$ip = $db->loadResult();
+		$this->db->setQuery($query, 0, 1);
+		$ip = $this->db->loadResult();
 
 		if (!empty($ip))
 		{


### PR DESCRIPTION
Pull Request for Issue # . 
 
If needed close # 
 
#### Summary of Changes 
 
Remove deprecated usage of Factory::getDbo() in classes which extends KunenaController

#### Testing Instructions
