### PR TITLE
[K6.0] KunenaForum::isDev() return always true

### DIFF
--- a/src/libraries/kunena/src/Forum/KunenaForum.php
+++ b/src/libraries/kunena/src/Forum/KunenaForum.php
@@ -209,7 +209,12 @@ abstract class KunenaForum
 	 */
 	public static function isDev(): bool
 	{
-		if ('@kunenaversion@' == '@' . 'kunenaversion' . '@')
+		SELF::version();
+
+		$match = [];
+		preg_match('/(-DEV)|(-GIT)/i', SELF::$version, $match);
+
+		if (!empty($match))
 		{
 			return true;
 		}


### PR DESCRIPTION
Pull Request for Issue # . 
 
If needed close # 
 
#### Summary of Changes 
 
The method KunenaForum::isDev() which check if you are in dev environnement return always true and the logs works only if you are on production

#### Testing Instructions

If your Kunena version is 6.0.0-BETA6-DEV-GIT the logs are disabled else if your Kunena version is 6.0.0-BETA6 the logs are enabled else