### PR TITLE
Fixes icons disappearing in Kunena 5.2.7 (Fixes #8622)

### DIFF
--- a/src/administrator/components/com_kunena/install/plugins/plg_kunena_comprofiler/avatar.php
+++ b/src/administrator/components/com_kunena/install/plugins/plg_kunena_comprofiler/avatar.php
@@ -78,7 +78,7 @@ class KunenaAvatarComprofiler extends KunenaAvatar
 			$cbUser = CBuser::getInstance($user->userid);
 		}
 
-		if ($cbUser === null)
+		if ($cbUser !== null)
 		{
 			if ($sizex <= 144)
 			{


### PR DESCRIPTION
Pull Request for Issue #8622 . 

#### Summary of Changes 

There is a refactoring bug in commit 659bbb3454a369f110ad782a52729e2c115ac130

This is an obvious code fix. Code was accessing $cbUser as object only if null.

just check code and the refactoring bug introduced by commit 659bbb3454a369f110ad782a52729e2c115ac130 :
https://github.com/Kunena/Kunena-Forum/commit/659bbb3454a369f110ad782a52729e2c115ac130

#### Testing Instructions
- Use Kunena 5.2.7 with CB, see forum index, no avatars displayed.
- Apply fix
- Avatars display fine.

I tested the fix on a clone of https://www.joomlapolis.com/