### PR TITLE
[K6.0] Error when initialize custom error handler on non-git env

### DIFF
--- a/src/libraries/kunena/src/Error/KunenaError.php
+++ b/src/libraries/kunena/src/Error/KunenaError.php
@@ -76,7 +76,7 @@ abstract class KunenaError
 			self::$admin  = Factory::getApplication()->isClient('administrator');
 
 			// Make sure we are able to log fatal errors.
-			register_shutdown_function(['KunenaError', 'shutdownHandler'], self::$debug || self::$admin || KUNENA_PROFILER);
+			register_shutdown_function(['Kunena\Forum\Libraries\Error\KunenaError', 'shutdownHandler'], self::$debug || self::$admin || KUNENA_PROFILER);
 
 			if (!self::$debug)
 			{


### PR DESCRIPTION
Pull Request for Issue # . 
 
If needed close # 
 
#### Summary of Changes 
 
When you are on non-git environnement you have this error :  register_shutdown_function(): Argument #1 ($callback) must be a valid callback, class "KunenaError" not found 

#### Testing Instructions
