### PR TITLE
[K6.0] Set Php 7.4.x as minimal version by remove Php 7.3 is in EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 *Kunena* 6.0 requires
 
     Joomla: version 4.0.4 or greater (>= 4.0.4 recommended)
-    PHP: version 7.3.5 or greater (>= 7.3.5 recommended)
+    PHP: version 7.4.1 or greater (>= 7.4.1 recommended)
     MySQL: version 5.7.8 or greater (>= 5.7.8 recommended)
 
 Our installer will check for minimal version requirements and will abort the install if they are no met.

--- a/src/script.php
+++ b/src/script.php
@@ -47,9 +47,8 @@ class Pkg_KunenaInstallerScript extends InstallerScript
 	protected $versions = [
 		'PHP'     => [
 			'8.0' => '8.0.0',
-			'7.4' => '7.4.0',
-			'7.3' => '7.3.5',
-			'0'   => '7.3.5', // Preferred version
+			'7.4' => '7.4.1',
+			'0'   => '7.4.1', // Preferred version
 		],
 		'MySQL'   => [
 			'8.0' => '8.0.0',


### PR DESCRIPTION
Pull Request for Issue # . 
 
If needed close # 
 
#### Summary of Changes 
 
Set Php 7.4.x as minimal version by remove Php 7.3 which is in EOL from 6th of december 2021

#### Testing Instructions
