### PR TITLE
Refactor closable alerts to BS5 syntax

### DIFF
--- a/src/site/template/aurelia/layouts/category/item/default.php
+++ b/src/site/template/aurelia/layouts/category/item/default.php
@@ -28,9 +28,9 @@ $this->addStyleSheet('rating.css');
 <?php if ($this->category->headerdesc) : ?>
     <div class="clearfix"></div>
     <br>
-    <h1 class="alert alert-info shadow-lg rounded">
-        <a class="close" data-bs-dismiss="alert" href="#"></a>
+    <h1 class="alert alert-info shadow-lg rounded alert-dismissible fade show">
 		<?php echo $this->category->displayField('headerdesc'); ?>
+		<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </h1>
 <?php endif; ?>
 

--- a/src/site/template/aurelia/layouts/topic/item/default.php
+++ b/src/site/template/aurelia/layouts/topic/item/default.php
@@ -56,9 +56,9 @@ if ($this->topic->locked)
 ?>
 <div class="kunena-topic-item <?php echo $txt; ?>">
 	<?php if ($this->category->headerdesc) : ?>
-        <div class="alert alert-info shadow-lg rounded">
-            <a class="close" data-bs-dismiss="alert" href="#">&times;</a>
+        <div class="alert alert-info shadow-lg rounded alert-dismissible fade show">
 			<?php echo $this->category->displayField('headerdesc'); ?>
+			<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
 	<?php endif; ?>
 

--- a/src/site/template/aurelia/layouts/widget/announcement/default.php
+++ b/src/site/template/aurelia/layouts/widget/announcement/default.php
@@ -13,45 +13,39 @@
 defined('_JEXEC') or die();
 
 use Joomla\CMS\Language\Text;
-use Kunena\Forum\Libraries\Icons\KunenaIcons;
 use Kunena\Forum\Libraries\Route\KunenaRoute;
 
 ?>
 
-<div class="shadow-lg rounded" id="announcement<?php echo $this->announcement->id; ?>">
-    <div class="alert alert-info">
-        <div class="close float-end" data-bs-toggle="collapse"
-             data-bs-target="#announcement<?php echo $this->announcement->id; ?>">
-			<?php echo KunenaIcons::cancel(); ?>
-        </div>
-        <h5>
-            <a class="btn-link"
-               href="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=announcement&layout=listing'); ?>"
-               title="<?php echo Text::_('COM_KUNENA_VIEW_COMMON_ANNOUNCE_LIST') ?>">
-				<?php echo $this->announcement->displayField('title'); ?>
-            </a>
+<div class="alert alert-info shadow-lg rounded alert-dismissible fade show" id="announcement<?php echo $this->announcement->id; ?>">
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+	<h5>
+		<a class="btn-link"
+			href="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=announcement&layout=listing'); ?>"
+			title="<?php echo Text::_('COM_KUNENA_VIEW_COMMON_ANNOUNCE_LIST') ?>">
+			<?php echo $this->announcement->displayField('title'); ?>
+		</a>
 
-			<?php if ($this->announcement->showdate)
-				:
-				?>
-                <small>(<?php echo $this->announcement->displayField('created', 'date_today'); ?>)</small>
-			<?php endif; ?>
-        </h5>
-
-        <div>
-            <p><?php echo $this->announcement->displayField('sdescription'); ?></p>
-        </div>
-		<?php if (!empty($this->announcement->description))
+		<?php if ($this->announcement->showdate)
 			:
 			?>
-            <div>
-                <a class="btn-link"
-                   href="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=announcement&layout=default&id=' . $this->announcement->id); ?>"
-                   title="<?php echo $this->announcement->displayField('title') ?>">
-					<?php echo Text::_('COM_KUNENA_ANN_READMORE'); ?>
-                </a>
-            </div>
+			<small>(<?php echo $this->announcement->displayField('created', 'date_today'); ?>)</small>
 		<?php endif; ?>
-    </div>
+	</h5>
+
+	<div>
+		<p><?php echo $this->announcement->displayField('sdescription'); ?></p>
+	</div>
+	<?php if (!empty($this->announcement->description))
+		:
+		?>
+		<div>
+			<a class="btn-link"
+				href="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=announcement&layout=default&id=' . $this->announcement->id); ?>"
+				title="<?php echo $this->announcement->displayField('title') ?>">
+				<?php echo Text::_('COM_KUNENA_ANN_READMORE'); ?>
+			</a>
+		</div>
+	<?php endif; ?>
 </div>
 

--- a/src/site/template/aurelia/template.php
+++ b/src/site/template/aurelia/template.php
@@ -112,6 +112,7 @@ class KunenaTemplateAurelia extends KunenaTemplate
 			HTMLHelper::_('bootstrap.tooltip');
 			HTMLHelper::_('bootstrap.renderModal');
 			HTMLHelper::_('bootstrap.collapse');
+			HTMLHelper::_('bootstrap.alert');
 		}
 
 		$doc = Factory::getApplication()->getDocument();


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
refactored closable alerts to BS5

#### Testing Instructions
category description, topic headerdesc and announcements should display okay and conform BS5 alert. They should be closable via X button

Note: haven't tested announcement change myself