### PR TITLE
[K6.0]KunenaRoute::stringURLSafe(): Argument #1 must be of type string

### DIFF
--- a/src/libraries/kunena/src/Route/KunenaRoute.php
+++ b/src/libraries/kunena/src/Route/KunenaRoute.php
@@ -878,7 +878,7 @@ abstract class KunenaRoute
 	 *
 	 * @since   Kunena 6.0
 	 */
-	public static function stringURLSafe(string $string, $default = null)
+	public static function stringURLSafe($string, $default = null)
 	{
 		KunenaProfiler::getInstance() ? KunenaProfiler::instance()->start('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
 


### PR DESCRIPTION
Pull Request for Issue # . 
 
If needed close # 
 
#### Summary of Changes 
 
#### Testing Instructions
