### PR TITLE
Dropdown buttons

### DIFF
--- a/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
+++ b/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
@@ -133,7 +133,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'message',
 					'communication',
 					'reply',
-					false,
+					true,
 					KunenaIcons::pencil()
 				)
 			);
@@ -162,7 +162,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'message',
 						'communication',
 						"kreply{$mesid}",
-						false,
+						true,
 						KunenaIcons::pencil()
 					)
 				);
@@ -190,7 +190,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'message',
 					'communication',
 					'quote',
-					false,
+					true,
 					KunenaIcons::quote()
 				)
 			);
@@ -252,7 +252,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'message',
 						'user',
 						'thankyou',
-						false,
+						true,
 						KunenaIcons::poll_add()
 					)
 				);
@@ -287,7 +287,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'message',
 						'user',
 						'unthankyou',
-						false,
+						true,
 						KunenaIcons::poll_rem()
 					)
 				);
@@ -322,7 +322,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'message',
 						'user',
 						'btn_report',
-						false,
+						true,
 						KunenaIcons::report()
 					)
 				);
@@ -360,7 +360,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'message',
 					'moderation',
 					'edit',
-					false,
+					true,
 					KunenaIcons::edit()
 				)
 			);
@@ -390,7 +390,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'message',
 					'moderation',
 					'edit',
-					false,
+					true,
 					KunenaIcons::shield()
 				)
 			);
@@ -422,7 +422,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'message',
 						'moderation',
 						'approve',
-						false,
+						true,
 						KunenaIcons::check()
 					)
 				);
@@ -450,7 +450,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'message',
 					'moderation',
 					'delete',
-					false,
+					true,
 					KunenaIcons::delete()
 				)
 			);
@@ -481,7 +481,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'message',
 						'moderation',
 						'undelete',
-						false,
+						true,
 						KunenaIcons::back()
 					)
 				);
@@ -511,7 +511,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'message',
 						'moderation',
 						'permdelete',
-						false,
+						true,
 						KunenaIcons::delete()
 					)
 				);
@@ -541,7 +541,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'message',
 					'moderation',
 					'delete',
-					false,
+					true,
 					KunenaIcons::delete()
 				)
 			);

--- a/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
+++ b/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
@@ -124,6 +124,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 				)
 			);
 
+			// Dropdown Item version
+			$this->messageButtons->set(
+				'reply_dropdown',
+				$this->getButton(
+					sprintf($layout, 'reply'),
+					'reply',
+					'message',
+					'communication',
+					'reply',
+					false,
+					KunenaIcons::pencil()
+				)
+			);
+
 			if ($me->exists() && $this->config->quickReply)
 			{
 				$this->messageButtons->set(
@@ -138,6 +152,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						KunenaIcons::pencil()
 					)
 				);
+
+				// Dropdown Item version
+				$this->messageButtons->set(
+					'quickReply_dropdown',
+					$this->getButton(
+						sprintf($layout, 'reply'),
+						'quickReply',
+						'message',
+						'communication',
+						"kreply{$mesid}",
+						false,
+						KunenaIcons::pencil()
+					)
+				);
 			}
 
 			$this->messageButtons->set(
@@ -149,6 +177,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'communication',
 					'quote',
 					$button,
+					KunenaIcons::quote()
+				)
+			);
+
+			// Dropdown Item version
+			$this->messageButtons->set(
+				'quote_dropdown',
+				$this->getButton(
+					sprintf($layout, 'reply&quote=1'),
+					'quote',
+					'message',
+					'communication',
+					'quote',
+					false,
 					KunenaIcons::quote()
 				)
 			);
@@ -200,6 +242,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						KunenaIcons::poll_add()
 					)
 				);
+
+				// Dropdown Item version
+				$this->messageButtons->set(
+						'thankyou_dropdown',
+					$this->getButton(
+						sprintf($task, 'thankyou'),
+						'thankyou',
+						'message',
+						'user',
+						'thankyou',
+						false,
+						KunenaIcons::poll_add()
+					)
+				);
 			}
 		}
 
@@ -221,6 +277,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						KunenaIcons::poll_rem()
 					)
 				);
+
+				// Dropdown Item version
+				$this->messageButtons->set(
+					'unthankyou_dropdown',
+					$this->getButton(
+						sprintf($task, 'unthankyou&userid=' . $me->userid),
+						'unthankyou',
+						'message',
+						'user',
+						'unthankyou',
+						false,
+						KunenaIcons::poll_rem()
+					)
+				);
 			}
 		}
 
@@ -239,6 +309,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'user',
 						'btn_report',
 						$button,
+						KunenaIcons::report()
+					)
+				);
+
+				// Dropdown Item version
+				$this->messageButtons->set(
+					'report_dropdown',
+					$this->getButton(
+						sprintf($layout, '#report' . $mesid . ''),
+						'report',
+						'message',
+						'user',
+						'btn_report',
+						false,
 						KunenaIcons::report()
 					)
 				);
@@ -266,6 +350,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					KunenaIcons::edit()
 				)
 			);
+
+			// Dropdown Item version
+			$this->messageButtons->set(
+				'edit_dropdown',
+				$this->getButton(
+					sprintf($layout, 'edit'),
+					'edit',
+					'message',
+					'moderation',
+					'edit',
+					false,
+					KunenaIcons::edit()
+				)
+			);
 		}
 
 		if ($this->message->isAuthorised('move'))
@@ -279,6 +377,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'moderation',
 					'edit',
 					$button,
+					KunenaIcons::shield()
+				)
+			);
+
+			// Dropdown Item version
+			$this->messageButtons->set(
+				'moderate_dropdown',
+				$this->getButton(
+					sprintf($layout, 'moderate'),
+					'moderate',
+					'message',
+					'moderation',
+					'edit',
+					false,
 					KunenaIcons::shield()
 				)
 			);
@@ -300,6 +412,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						KunenaIcons::check()
 					)
 				);
+
+				// Dropdown Item version
+				$this->messageButtons->set(
+					'publish_dropdown',
+					$this->getButton(
+						sprintf($task, 'approve'),
+						'approve',
+						'message',
+						'moderation',
+						'approve',
+						false,
+						KunenaIcons::check()
+					)
+				);
 			}
 
 			$this->messageButtons->set(
@@ -310,7 +436,21 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'message',
 					'moderation',
 					'delete',
-					'',
+					$button,
+					KunenaIcons::delete()
+				)
+			);
+
+			// Dropdown Item version
+			$this->messageButtons->set(
+				'delete_dropdown',
+				$this->getButton(
+					sprintf($task, 'delete'),
+					'delete',
+					'message',
+					'moderation',
+					'delete',
+					false,
 					KunenaIcons::delete()
 				)
 			);
@@ -331,6 +471,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						KunenaIcons::back()
 					)
 				);
+
+				// Dropdown Item version
+				$this->messageButtons->set(
+					'undelete_dropdown',
+					$this->getButton(
+						sprintf($task, 'undelete'),
+						'undelete',
+						'message',
+						'moderation',
+						'undelete',
+						false,
+						KunenaIcons::back()
+					)
+				);
 			}
 
 			if ($this->message->getTopic()->isAuthorised('permdelete'))
@@ -347,6 +501,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						KunenaIcons::delete()
 					)
 				);
+
+				// Dropdown Item version
+				$this->messageButtons->set(
+					'permdelete_dropdown',
+					$this->getButton(
+						sprintf($task, 'permdelete'),
+						'permdelete',
+						'message',
+						'moderation',
+						'permdelete',
+						false,
+						KunenaIcons::delete()
+					)
+				);
 			}
 		}
 		elseif ($this->message->isAuthorised('delete'))
@@ -360,6 +528,20 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 					'moderation',
 					'delete',
 					$button,
+					KunenaIcons::delete()
+				)
+			);
+
+			// Dropdown Item version
+			$this->messageButtons->set(
+				'delete_dropdown',
+				$this->getButton(
+					sprintf($task, 'delete'),
+					'delete',
+					'message',
+					'moderation',
+					'delete',
+					false,
 					KunenaIcons::delete()
 				)
 			);

--- a/src/site/src/Controller/Topic/Item/Actions/TopicItemActionsDisplay.php
+++ b/src/site/src/Controller/Topic/Item/Actions/TopicItemActionsDisplay.php
@@ -182,7 +182,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			// Dropdown Item version
 			$this->topicButtons->set(
 				'lock_dropdown',
-				$this->getButton(sprintf($task, $lock), $lock, 'topic', 'moderation', false, ftruealse, KunenaIcons::lock())
+				$this->getButton(sprintf($task, $lock), $lock, 'topic', 'moderation', false, true, KunenaIcons::lock())
 			);
 
 			$this->topicButtons->set(

--- a/src/site/src/Controller/Topic/Item/Actions/TopicItemActionsDisplay.php
+++ b/src/site/src/Controller/Topic/Item/Actions/TopicItemActionsDisplay.php
@@ -95,6 +95,12 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 				'reply',
 				$this->getButton(sprintf($layout, 'reply'), 'reply', 'topic', 'communication', false, $button, KunenaIcons::undo())
 			);
+
+			// Dropdown Item version
+			$this->topicButtons->set(
+				'reply_dropdown',
+				$this->getButton(sprintf($layout, 'reply'), 'reply', 'topic', 'communication', false, false, KunenaIcons::undo())
+			);
 		}
 
 		if ($userTopic->subscribed)
@@ -104,6 +110,11 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 				'subscribe',
 				$this->getButton(sprintf($task, 'unsubscribe'), 'unsubscribe', 'topic', 'user', false, $button, KunenaIcons::emailOpen())
 			);
+			// Dropdown Item version
+			$this->topicButtons->set(
+				'subscribe_dropdown',
+				$this->getButton(sprintf($task, 'unsubscribe'), 'unsubscribe', 'topic', 'user', false, false, KunenaIcons::emailOpen())
+			);
 		}
 		elseif ($this->topic->isAuthorised('subscribe'))
 		{
@@ -111,6 +122,11 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			$this->topicButtons->set(
 				'subscribe',
 				$this->getButton(sprintf($task, 'subscribe'), 'subscribe', 'topic', 'user', false, $button, KunenaIcons::email())
+			);
+			// Dropdown Item version
+			$this->topicButtons->set(
+				'subscribe_dropdown',
+				$this->getButton(sprintf($task, 'subscribe'), 'subscribe', 'topic', 'user', false, false, KunenaIcons::email())
 			);
 		}
 
@@ -121,6 +137,11 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 				'favorite',
 				$this->getButton(sprintf($task, 'unfavorite'), 'unfavorite', 'topic', 'user', false, $button, KunenaIcons::star())
 			);
+			// Dropdown Item version
+			$this->topicButtons->set(
+				'favorite_dropdown',
+				$this->getButton(sprintf($task, 'unfavorite'), 'unfavorite', 'topic', 'user', false, false, KunenaIcons::star())
+			);
 		}
 		elseif ($this->topic->isAuthorised('favorite'))
 		{
@@ -128,6 +149,11 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			$this->topicButtons->set(
 				'favorite',
 				$this->getButton(sprintf($task, 'favorite'), 'favorite', 'topic', 'user', false, $button, KunenaIcons::starOpen())
+			);
+			// Dropdown Item version
+			$this->topicButtons->set(
+				'favorite_dropdown',
+				$this->getButton(sprintf($task, 'favorite'), 'favorite', 'topic', 'user', false, false, KunenaIcons::starOpen())
 			);
 		}
 
@@ -142,14 +168,32 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 				$this->getButton(sprintf($task, $sticky), $sticky, 'topic', 'moderation', false, $button, KunenaIcons::sticky())
 			);
 
+			// Dropdown Item version
+			$this->topicButtons->set(
+				'sticky_dropdown',
+				$this->getButton(sprintf($task, $sticky), $sticky, 'topic', 'moderation', false, false, KunenaIcons::sticky())
+			);
+			
 			$this->topicButtons->set(
 				'lock',
 				$this->getButton(sprintf($task, $lock), $lock, 'topic', 'moderation', false, $button, KunenaIcons::lock())
 			);
 
+			// Dropdown Item version
+			$this->topicButtons->set(
+				'lock_dropdown',
+				$this->getButton(sprintf($task, $lock), $lock, 'topic', 'moderation', false, false, KunenaIcons::lock())
+			);
+
 			$this->topicButtons->set(
 				'moderate',
 				$this->getButton(sprintf($layout, 'moderate'), 'moderate', 'topic', 'moderation', false, $button, KunenaIcons::shield())
+			);
+
+			// Dropdown Item version
+			$this->topicButtons->set(
+				'moderate_dropdown',
+				$this->getButton(sprintf($layout, 'moderate'), 'moderate', 'topic', 'moderation', false, false, KunenaIcons::shield())
 			);
 
 			if ($this->topic->hold == 1)
@@ -158,6 +202,12 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 					'approve',
 					$this->getButton(sprintf($task, 'approve'), 'moderate', 'topic', 'moderation', false, $button, KunenaIcons::poll_add())
 				);
+
+				// Dropdown Item version
+				$this->topicButtons->set(
+					'approve_dropdown',
+					$this->getButton(sprintf($task, 'approve'), 'moderate', 'topic', 'moderation', false, false, KunenaIcons::poll_add())
+				);
 			}
 
 			if ($this->topic->hold == 1 || $this->topic->hold == 0)
@@ -165,6 +215,12 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 				$this->topicButtons->set(
 					'delete',
 					$this->getButton(sprintf($task, 'delete'), 'delete', 'topic', 'moderation', false, $button, KunenaIcons::delete())
+				);
+
+				// Dropdown Item version
+				$this->topicButtons->set(
+					'delete_dropdown',
+					$this->getButton(sprintf($task, 'delete'), 'delete', 'topic', 'moderation', false, false, KunenaIcons::delete())
 				);
 			}
 			elseif ($this->topic->hold == 2 || $this->topic->hold == 3)
@@ -175,6 +231,12 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 						'permdelete',
 						$this->getButton(sprintf($task, 'permdelete'), 'permdelete', 'topic', 'moderation', false, $button)
 					);
+
+					// Dropdown Item version
+					$this->topicButtons->set(
+						'permdelete_dropdown',
+						$this->getButton(sprintf($task, 'permdelete'), 'permdelete', 'topic', 'moderation', false, false)
+					);
 				}
 
 				if ($this->topic->isAuthorised('undelete'))
@@ -182,6 +244,12 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 					$this->topicButtons->set(
 						'undelete',
 						$this->getButton(sprintf($task, 'undelete'), 'undelete', 'topic', 'moderation', false, $button)
+					);
+
+					// Dropdown Item version
+					$this->topicButtons->set(
+						'undelete_dropdown',
+						$this->getButton(sprintf($task, 'undelete'), 'undelete', 'topic', 'moderation', false, false)
 					);
 				}
 			}

--- a/src/site/src/Controller/Topic/Item/Actions/TopicItemActionsDisplay.php
+++ b/src/site/src/Controller/Topic/Item/Actions/TopicItemActionsDisplay.php
@@ -99,7 +99,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			// Dropdown Item version
 			$this->topicButtons->set(
 				'reply_dropdown',
-				$this->getButton(sprintf($layout, 'reply'), 'reply', 'topic', 'communication', false, false, KunenaIcons::undo())
+				$this->getButton(sprintf($layout, 'reply'), 'reply', 'topic', 'communication', false, true, KunenaIcons::undo())
 			);
 		}
 
@@ -113,7 +113,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			// Dropdown Item version
 			$this->topicButtons->set(
 				'subscribe_dropdown',
-				$this->getButton(sprintf($task, 'unsubscribe'), 'unsubscribe', 'topic', 'user', false, false, KunenaIcons::emailOpen())
+				$this->getButton(sprintf($task, 'unsubscribe'), 'unsubscribe', 'topic', 'user', false, true, KunenaIcons::emailOpen())
 			);
 		}
 		elseif ($this->topic->isAuthorised('subscribe'))
@@ -126,7 +126,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			// Dropdown Item version
 			$this->topicButtons->set(
 				'subscribe_dropdown',
-				$this->getButton(sprintf($task, 'subscribe'), 'subscribe', 'topic', 'user', false, false, KunenaIcons::email())
+				$this->getButton(sprintf($task, 'subscribe'), 'subscribe', 'topic', 'user', false, true, KunenaIcons::email())
 			);
 		}
 
@@ -140,7 +140,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			// Dropdown Item version
 			$this->topicButtons->set(
 				'favorite_dropdown',
-				$this->getButton(sprintf($task, 'unfavorite'), 'unfavorite', 'topic', 'user', false, false, KunenaIcons::star())
+				$this->getButton(sprintf($task, 'unfavorite'), 'unfavorite', 'topic', 'user', false, true, KunenaIcons::star())
 			);
 		}
 		elseif ($this->topic->isAuthorised('favorite'))
@@ -153,7 +153,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			// Dropdown Item version
 			$this->topicButtons->set(
 				'favorite_dropdown',
-				$this->getButton(sprintf($task, 'favorite'), 'favorite', 'topic', 'user', false, false, KunenaIcons::starOpen())
+				$this->getButton(sprintf($task, 'favorite'), 'favorite', 'topic', 'user', false, true, KunenaIcons::starOpen())
 			);
 		}
 
@@ -171,7 +171,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			// Dropdown Item version
 			$this->topicButtons->set(
 				'sticky_dropdown',
-				$this->getButton(sprintf($task, $sticky), $sticky, 'topic', 'moderation', false, false, KunenaIcons::sticky())
+				$this->getButton(sprintf($task, $sticky), $sticky, 'topic', 'moderation', false, true, KunenaIcons::sticky())
 			);
 			
 			$this->topicButtons->set(
@@ -182,7 +182,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			// Dropdown Item version
 			$this->topicButtons->set(
 				'lock_dropdown',
-				$this->getButton(sprintf($task, $lock), $lock, 'topic', 'moderation', false, false, KunenaIcons::lock())
+				$this->getButton(sprintf($task, $lock), $lock, 'topic', 'moderation', false, ftruealse, KunenaIcons::lock())
 			);
 
 			$this->topicButtons->set(
@@ -193,7 +193,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 			// Dropdown Item version
 			$this->topicButtons->set(
 				'moderate_dropdown',
-				$this->getButton(sprintf($layout, 'moderate'), 'moderate', 'topic', 'moderation', false, false, KunenaIcons::shield())
+				$this->getButton(sprintf($layout, 'moderate'), 'moderate', 'topic', 'moderation', false, true, KunenaIcons::shield())
 			);
 
 			if ($this->topic->hold == 1)
@@ -206,7 +206,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 				// Dropdown Item version
 				$this->topicButtons->set(
 					'approve_dropdown',
-					$this->getButton(sprintf($task, 'approve'), 'moderate', 'topic', 'moderation', false, false, KunenaIcons::poll_add())
+					$this->getButton(sprintf($task, 'approve'), 'moderate', 'topic', 'moderation', false, true, KunenaIcons::poll_add())
 				);
 			}
 
@@ -220,7 +220,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 				// Dropdown Item version
 				$this->topicButtons->set(
 					'delete_dropdown',
-					$this->getButton(sprintf($task, 'delete'), 'delete', 'topic', 'moderation', false, false, KunenaIcons::delete())
+					$this->getButton(sprintf($task, 'delete'), 'delete', 'topic', 'moderation', false, true, KunenaIcons::delete())
 				);
 			}
 			elseif ($this->topic->hold == 2 || $this->topic->hold == 3)
@@ -235,7 +235,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 					// Dropdown Item version
 					$this->topicButtons->set(
 						'permdelete_dropdown',
-						$this->getButton(sprintf($task, 'permdelete'), 'permdelete', 'topic', 'moderation', false, false)
+						$this->getButton(sprintf($task, 'permdelete'), 'permdelete', 'topic', 'moderation', false, true)
 					);
 				}
 
@@ -249,7 +249,7 @@ class TopicItemActionsDisplay extends KunenaControllerDisplay
 					// Dropdown Item version
 					$this->topicButtons->set(
 						'undelete_dropdown',
-						$this->getButton(sprintf($task, 'undelete'), 'undelete', 'topic', 'moderation', false, false)
+						$this->getButton(sprintf($task, 'undelete'), 'undelete', 'topic', 'moderation', false, true)
 					);
 				}
 			}

--- a/src/site/template/aurelia/layouts/message/item/actions/default.php
+++ b/src/site/template/aurelia/layouts/message/item/actions/default.php
@@ -109,12 +109,12 @@ endif; ?>
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu">
-                    <li><?php echo $this->messageButtons->get('reply'); ?></li>
-                    <li><?php echo $this->messageButtons->get('quote'); ?></li>
-                    <li><?php echo $this->messageButtons->get('edit'); ?></li>
+                    <li><?php echo $this->messageButtons->get('reply_dropdown'); ?></li>
+                    <li><?php echo $this->messageButtons->get('quote_dropdown'); ?></li>
+                    <li><?php echo $this->messageButtons->get('edit_dropdown'); ?></li>
 					<?php
 					if ($config->userDeleteMessage > 0) : ?>
-                        <li><?php echo $this->messageButtons->get('delete'); ?></li>
+                        <li><?php echo $this->messageButtons->get('delete_dropdown'); ?></li>
 					<?php endif; ?>
                 </ul>
             </div>
@@ -128,12 +128,12 @@ endif; ?>
                         <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu">
-                        <li><?php echo $this->messageButtons->get('moderate'); ?></li>
-                        <li><?php echo $this->messageButtons->get('delete'); ?></li>
-                        <li><?php echo $this->messageButtons->get('undelete'); ?></li>
-                        <li><?php echo $this->messageButtons->get('permdelete'); ?></li>
-                        <li><?php echo $this->messageButtons->get('publish'); ?></li>
-                        <li><?php echo $this->messageButtons->get('spam'); ?></li>
+                        <li><?php echo $this->messageButtons->get('moderate_dropdown'); ?></li>
+                        <li><?php echo $this->messageButtons->get('delete_dropdown'); ?></li>
+                        <li><?php echo $this->messageButtons->get('undelete_dropdown'); ?></li>
+                        <li><?php echo $this->messageButtons->get('permdelete_dropdown'); ?></li>
+                        <li><?php echo $this->messageButtons->get('publish_dropdown'); ?></li>
+                        <li><?php echo $this->messageButtons->get('spam_dropdown'); ?></li>
                     </ul>
                 </div>
 			<?php endif; ?>

--- a/src/site/template/aurelia/layouts/topic/item/actions/default.php
+++ b/src/site/template/aurelia/layouts/topic/item/actions/default.php
@@ -47,12 +47,12 @@ $fullactions     = $this->ktemplate->params->get('fullactions');
 					<span class="caret"></span>
 				</a>
 				<ul class="dropdown-menu">
-					<li><?php echo $this->topicButtons->get('delete') ?></li>
-					<li><?php echo $this->topicButtons->get('permdelete') ?></li>
-					<li><?php echo $this->topicButtons->get('undelete') ?></li>
-					<li><?php echo $this->topicButtons->get('moderate') ?></li>
-					<li><?php echo $this->topicButtons->get('sticky') ?></li>
-					<li><?php echo $this->topicButtons->get('lock') ?></li>
+					<li><?php echo $this->topicButtons->get('delete_dropdown') ?></li>
+					<li><?php echo $this->topicButtons->get('permdelete_dropdown') ?></li>
+					<li><?php echo $this->topicButtons->get('undelete_dropdown') ?></li>
+					<li><?php echo $this->topicButtons->get('moderate_dropdown') ?></li>
+					<li><?php echo $this->topicButtons->get('sticky_dropdown') ?></li>
+					<li><?php echo $this->topicButtons->get('lock_dropdown') ?></li>
 				</ul>
 			</div>
 		<?php endif ?>
@@ -75,9 +75,9 @@ $fullactions     = $this->ktemplate->params->get('fullactions');
 						<span class="caret"></span>
 					</a>
 					<ul class="dropdown-menu">
-						<li><?php echo $this->topicButtons->get('reply') ?></li>
-						<li><?php echo $this->topicButtons->get('subscribe') ?></li>
-						<li><?php echo $this->topicButtons->get('favorite') ?></li>
+						<li><?php echo $this->topicButtons->get('reply_dropdown') ?></li>
+						<li><?php echo $this->topicButtons->get('subscribe_dropdown') ?></li>
+						<li><?php echo $this->topicButtons->get('favorite_dropdown') ?></li>
 					</ul>
 				</div>
 			<?php endif ?>
@@ -97,12 +97,12 @@ $fullactions     = $this->ktemplate->params->get('fullactions');
 						<span class="caret"></span>
 					</a>
 					<ul class="dropdown-menu">
-						<li><?php echo $this->topicButtons->get('delete') ?></li>
-						<li><?php echo $this->topicButtons->get('permdelete') ?></li>
-						<li><?php echo $this->topicButtons->get('undelete') ?></li>
-						<li><?php echo $this->topicButtons->get('moderate') ?></li>
-						<li><?php echo $this->topicButtons->get('sticky') ?></li>
-						<li><?php echo $this->topicButtons->get('lock') ?></li>
+						<li><?php echo $this->topicButtons->get('delete_dropdown') ?></li>
+						<li><?php echo $this->topicButtons->get('permdelete_dropdown') ?></li>
+						<li><?php echo $this->topicButtons->get('undelete_dropdown') ?></li>
+						<li><?php echo $this->topicButtons->get('moderate_dropdown') ?></li>
+						<li><?php echo $this->topicButtons->get('sticky_dropdown') ?></li>
+						<li><?php echo $this->topicButtons->get('lock_dropdown') ?></li>
 					</ul>
 				</div>
 			<?php endif ?>


### PR DESCRIPTION
Pull Request for Issue #8990 . 
 
#### Summary of Changes 
added dropdown versions of buttons (message and topic). This was needed because of the use of a registry for the buttons > you cannot pass parameters when getting a value.
 
#### Testing Instructions
test with both show default actions on and off
in both cases, buttons should look like buttons and the items in the dropdown should look like dropdown items.
Before this PR the dropdown itmes looked like buttons