### PR TITLE
Change: refactor svg icons to load locally instead of remote

### DIFF
--- a/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
+++ b/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
@@ -44,23 +44,23 @@ class KunenaSvgIcons
 
 		if ($group == 'default')
 		{
-				$file = JPATH_SITE . '/media/kunena/core/svg/' . $svgname;
+			$file = JPATH_SITE . '/media/kunena/core/svg/' . $svgname;
 		}
 		elseif ($group == 'social')
 		{
-				$file = JPATH_SITE . '/media/kunena/core/images/social/' . $svgname;
+			$file = JPATH_SITE . '/media/kunena/core/images/social/' . $svgname;
 		}
 		elseif ($group == 'systemtopicIcons')
 		{
-				$file = JPATH_SITE . '/media/kunena/core/svg/' . $iconset . '/system/' . $svgname;
+			$file = JPATH_SITE . '/media/kunena/core/svg/' . $iconset . '/system/' . $svgname;
 		}
 		elseif ($group == 'usertopicIcons')
 		{
-				$file = JPATH_SITE . '/media/kunena/core/svg/' . $iconset . '/user/' . $svgname;
+			$file = JPATH_SITE . '/media/kunena/core/svg/' . $iconset . '/user/' . $svgname;
 		}
 		else
 		{
-				$file = JPATH_SITE . '/' . $group . $svgname;
+			$file = JPATH_SITE . '/' . $group . $svgname;
 		}
 
 		$svg = file_get_contents($file . '.svg');

--- a/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
+++ b/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
@@ -44,35 +44,36 @@ class KunenaSvgIcons
 
 		if ($group == 'default')
 		{
-			$file = Uri::root() . 'media/kunena/core/svg/' . $svgname;
+				$file = JPATH_SITE . '/media/kunena/core/svg/' . $svgname;
 		}
 		elseif ($group == 'social')
 		{
-			$file = Uri::root() . 'media/kunena/core/images/social/' . $svgname;
+				$file = JPATH_SITE . '/media/kunena/core/images/social/' . $svgname;
 		}
 		elseif ($group == 'systemtopicIcons')
 		{
-			$file = Uri::root() . 'media/kunena/core/svg/' . $iconset . '/system/' . $svgname;
+				$file = JPATH_SITE . '/media/kunena/core/svg/' . $iconset . '/system/' . $svgname;
 		}
 		elseif ($group == 'usertopicIcons')
 		{
-			$file = Uri::root() . 'media/kunena/core/svg/' . $iconset . '/user/' . $svgname;
+				$file = JPATH_SITE . '/media/kunena/core/svg/' . $iconset . '/user/' . $svgname;
 		}
 		else
 		{
-			$file = Uri::root() . $group . $svgname;
+				$file = JPATH_SITE . '/' . $group . $svgname;
 		}
 
-		$iconfile = new DOMDocument;
-		$opts     = [
-			'http' => [
-				'user_agent' => 'PHP libxml agent',
-			],
-		];
-		$context  = stream_context_create($opts);
-		libxml_set_streams_context($context);
-		$iconfile->load($file . '.svg');
+		$svg = file_get_contents($file . '.svg');
 
-		return $iconfile->saveHTML($iconfile->getElementsByTagName('svg')[0]);
+		if ($svg)
+		{
+			$iconfile = new DOMDocument;
+			$iconfile->load($file . '.svg');
+
+			return $iconfile->saveHTML($iconfile->getElementsByTagName('svg')[0]);
+		}
+		else {
+			return '';
+		}
 	}
 }

--- a/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
+++ b/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
@@ -63,13 +63,10 @@ class KunenaSvgIcons
 			$file = JPATH_SITE . '/' . $group . $svgname;
 		}
 
-		$svg = file_get_contents($file . '.svg');
+		$iconfile = new DOMDocument;
 
-		if ($svg)
+		if ($iconfile->load($file . '.svg'))
 		{
-			$iconfile = new DOMDocument;
-			$iconfile->load($file . '.svg');
-
 			return $iconfile->saveHTML($iconfile->getElementsByTagName('svg')[0]);
 		}
 		else {


### PR DESCRIPTION
Pull Request for Issue
svg icons are stored locally but are always fetch via a remote lookup (https://domain/...)
This has a performance impact and also will give errors when e.g. the site is not properly secured (e.g. localhost that cannot have ssl certificate)
 
#### Summary of Changes 
 this PR will load the svg icons via a simple (local) file read.

#### Testing Instructions
install PR and see if all icons are still shown in several views