### PR TITLE
[K6.0] KunenaUserHelper::isIPv6():Argument #1 ($ip) must be of type int

### DIFF
--- a/src/libraries/kunena/src/User/KunenaUserHelper.php
+++ b/src/libraries/kunena/src/User/KunenaUserHelper.php
@@ -800,7 +800,7 @@ abstract class KunenaUserHelper
 	 *
 	 * @since   Kunena 6
 	 */
-	public static function isIPv6(int $ip): bool
+	public static function isIPv6(string $ip): bool
 	{
 		return IpHelper::isIPv6($ip);
 	}


### PR DESCRIPTION
Pull Request for Issue # . 
 
If needed close # 
 
#### Summary of Changes 
 
Fix the error : Kunena\Forum\Libraries\User\KunenaUserHelper::isIPv6(): Argument #1 ($ip) must be of type int, string given, called in joomla\Kunena-forum-6.0\src\site\src\Controllers\TopicController.php on line 943

#### Testing Instructions
