### PR TITLE
Change: remove hover effect on search input

### DIFF
--- a/src/site/template/aurelia/assets/scss/general.scss
+++ b/src/site/template/aurelia/assets/scss/general.scss
@@ -919,47 +919,47 @@ div.pagination a.disabled:hover {
   vertical-align: middle;
 }
 
-.search {
-  position: relative;
-  float: left;
-  width: 230px;
-  height: 30px;
-  padding: 5px 0;
-  line-height: 22px;
-}
+// .search {
+//   position: relative;
+//   float: left;
+//   width: 230px;
+//   height: 30px;
+//   padding: 5px 0;
+//   line-height: 22px;
+// }
 
-.kunena-search .search {
-  padding: 0;
-}
+// .kunena-search .search {
+//   padding: 0;
+// }
 
-.search input {
-  position: absolute;
-  float: Left;
-  width: 0;
-  height: 30px;
-  padding: 0 2px;
-  margin-left: 210px;
-  line-height: 18px;
-  border-radius: 1px;
-  transition: all .7s ease-in-out;
-}
+// .search input {
+//   position: absolute;
+//   float: Left;
+//   width: 0;
+//   height: 30px;
+//   padding: 0 2px;
+//   margin-left: 210px;
+//   line-height: 18px;
+//   border-radius: 1px;
+//   transition: all .7s ease-in-out;
+// }
 
-.search:hover input, .search input:focus {
-  width: 200px;
-  margin-left: 0;
-}
+// .search:hover input, .search input:focus {
+//   width: 200px;
+//   margin-left: 0;
+// }
 
-.search .btn {
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: 30px;
-  border-radius: 1px;
+// .search .btn {
+//   position: absolute;
+//   top: 0;
+//   right: 0;
+//   height: 30px;
+//   border-radius: 1px;
 
-  i {
-    margin-top: -3px;
-  }
-}
+//   i {
+//     margin-top: -3px;
+//   }
+// }
 
 .glyphicon-white {
   color: #fff;
@@ -977,12 +977,12 @@ div.pagination a.disabled:hover {
   padding-left: 0;
 }
 
-.form-control {
-  width: 100%;
-  max-width: 100%;
-  height: auto;
-  font-size: 15px;
-}
+// .form-control {
+//   width: 100%;
+//   max-width: 100%;
+//   height: auto;
+//   font-size: 15px;
+// }
 
 i {
   margin: 0;

--- a/src/site/template/aurelia/layouts/widget/search/topic.php
+++ b/src/site/template/aurelia/layouts/widget/search/topic.php
@@ -23,29 +23,23 @@ $childforums = (int) (!isset($this->childforums) || $this->childforums);
 ?>
 <div class="kunena-search search">
 	<form role="search" action="<?php echo KunenaRoute::_(); ?>" method="post">
-		<input type="hidden" name="view" value="search"/>
-		<input type="hidden" name="task" value="results"/>
-		<?php if (isset($this->catid))
-		:
-			?>
-			<input type="hidden" name="catids[]" value="<?php echo $this->catid; ?>"/>
+		<input type="hidden" name="view" value="search" />
+		<input type="hidden" name="task" value="results" />
+		<?php if (isset($this->catid)) :
+		?>
+			<input type="hidden" name="catids[]" value="<?php echo $this->catid; ?>" />
 		<?php endif; ?>
 
-		<?php if (isset($this->id))
-		:
-			?>
-			<input type="hidden" name="ids[]" value="<?php echo $this->id; ?>"/>
+		<?php if (isset($this->id)) :
+		?>
+			<input type="hidden" name="ids[]" value="<?php echo $this->id; ?>" />
 		<?php endif; ?>
 		<?php echo HTMLHelper::_('form.token'); ?>
 		<div class="input-group">
-			<label for="mod-search-searchword"></label>
-			<input name="query" class="form-control hasTooltip" id="mod-search-searchword" type="search" maxlength="64"
-				   placeholder="<?php echo Text::_('COM_KUNENA_MENU_SEARCH'); ?>" data-original-title="<?php echo Text::_('COM_KUNENA_WIDGET_SEARCH_INPUT_TOOLTIP'); ?>" />
-			<span class="input-group-append">
-				<button class="btn btn-light border" type="submit">
+			<input name="query" class="form-control hasTooltip" id="mod-search-searchword" type="search" maxlength="64" placeholder="<?php echo Text::_('COM_KUNENA_MENU_SEARCH'); ?>" data-original-title="<?php echo Text::_('COM_KUNENA_WIDGET_SEARCH_INPUT_TOOLTIP'); ?>" />
+			<button class="btn btn-outline-primary" type="submit">
 				<?php echo KunenaIcons::search(); ?>
 			</button>
-			</span>
 		</div>
 	</form>
 </div>

--- a/src/site/template/aurelia/layouts/widget/search/user.php
+++ b/src/site/template/aurelia/layouts/widget/search/user.php
@@ -23,26 +23,18 @@ $state = $this->state;
 ?>
 
 <div class="kunena-search">
-	<form action="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=user&layout=list'); ?>" method="post"
-		  name="usrlform" id="usrlform">
-		<input type="hidden" name="view" value="user"/>
-		<?php if ($me->exists())
-		:
-			?>
-			<input type="hidden" id="kurl_users" name="kurl_users"
-				   value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=user&layout=listmention&format=raw') ?>"/>
+	<form action="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=user&layout=list'); ?>" method="post" name="usrlform" id="usrlform">
+		<input type="hidden" name="view" value="user" />
+		<?php if ($me->exists()) :
+		?>
+			<input type="hidden" id="kurl_users" name="kurl_users" value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=user&layout=listmention&format=raw') ?>" />
 		<?php endif; ?>
 		<?php echo HTMLHelper::_('form.token'); ?>
 		<div class="input-group search">
-			<label for="kusersearch"></label>
-			<input id="kusersearch" class="form-control input-sm search-query" type="text" name="search"
-				   value="<?php echo !empty($state) ? $this->escape($state) : ''; ?>"
-				   placeholder="<?php echo Text::_('COM_KUNENA_USRL_SEARCH'); ?>"/>
-			<span class="input-group-append">
-					<button class="btn btn-light border" type="submit">
-						<?php echo KunenaIcons::search(); ?>
-					</button>
-				</span>
+			<input id="kusersearch" class="form-control input-sm search-query" type="text" name="search" value="<?php echo !empty($state) ? $this->escape($state) : ''; ?>" placeholder="<?php echo Text::_('COM_KUNENA_USRL_SEARCH'); ?>" />
+			<button class="btn btn-outline-primary" type="submit">
+				<?php echo KunenaIcons::search(); ?>
+			</button>
 		</div>
 	</form>
 </div>


### PR DESCRIPTION
Pull Request for Issue # . 
search input in topic / user is hidden by default and when search icon is hovered, the input is revealed.
This doesn't work on mobile as mobile devices cannot hover (they only have touch control). When touching the icon you are actually doing a submit and are reirected to the search form instead.
 
#### Summary of Changes 
This change refactored the search field and removes the hover effect.
css changes (only removals) are done via commenting out the relevant css code
 
#### Testing Instructions
after the change, the search field is displayed as any other field, test if search is still working.