### PR TITLE
[K6.0] Php 8.1 with profile bottom on message error passing null instead

### DIFF
--- a/src/libraries/kunena/src/Date/KunenaDate.php
+++ b/src/libraries/kunena/src/Date/KunenaDate.php
@@ -29,8 +29,10 @@ use Kunena\Forum\Libraries\Profiler\KunenaProfiler;
 class KunenaDate extends Date
 {
 	/**
-	 * @param   string  $date  date
-	 * @param   null    $tz    tz
+	 * Return an instance of KunenaDate object
+	 * 
+	 * @param   string  $date  String in a format accepted by strtotime(), defaults to "now".
+	 * @param   mixed   $tz    Time zone to be used for the date. Might be a string or a DateTimeZone object.
 	 *
 	 * @return  KunenaDate
 	 *

--- a/src/site/template/aurelia/layouts/user/profile/horizontal.php
+++ b/src/site/template/aurelia/layouts/user/profile/horizontal.php
@@ -173,7 +173,7 @@ if ($config->showKarma)
 			</li>
 			<li>
 				<strong> <?php echo Text::_('COM_KUNENA_MYPROFILE_BIRTHDATE'); ?>:</strong>
-				<span> <?php echo KunenaDate::getInstance($user->birthdate)->toSpan('date', 'ago', 'utc'); ?> </span>
+				<span> <?php echo !empty($user->birthdate) ? KunenaDate::getInstance($user->birthdate)->toSpan('date', 'ago', 'utc') : ''; ?> </span>
 			</li>
 			<?php echo $this->subLayout('Widget/Module')->set('position', 'kunena_profile_horizontal'); ?>
 			<?php echo $this->subLayout('Widget/Module')->set('position', 'kunena_profile_horizontal_' . $user->userid); ?>


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
 
Fix the following error on birthday date with Php 8.1 and profile displayed as bottom position : Deprecated: DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in \libraries\src\Date\Date.php on line 126

#### Testing Instructions