### PR TITLE
(un)thankyou buttons are never used in actions

### DIFF
--- a/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
+++ b/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
@@ -238,7 +238,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'message',
 						'user',
 						'thankyou',
-						$button,
+						false,
 						KunenaIcons::poll_add()
 					)
 				);
@@ -273,7 +273,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 						'message',
 						'user',
 						'unthankyou',
-						$button,
+						false,
 						KunenaIcons::poll_rem()
 					)
 				);


### PR DESCRIPTION
Pull Request for Issue # 8990. 
 
#### Summary of Changes 
additional change to #8994 : thanksyou and unthankyou buttons should never toggle on actionbutton config parameter as these are always displayed as button and not as dropdownitem
 
#### Testing Instructions
login, go to topic / message for user. the thankyou button has class dropdown-item
after this change the button has no dropdown-item class. Both for action buttons or no action buttons