### PR TITLE
[Bugfix] Fix stripped/broken [code] bbcode when "type" is not specified

### DIFF
--- a/src/libraries/kunena/bbcode/bbcode.php
+++ b/src/libraries/kunena/bbcode/bbcode.php
@@ -2193,7 +2193,11 @@ class KunenaBbcodeLibrary extends Nbbc\BBCodeLibrary
 		else
 		{
 			$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
-			$code = '<pre xml:' . $type . '>' . $content . '</pre>';
+			if ($type) {
+				$code = '<pre xml:' . $type . '>' . $content . '</pre>';
+			} else {
+				$code = '<pre>' . $content . '</pre>';
+			}
 		}
 
 		return '<div class="highlight">' . $code . '</div>';


### PR DESCRIPTION
When [code] blocks have no specified "type" (e.g. for php, js etc.), the resulting HTML to be rendered is `<pre xml:>...</pre>` which in turn breaks the final HTML that is output by Kunena. This simple check ensures the validity of the HTML output to be rendered.

Resolves the issue reported originally here: https://www.kunena.org/forum/k-5-2-support/161931-bug-in-code-code-parser