### PR TITLE
Success messages

### DIFF
--- a/src/admin/src/Controller/AttachmentsController.php
+++ b/src/admin/src/Controller/AttachmentsController.php
@@ -109,7 +109,7 @@ class AttachmentsController extends FormController
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_ATTACHMENTS_DELETED_SUCCESSFULLY'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_ATTACHMENTS_DELETED_SUCCESSFULLY'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 }

--- a/src/admin/src/Controller/CategoriesController.php
+++ b/src/admin/src/Controller/CategoriesController.php
@@ -139,7 +139,7 @@ class CategoriesController extends KunenaController
 				{
 					$this->app->enqueueMessage(
 						Text::sprintf('COM_KUNENA_A_CATEGORY_SAVE_FAILED', $category->id, $this->escape($category->getError())),
-						'notice'
+						'error'
 					);
 				}
 			}
@@ -154,12 +154,12 @@ class CategoriesController extends KunenaController
 
 		if ($count == 1 && $name)
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_SAVED', $this->escape($name)));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_SAVED', $this->escape($name)), 'success');
 		}
 
 		if ($count > 1)
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORIES_SAVED', $count));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORIES_SAVED', $count), 'success');
 		}
 	}
 
@@ -433,7 +433,7 @@ class CategoriesController extends KunenaController
 		{
 			if (!$category->isAuthorised('admin'))
 			{
-				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->name)), 'notice');
+				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->name)), 'error');
 			}
 			elseif (!$category->isCheckedOut($this->me->userid))
 			{
@@ -444,7 +444,7 @@ class CategoriesController extends KunenaController
 				}
 				else
 				{
-					$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_DELETE_FAILED', $this->escape($category->getError())), 'notice');
+					$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_DELETE_FAILED', $this->escape($category->getError())), 'error');
 				}
 			}
 			else
@@ -455,12 +455,12 @@ class CategoriesController extends KunenaController
 
 		if ($count == 1 && $name)
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_DELETED', $this->escape($name)));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_DELETED', $this->escape($name)), 'success');
 		}
 
 		if ($count > 1)
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORIES_DELETED', $count));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORIES_DELETED', $count), 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -494,7 +494,7 @@ class CategoriesController extends KunenaController
 
 		if (!$category->isAuthorised('admin'))
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->name)), 'notice');
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->name)), 'error');
 		}
 		elseif (!$category->isCheckedOut($this->me->userid))
 		{
@@ -555,7 +555,7 @@ class CategoriesController extends KunenaController
 
 			if (!$category->getParent()->tryAuthorise('admin'))
 			{
-				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->getParent()->name)), 'notice');
+				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->getParent()->name)), 'error');
 			}
 			elseif (!$category->isCheckedOut($this->me->userid))
 			{
@@ -566,7 +566,7 @@ class CategoriesController extends KunenaController
 				{
 					$this->app->enqueueMessage(
 						Text::sprintf('COM_KUNENA_A_CATEGORY_SAVE_FAILED', $category->id, $this->escape($category->getError())),
-						'notice'
+						'error'
 					);
 				}
 			}
@@ -581,7 +581,7 @@ class CategoriesController extends KunenaController
 
 		if ($success)
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_NEW_ORDERING_SAVED'));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_NEW_ORDERING_SAVED'), 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -690,7 +690,7 @@ class CategoriesController extends KunenaController
 
 		if (!$category->getParent()->tryAuthorise('admin'))
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->getParent()->name)), 'notice');
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->getParent()->name)), 'error');
 
 			return;
 		}
@@ -792,7 +792,7 @@ class CategoriesController extends KunenaController
 
 		if ($catParent == 0 || empty($cid))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_CATEGORIES_LABEL_BATCH_NOT_SELECTED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_CATEGORIES_LABEL_BATCH_NOT_SELECTED'), 'notice');
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 
 			return false;
@@ -816,14 +816,14 @@ class CategoriesController extends KunenaController
 					}
 					catch (RuntimeException $e)
 					{
-						$this->app->enqueueMessage($e->getMessage());
+						$this->app->enqueueMessage($e->getMessage(), 'error');
 
 						return false;
 					}
 				}
 			}
 
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_CATEGORIES_LABEL_BATCH_MOVE_SUCCESS'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_CATEGORIES_LABEL_BATCH_MOVE_SUCCESS'), 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));

--- a/src/admin/src/Controller/CategoryController.php
+++ b/src/admin/src/Controller/CategoryController.php
@@ -130,7 +130,7 @@ class CategoryController extends FormController
 
 		if (empty($post['name']))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_CATEGORY_MANAGER_PLEASE_SET_A_TITLE'), 'notice');
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_CATEGORY_MANAGER_PLEASE_SET_A_TITLE'), 'error');
 
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 
@@ -155,12 +155,12 @@ class CategoryController extends FormController
 		if ($category->exists() && !$category->isAuthorised('admin'))
 		{
 			// Category exists and user is not admin in category
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->name)), 'notice');
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($category->name)), 'error');
 		}
 		elseif (!$category->exists() && !$me->isAdmin($parent))
 		{
 			// Category doesn't exist and user is not admin in parent, parentid=0 needs global admin rights
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($parent->name)), 'notice');
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_NO_ADMIN', $this->escape($parent->name)), 'error');
 		}
 		elseif (!$category->isCheckedOut($me->userid))
 		{
@@ -236,7 +236,7 @@ class CategoryController extends FormController
 
 		if ($success)
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_SAVED', $this->escape($category->name)));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_CATEGORY_SAVED', $this->escape($category->name)), 'success');
 		}
 
 		if (!empty($post['rmmod']))
@@ -252,7 +252,7 @@ class CategoryController extends FormController
 							'COM_KUNENA_VIEW_CATEGORY_EDIT_MODERATOR_REMOVED',
 							$this->escape($user->getName()),
 							$this->escape($category->name)
-						)
+						), 'success'
 					);
 				}
 			}

--- a/src/admin/src/Controller/ConfigController.php
+++ b/src/admin/src/Controller/ConfigController.php
@@ -113,7 +113,7 @@ class ConfigController extends FormController
 				{
 					if (empty($postvalue))
 					{
-						$this->app->enqueueMessage(Text::_('COM_KUNENA_IMAGEWIDTH_IMAGEHEIGHT_EMPTY_CONFIG_NOT_SAVED'));
+						$this->app->enqueueMessage(Text::_('COM_KUNENA_IMAGEWIDTH_IMAGEHEIGHT_EMPTY_CONFIG_NOT_SAVED'), 'error');
 						$this->setRedirect(KunenaRoute::_($urlVar, false));
 
 						return;
@@ -138,7 +138,7 @@ class ConfigController extends FormController
 
 		KunenaFactory::loadLanguage('com_kunena.controllers', 'admin');
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_CONFIGSAVED'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_CONFIGSAVED'), 'success');
 
 		if ($this->task == 'apply')
 		{

--- a/src/admin/src/Controller/LogsController.php
+++ b/src/admin/src/Controller/LogsController.php
@@ -106,12 +106,12 @@ class LogsController extends FormController
 
 		if ($numRows > 0)
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_LOG_ENTRIES_DELETED', $numRows));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_LOG_ENTRIES_DELETED', $numRows), 'success');
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_LOG_ENTRIES_DELETED_NOTHING_TO_DELETE'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_LOG_ENTRIES_DELETED_NOTHING_TO_DELETE'), 'notice');
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 		}
 	}

--- a/src/admin/src/Controller/RanksController.php
+++ b/src/admin/src/Controller/RanksController.php
@@ -165,7 +165,7 @@ class RanksController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				$this->app->enqueueMessage($e->getMessage());
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
@@ -188,13 +188,13 @@ class RanksController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				$this->app->enqueueMessage($e->getMessage());
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_RANK_SAVED'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_RANK_SAVED'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -224,7 +224,7 @@ class RanksController extends FormController
 
 		if ($upload)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_RANKS_UPLOAD_SUCCESS'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_RANKS_UPLOAD_SUCCESS'), 'success');
 		}
 		else
 		{
@@ -275,13 +275,13 @@ class RanksController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				$this->app->enqueueMessage($e->getMessage());
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_RANK_DELETED'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_RANK_DELETED'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 

--- a/src/admin/src/Controller/SmiliesController.php
+++ b/src/admin/src/Controller/SmiliesController.php
@@ -156,7 +156,7 @@ class SmiliesController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				$this->app->enqueueMessage($e->getMessage());
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
@@ -178,13 +178,13 @@ class SmiliesController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				$this->app->enqueueMessage($e->getMessage());
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_SMILEY_SAVED'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_SMILEY_SAVED'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -214,7 +214,7 @@ class SmiliesController extends FormController
 
 		if ($upload)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_EMOTICONS_UPLOAD_SUCCESS'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_EMOTICONS_UPLOAD_SUCCESS'), 'success');
 		}
 		else
 		{
@@ -264,13 +264,13 @@ class SmiliesController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				$this->app->enqueueMessage($e->getMessage());
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_SMILEY_DELETED'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_SMILEY_DELETED'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 

--- a/src/admin/src/Controller/TemplateController.php
+++ b/src/admin/src/Controller/TemplateController.php
@@ -100,7 +100,7 @@ class TemplateController extends FormController
 		{
 			$this->app->enqueueMessage(
 				Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' .
-				Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED')
+				Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED'), 'error'
 			);
 
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -110,7 +110,7 @@ class TemplateController extends FormController
 
 		$this->internalSaveParamFile($template);
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_CONFIGURATION_SAVED'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_CONFIGURATION_SAVED'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -177,7 +177,7 @@ class TemplateController extends FormController
 
 			if (!$return)
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_FAILED_WRITE_FILE', $file));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_FAILED_WRITE_FILE', $file), 'error');
 				$this->app->redirect(KunenaRoute::_($this->baseurl, false));
 			}
 		}
@@ -552,7 +552,7 @@ class TemplateController extends FormController
 		{
 			$this->app->enqueueMessage(
 				Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' .
-				Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED')
+				Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED'), 'error'
 			);
 
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -562,7 +562,7 @@ class TemplateController extends FormController
 
 		$this->internalSaveParamFile($template);
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_CONFIGURATION_SAVED'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_CONFIGURATION_SAVED'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl . '&view=template&layout=edit&name=' . $template, false));
 	}
 
@@ -589,7 +589,7 @@ class TemplateController extends FormController
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_TEMPLATES_SETTINGS_RESTORED_SUCCESSFULLY'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_TEMPLATES_SETTINGS_RESTORED_SUCCESSFULLY'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -611,7 +611,7 @@ class TemplateController extends FormController
 
 		if (!$template)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED'), 'error');
 
 			return;
 		}
@@ -620,7 +620,7 @@ class TemplateController extends FormController
 
 		if (!is_dir($tBaseDir . '/' . $template))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_FOUND'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_FOUND'), 'error');
 
 			return;
 		}
@@ -730,7 +730,7 @@ class TemplateController extends FormController
 		$template = KunenaFactory::getTemplate($id);
 		$template->clearCache();
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_DEFAULT_SELECTED'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_DEFAULT_SELECTED'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -793,11 +793,11 @@ class TemplateController extends FormController
 
 			// Clear all cache, just in case.
 			KunenaCacheHelper::clearAll();
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_UNINSTALL_SUCCESS', $id));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_UNINSTALL_SUCCESS', $id), 'success');
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE') . ' ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_UNINSTALL') . ': ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_DIR_NOT_EXIST'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE') . ' ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_UNINSTALL') . ': ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_DIR_NOT_EXIST'), 'error');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));

--- a/src/admin/src/Controller/TemplatesController.php
+++ b/src/admin/src/Controller/TemplatesController.php
@@ -86,7 +86,7 @@ class TemplatesController extends FormController
 		{
 			$this->app->enqueueMessage(
 				Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_INSTALL_EXTRACT_MISSING', $this->escape($file['name'])),
-				'notice'
+				'error'
 			);
 			$result = false;
 		}
@@ -105,7 +105,7 @@ class TemplatesController extends FormController
 				{
 					$this->app->enqueueMessage(
 						Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_INSTALL_EXTRACT_FAILED', $this->escape($file['name'])),
-						'notice'
+						'error'
 					);
 					$result = false;
 				}
@@ -173,12 +173,12 @@ class TemplatesController extends FormController
 
 							if ($success !== true)
 							{
-								$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_INSTALL_FAILED', $template->directory), 'notice');
+								$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_INSTALL_FAILED', $template->directory), 'error');
 								$result = false;
 							}
 							else
 							{
-								$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_INSTALL_SUCCESS', $template->directory));
+								$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_INSTALL_SUCCESS', $template->directory), 'success');
 							}
 						}
 
@@ -264,7 +264,7 @@ class TemplatesController extends FormController
 
 		if (!$templatename)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED.'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED.'), 'error');
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 
 			return;
@@ -275,7 +275,7 @@ class TemplatesController extends FormController
 
 		if ($return)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_FILE_SAVED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_FILE_SAVED'), 'success');
 		}
 		else
 		{
@@ -316,7 +316,7 @@ class TemplatesController extends FormController
 		{
 			$this->app->enqueueMessage(
 				Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': '
-				. Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED.')
+				. Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED.'), 'error'
 			);
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 
@@ -328,14 +328,14 @@ class TemplatesController extends FormController
 
 		if ($return)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_FILE_SAVED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_FILE_SAVED'), 'success');
 			$this->setRedirect(KunenaRoute::_($this->baseurl . '&layout=chooseScss&id=' . $templatename, false));
 		}
 		else
 		{
 			$this->app->enqueueMessage(
 				Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': '
-				. Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_FAILED_OPEN_FILE.', $file)
+				. Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_FAILED_OPEN_FILE.', $file), 'error'
 			);
 			$this->setRedirect(KunenaRoute::_($this->baseurl . '&layout=chooseScss&id=' . $templatename, false));
 		}
@@ -359,7 +359,7 @@ class TemplatesController extends FormController
 
 		if (File::getExt($filename) !== 'css')
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_WRONG_CSS'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_WRONG_CSS'), 'error');
 			$this->setRedirect(KunenaRoute::_($this->baseurl . '&layout=chooseCss&id=' . $templatename, false));
 		}
 
@@ -395,7 +395,7 @@ class TemplatesController extends FormController
 
 		if (!$templatename)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED.'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED.'), 'error');
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 
 			return;
@@ -406,11 +406,11 @@ class TemplatesController extends FormController
 
 		if ($return)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_FILE_SAVED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_FILE_SAVED'), 'success');
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_FAILED_OPEN_FILE.', $file));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_FAILED_OPEN_FILE.', $file), 'error');
 		}
 	}
 
@@ -440,7 +440,7 @@ class TemplatesController extends FormController
 
 		if (!$templatename)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED.'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_TEMPLATE_NOT_SPECIFIED.'), 'error');
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 
 			return;
@@ -451,12 +451,12 @@ class TemplatesController extends FormController
 
 		if ($return)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_FILE_SAVED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_FILE_SAVED'), 'success');
 			$this->setRedirect(KunenaRoute::_($this->baseurl . "&layout=chooseCss", false));
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_FAILED_OPEN_FILE.', $file));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_TEMPLATE_MANAGER_OPERATION_FAILED') . ': ' . Text::sprintf('COM_KUNENA_A_TEMPLATE_MANAGER_FAILED_OPEN_FILE.', $file), 'error');
 			$this->setRedirect(KunenaRoute::_($this->baseurl . "&layout=chooseCss", false));
 		}
 	}

--- a/src/admin/src/Controller/ToolsController.php
+++ b/src/admin/src/Controller/ToolsController.php
@@ -226,14 +226,14 @@ class ToolsController extends FormController
 		{
 			Factory::getApplication()->enqueueMessage(
 				"" . Text::_('COM_KUNENA_FORUMPRUNEDFOR') . " " . $pruneDays . " "
-				. Text::_('COM_KUNENA_PRUNEDAYS') . "; " . Text::_('COM_KUNENA_PRUNEDELETED') . " {$count} " . Text::_('COM_KUNENA_PRUNETHREADS')
+				. Text::_('COM_KUNENA_PRUNEDAYS') . "; " . Text::_('COM_KUNENA_PRUNEDELETED') . " {$count} " . Text::_('COM_KUNENA_PRUNETHREADS'), 'success'
 			);
 		}
 		else
 		{
 			Factory::getApplication()->enqueueMessage(
 				"" . Text::_('COM_KUNENA_FORUMPRUNEDFOR') . " " . $pruneDays . " "
-				. Text::_('COM_KUNENA_PRUNEDAYS') . "; " . Text::_('COM_KUNENA_PRUNETRASHED') . " {$count} " . Text::_('COM_KUNENA_PRUNETHREADS')
+				. Text::_('COM_KUNENA_PRUNEDAYS') . "; " . Text::_('COM_KUNENA_PRUNETRASHED') . " {$count} " . Text::_('COM_KUNENA_PRUNETHREADS'), 'success'
 			);
 		}
 
@@ -286,12 +286,12 @@ class ToolsController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
 
-			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_ADD_DONE', $db->getAffectedRows()));
+			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_ADD_DONE', $db->getAffectedRows()), 'success');
 		}
 
 		if ($userDel)
@@ -312,12 +312,12 @@ class ToolsController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
 
-			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_DELETE_DONE', $db->getAffectedRows()));
+			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_DELETE_DONE', $db->getAffectedRows()), 'success');
 		}
 
 		if ($userDelLife)
@@ -335,7 +335,7 @@ class ToolsController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
@@ -352,12 +352,12 @@ class ToolsController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
 
-			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_DELETE_DONE', $db->getAffectedRows()));
+			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_DELETE_DONE', $db->getAffectedRows()), 'success');
 		}
 
 		if ($userRename)
@@ -378,15 +378,15 @@ class ToolsController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
 
-			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_RENAME_DONE', $db->getAffectedRows()));
+			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_RENAME_DONE', $db->getAffectedRows()), 'success');
 		}
 
-		Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_RENAME_DONE', $db->getAffectedRows()));
+		Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_SYNC_USERS_RENAME_DONE', $db->getAffectedRows()), 'success');
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
@@ -722,7 +722,7 @@ class ToolsController extends FormController
 		$installer->deleteMenu();
 		$installer->createMenu();
 
-		Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_MENU_CREATED'));
+		Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_MENU_CREATED'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -751,11 +751,11 @@ class ToolsController extends FormController
 
 		if ($errors)
 		{
-			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_MENU_FIXED_LEGACY_FAILED', $errors[0]), 'notice');
+			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_MENU_FIXED_LEGACY_FAILED', $errors[0]), 'error');
 		}
 		else
 		{
-			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_MENU_FIXED_LEGACY', \count($legacy)));
+			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_MENU_FIXED_LEGACY', \count($legacy)), 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -800,7 +800,7 @@ class ToolsController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
@@ -809,18 +809,18 @@ class ToolsController extends FormController
 
 			if ($count > 0)
 			{
-				Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_MENU_RE_PURGED', $count, $reString));
+				Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_MENU_RE_PURGED', $count, $reString), 'success');
 				$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 			}
 			else
 			{
-				Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_MENU_RE_PURGE_FAILED', $reString));
+				Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_MENU_RE_PURGE_FAILED', $reString), 'error');
 				$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 			}
 		}
 		else
 		{
-			Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_MENU_RE_PURGE_FORGOT_STATEMENT'));
+			Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_MENU_RE_PURGE_FORGOT_STATEMENT'), 'warning');
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 		}
 	}
@@ -875,7 +875,7 @@ class ToolsController extends FormController
 		}
 		catch (RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($e->getMessage());
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 			return;
 		}
@@ -898,22 +898,22 @@ class ToolsController extends FormController
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
 
-			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_TOOLS_CLEANUP_IP_USERS_DONE', $count));
+			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_TOOLS_CLEANUP_IP_USERS_DONE', $count), 'success');
 		}
 
 		if ($count > 0)
 		{
-			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_TOOLS_CLEANUP_IP_DONE', $count));
+			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_KUNENA_TOOLS_CLEANUP_IP_DONE', $count), 'success');
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 		}
 		else
 		{
-			Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_TOOLS_CLEANUP_IP_FAILED'));
+			Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_TOOLS_CLEANUP_IP_FAILED'), 'error');
 			$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 		}
 	}
@@ -965,7 +965,7 @@ class ToolsController extends FormController
 		{
 			if (empty($code) || $code == 0)
 			{
-				Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_TOOLS_UNINSTALL_LOGIN_SECRETKEY_INVALID'));
+				Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_TOOLS_UNINSTALL_LOGIN_SECRETKEY_INVALID'), 'error');
 				$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 			}
 		}
@@ -985,7 +985,7 @@ class ToolsController extends FormController
 			return;
 		}
 
-		Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_TOOLS_UNINSTALL_LOGIN_FAILED'));
+		Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_TOOLS_UNINSTALL_LOGIN_FAILED'), 'error');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 

--- a/src/admin/src/Controller/TrashController.php
+++ b/src/admin/src/Controller/TrashController.php
@@ -95,7 +95,7 @@ class TrashController extends FormController
 
 				if (!$success)
 				{
-					$this->app->enqueueMessage($topic->getError());
+					$this->app->enqueueMessage($topic->getError(), 'error');
 				}
 			}
 
@@ -103,7 +103,7 @@ class TrashController extends FormController
 			{
 				KunenaTopicHelper::recount($cid);
 				KunenaCategoryHelper::recount($topic->getCategory()->id);
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_TRASH_DELETE_TOPICS_DONE'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_TRASH_DELETE_TOPICS_DONE'), 'success');
 			}
 		}
 		elseif ($type == 'messages')
@@ -124,7 +124,7 @@ class TrashController extends FormController
 
 				if (!$success)
 				{
-					$this->app->enqueueMessage($message->getError());
+					$this->app->enqueueMessage($message->getError(), 'error');
 				}
 			}
 
@@ -132,7 +132,7 @@ class TrashController extends FormController
 			{
 				KunenaTopicHelper::recount($cid);
 				KunenaCategoryHelper::recount($topic->getCategory()->id);
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_TRASH_DELETE_MESSAGES_DONE'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_TRASH_DELETE_MESSAGES_DONE'), 'success');
 			}
 		}
 
@@ -194,7 +194,7 @@ class TrashController extends FormController
 				}
 				else
 				{
-					$this->app->enqueueMessage($target->getError(), 'notice');
+					$this->app->enqueueMessage($target->getError(), 'error');
 				}
 			}
 		}
@@ -219,7 +219,7 @@ class TrashController extends FormController
 				}
 				else
 				{
-					$this->app->enqueueMessage($target->getError(), 'notice');
+					$this->app->enqueueMessage($target->getError(), 'error');
 				}
 			}
 		}
@@ -233,7 +233,7 @@ class TrashController extends FormController
 
 		if ($nbItems > 0)
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_TRASH_ITEMS_RESTORE_DONE', $nbItems));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_TRASH_ITEMS_RESTORE_DONE', $nbItems), 'success');
 		}
 
 		KunenaUserHelper::recount();

--- a/src/admin/src/Controller/UserController.php
+++ b/src/admin/src/Controller/UserController.php
@@ -164,7 +164,7 @@ class UserController extends FormController
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_PROFILE_SAVED_SUCCESSFULLY'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_PROFILE_SAVED_SUCCESSFULLY'), 'success');
 			}
 
 			if ($type === 'save')

--- a/src/admin/src/Controller/UsersController.php
+++ b/src/admin/src/Controller/UsersController.php
@@ -163,7 +163,7 @@ class UsersController extends KunenaController
 			return;
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_USERMES_TRASHED_DONE'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_USERMES_TRASHED_DONE'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -262,11 +262,11 @@ class UsersController extends KunenaController
 
 		if ($error)
 		{
-			$this->app->enqueueMessage($error, 'notice');
+			$this->app->enqueueMessage($error, 'error');
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_USERMES_MOVED_DONE'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_A_USERMES_MOVED_DONE'), 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -306,7 +306,7 @@ class UsersController extends KunenaController
 		$options = ['clientid' => 0];
 		$this->app->logout((int) $id, $options);
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_USER_LOGOUT_DONE'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_A_USER_LOGOUT_DONE'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -349,7 +349,7 @@ class UsersController extends KunenaController
 		{
 			if ($my->id == $user->userid)
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_ERROR_CANNOT_DELETE_YOURSELF'), 'notice');
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_ERROR_CANNOT_DELETE_YOURSELF'), 'error');
 				continue;
 			}
 
@@ -357,7 +357,7 @@ class UsersController extends KunenaController
 
 			if ($instance->authorise('core.admin'))
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_ERROR_CANNOT_DELETE_ADMINS'), 'notice');
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_ERROR_CANNOT_DELETE_ADMINS'), 'error');
 				continue;
 			}
 
@@ -365,7 +365,7 @@ class UsersController extends KunenaController
 
 			if (!$result)
 			{
-				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_USER_DELETE_KUNENA_USER_TABLE_FAILED', $user->userid), 'notice');
+				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_USER_DELETE_KUNENA_USER_TABLE_FAILED', $user->userid), 'error');
 				continue;
 			}
 
@@ -374,7 +374,7 @@ class UsersController extends KunenaController
 
 			if (!$jresult)
 			{
-				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_USER_DELETE_JOOMLA_USER_TABLE_FAILED', $user->userid), 'notice');
+				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_USER_DELETE_JOOMLA_USER_TABLE_FAILED', $user->userid), 'error');
 				continue;
 			}
 
@@ -383,7 +383,7 @@ class UsersController extends KunenaController
 
 		if (!empty($usernames))
 		{
-			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_USER_DELETE_DONE_SUCCESSFULLY', implode(', ', $usernames)));
+			$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_USER_DELETE_DONE_SUCCESSFULLY', implode(', ', $usernames)), 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -442,7 +442,7 @@ class UsersController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -501,7 +501,7 @@ class UsersController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -552,7 +552,7 @@ class UsersController extends KunenaController
 
 		$this->setModerate($user, $modCatids);
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_MODERATE_DONE'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_MODERATE_DONE'), 'success');
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
@@ -662,7 +662,7 @@ class UsersController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -721,7 +721,7 @@ class UsersController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -780,7 +780,7 @@ class UsersController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
@@ -847,7 +847,7 @@ class UsersController extends KunenaController
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_USERS_SET_MODERATORS_DONE'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_USERS_SET_MODERATORS_DONE'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -903,14 +903,14 @@ class UsersController extends KunenaController
 				}
 				catch (Exception $e)
 				{
-					$this->app->enqueueMessage($e->getMessage());
+					$this->app->enqueueMessage($e->getMessage(), 'error');
 
 					return;
 				}
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_USERS_REMOVE_CAT_SUBSCRIPTIONS_DONE'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_USERS_REMOVE_CAT_SUBSCRIPTIONS_DONE'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -952,14 +952,14 @@ class UsersController extends KunenaController
 				}
 				catch (Exception $e)
 				{
-					$this->app->enqueueMessage($e->getMessage(), 'notice');
+					$this->app->enqueueMessage($e->getMessage(), 'error');
 
 					return;
 				}
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_USERS_REMOVE_TOPIC_SUBSCRIPTIONS_DONE'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_USERS_REMOVE_TOPIC_SUBSCRIPTIONS_DONE'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 
@@ -1013,7 +1013,7 @@ class UsersController extends KunenaController
 			}
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_USERS_ADD_CATEGORIES_SUBSCRIPTIONS_DONE'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_USERS_ADD_CATEGORIES_SUBSCRIPTIONS_DONE'), 'success');
 		$this->setRedirect(KunenaRoute::_($this->baseurl, false));
 	}
 }

--- a/src/admin/src/Model/CategoriesModel.php
+++ b/src/admin/src/Model/CategoriesModel.php
@@ -219,7 +219,7 @@ class CategoriesModel extends KunenaModel
 				}
 				catch (RuntimeException $e)
 				{
-					Factory::getApplication()->enqueueMessage($e->getMessage());
+					Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 					return;
 				}
@@ -289,7 +289,7 @@ class CategoriesModel extends KunenaModel
 
 				if (!$table->store())
 				{
-					Factory::getApplication()->enqueueMessage($table->getError());
+					Factory::getApplication()->enqueueMessage($table->getError(), 'error');
 
 					return false;
 				}

--- a/src/admin/src/Model/CategoryModel.php
+++ b/src/admin/src/Model/CategoryModel.php
@@ -78,7 +78,7 @@ class CategoryModel extends CategoriesModel
 				}
 				catch (RuntimeException $e)
 				{
-					Factory::getApplication()->enqueueMessage($e->getMessage());
+					Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 					return;
 				}

--- a/src/admin/src/Model/RankModel.php
+++ b/src/admin/src/Model/RankModel.php
@@ -113,7 +113,7 @@ class RankModel extends AdminModel
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}

--- a/src/admin/src/Model/SmileyModel.php
+++ b/src/admin/src/Model/SmileyModel.php
@@ -113,7 +113,7 @@ class SmileyModel extends AdminModel
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}

--- a/src/admin/src/Model/ToolsModel.php
+++ b/src/admin/src/Model/ToolsModel.php
@@ -601,7 +601,7 @@ class ToolsModel extends AdminModel
 		}
 		catch (RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($e->getMessage());
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 			return;
 		}
@@ -710,7 +710,7 @@ class ToolsModel extends AdminModel
 				}
 				catch (RuntimeException $e)
 				{
-					Factory::getApplication()->enqueueMessage($e->getMessage());
+					Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 					return false;
 				}

--- a/src/admin/src/Model/TrashModel.php
+++ b/src/admin/src/Model/TrashModel.php
@@ -308,7 +308,7 @@ class TrashModel extends KunenaModel
 		}
 		catch (ExecutionFailureException $e)
 		{
-			Factory::getApplication()->enqueueMessage($e->getMessage());
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 			return [];
 		}

--- a/src/admin/src/Model/UserModel.php
+++ b/src/admin/src/Model/UserModel.php
@@ -70,7 +70,7 @@ class UserModel extends KunenaModel
 		}
 		catch (RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($e->getMessage());
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 			return false;
 		}
@@ -127,7 +127,7 @@ class UserModel extends KunenaModel
 		}
 		catch (RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($e->getMessage());
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 			return false;
 		}
@@ -151,7 +151,7 @@ class UserModel extends KunenaModel
 			}
 			catch (RuntimeException $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return false;
 			}
@@ -236,7 +236,7 @@ class UserModel extends KunenaModel
 		}
 		catch (RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($e->getMessage());
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 			return false;
 		}
@@ -292,7 +292,7 @@ class UserModel extends KunenaModel
 		}
 		catch (RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($e->getMessage());
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 			return;
 		}

--- a/src/admin/src/Model/UsersModel.php
+++ b/src/admin/src/Model/UsersModel.php
@@ -112,7 +112,7 @@ class UsersModel extends ListModel
 		}
 		catch (RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($e->getMessage());
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 			return false;
 		}

--- a/src/admin/src/View/Cpanel/HtmlView.php
+++ b/src/admin/src/View/Cpanel/HtmlView.php
@@ -150,7 +150,7 @@ class HtmlView extends BaseHtmlView
 				{
 					$modelInstall->processUpgradeXMLNode($action);
 
-					$app->enqueueMessage(Text::sprintf('COM_KUNENA_INSTALL_VERSION_UPGRADED', $vernum));
+					$app->enqueueMessage(Text::sprintf('COM_KUNENA_INSTALL_VERSION_UPGRADED', $vernum), 'success');
 				}
 
 				$query = "UPDATE `#__kunena_version` SET state='';";

--- a/src/libraries/kunena/src/Controller/Application/Display.php
+++ b/src/libraries/kunena/src/Controller/Application/Display.php
@@ -299,12 +299,12 @@ class Display extends KunenaControllerDisplay
 						'COM_KUNENA_POST_ERROR_USER_BANNED_NOACCESS_EXPIRY',
 						KunenaDate::getInstance($banned->expiration)->toKunena('date_today')
 					),
-					'notice'
+					'error'
 				);
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_ERROR_USER_BANNED_NOACCESS'), 'notice');
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_ERROR_USER_BANNED_NOACCESS'), 'error');
 			}
 		}
 

--- a/src/libraries/kunena/src/Error/KunenaError.php
+++ b/src/libraries/kunena/src/Error/KunenaError.php
@@ -141,7 +141,7 @@ abstract class KunenaError
 		if (self::$debug)
 		{
 			$app = Factory::getApplication();
-			$app->enqueueMessage(Text::sprintf('COM_KUNENA_WARNING_' . strtoupper($where), $msg), 'notice');
+			$app->enqueueMessage(Text::sprintf('COM_KUNENA_WARNING_' . strtoupper($where), $msg), 'warning');
 		}
 	}
 

--- a/src/libraries/kunena/src/Forum/Category/KunenaCategoryHelper.php
+++ b/src/libraries/kunena/src/Forum/Category/KunenaCategoryHelper.php
@@ -1067,7 +1067,7 @@ abstract class KunenaCategoryHelper
 		}
 		catch (RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($e->getMessage());
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 			return false;
 		}

--- a/src/libraries/kunena/src/Forum/Topic/KunenaTopic.php
+++ b/src/libraries/kunena/src/Forum/Topic/KunenaTopic.php
@@ -1633,7 +1633,7 @@ class KunenaTopic extends KunenaDatabaseObject
 			catch (RuntimeException $e)
 			{
 				$app = Factory::getApplication();
-				$app->enqueueMessage($e->getMessage());
+				$app->enqueueMessage($e->getMessage(), 'error');
 			}
 
 			// So are we moving the whole topic?
@@ -1801,7 +1801,7 @@ class KunenaTopic extends KunenaDatabaseObject
 		catch (RuntimeException $e)
 		{
 			$app = Factory::getApplication();
-			$app->enqueueMessage($query);
+			$app->enqueueMessage($query, 'error');
 		}
 
 		// Make sure that all messages in topic have unique time (deterministic without ORDER BY time, id)
@@ -1815,7 +1815,7 @@ class KunenaTopic extends KunenaDatabaseObject
 		catch (RuntimeException $e)
 		{
 			$app = Factory::getApplication();
-			$app->enqueueMessage($e->getMessage());
+			$app->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		$query = 'UPDATE ' . $this->_db->quoteName('#__kunena_messages') . ' SET ' . $this->_db->quoteName('time') . ' = IF(time <= @ktime,@ktime:=@ktime+1,@ktime:=time) WHERE thread=' . $target->id . ' ORDER BY time ASC, id ASC';
@@ -1828,7 +1828,7 @@ class KunenaTopic extends KunenaDatabaseObject
 		catch (RuntimeException $e)
 		{
 			$app = Factory::getApplication();
-			$app->enqueueMessage($e->getMessage());
+			$app->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		if ($keep_poll)
@@ -1858,7 +1858,7 @@ class KunenaTopic extends KunenaDatabaseObject
 				catch (RuntimeException $e)
 				{
 					$app = Factory::getApplication();
-					$app->enqueueMessage($e->getMessage());
+					$app->enqueueMessage($e->getMessage(), 'error');
 				}
 			}
 

--- a/src/libraries/kunena/src/Route/KunenaRoute.php
+++ b/src/libraries/kunena/src/Route/KunenaRoute.php
@@ -927,7 +927,7 @@ abstract class KunenaRoute
 		}
 		catch (\RuntimeException $e)
 		{
-			$app->enqueueMessage($e->getMessage());
+			$app->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		$vars = [];

--- a/src/libraries/kunena/src/View/KunenaView.php
+++ b/src/libraries/kunena/src/View/KunenaView.php
@@ -290,7 +290,7 @@ class KunenaView extends HtmlView
 			}
 			catch (Exception $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}
@@ -303,7 +303,7 @@ class KunenaView extends HtmlView
 			}
 			catch (Exception $e)
 			{
-				Factory::getApplication()->enqueueMessage($e->getMessage());
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
 				return;
 			}

--- a/src/plugins/plg_system_kunena/kunena.php
+++ b/src/plugins/plg_system_kunena/kunena.php
@@ -212,7 +212,7 @@ EOF;
 			$manifest->version
 		), 'warning');
 		$app->enqueueMessage(Text::_('JLIB_INSTALLER_ABORT_COMP_INSTALL_CUSTOM_INSTALL_FAILURE'), 'error');
-		$app->enqueueMessage(Text::sprintf('COM_INSTALLER_MSG_UPDATE_ERROR', Text::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($type))));
+		$app->enqueueMessage(Text::sprintf('COM_INSTALLER_MSG_UPDATE_ERROR', Text::_('COM_INSTALLER_TYPE_TYPE_' . strtoupper($type))), 'error');
 		$app->redirect('index.php?option=com_installer');
 
 		return true;

--- a/src/site/src/Controllers/AnnouncementController.php
+++ b/src/site/src/Controllers/AnnouncementController.php
@@ -124,7 +124,7 @@ class AnnouncementController extends KunenaController
 					KunenaLog::log(KunenaLog::TYPE_MODERATION, KunenaLog::LOG_ANNOUNCEMENT_PUBLISH, ['id' => $announcement->id]);
 				}
 
-				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_ANN_SUCCESS_PUBLISH', $this->escape($announcement->title)));
+				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_ANN_SUCCESS_PUBLISH', $this->escape($announcement->title)), 'success');
 			}
 		}
 
@@ -192,7 +192,7 @@ class AnnouncementController extends KunenaController
 					KunenaLog::log(KunenaLog::TYPE_MODERATION, KunenaLog::LOG_ANNOUNCEMENT_UNPUBLISH, ['id' => $announcement->id]);
 				}
 
-				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_ANN_SUCCESS_UNPUBLISH', $this->escape($announcement->title)));
+				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_ANN_SUCCESS_UNPUBLISH', $this->escape($announcement->title)), 'success');
 			}
 		}
 
@@ -256,7 +256,7 @@ class AnnouncementController extends KunenaController
 					);
 				}
 
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_ANN_DELETED'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_ANN_DELETED'), 'success');
 			}
 		}
 
@@ -346,7 +346,7 @@ class AnnouncementController extends KunenaController
 			);
 		}
 
-		$this->app->enqueueMessage(Text::_($id ? 'COM_KUNENA_ANN_SUCCESS_EDIT' : 'COM_KUNENA_ANN_SUCCESS_ADD'));
+		$this->app->enqueueMessage(Text::_($id ? 'COM_KUNENA_ANN_SUCCESS_EDIT' : 'COM_KUNENA_ANN_SUCCESS_ADD'), 'success');
 		$this->setRedirect($announcement->getUrl('default', false));
 	}
 }

--- a/src/site/src/Controllers/CategoryController.php
+++ b/src/site/src/Controllers/CategoryController.php
@@ -101,7 +101,7 @@ class CategoryController extends CategoriesController
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_GEN_ALL_MARKED'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_GEN_ALL_MARKED'), 'success');
 			}
 		}
 		else
@@ -134,11 +134,11 @@ class CategoryController extends CategoriesController
 
 				if (\count($categories) > 1)
 				{
-					$this->app->enqueueMessage(Text::_('COM_KUNENA_GEN_ALL_MARKED'));
+					$this->app->enqueueMessage(Text::_('COM_KUNENA_GEN_ALL_MARKED'), 'success');
 				}
 				else
 				{
-					$this->app->enqueueMessage(Text::_('COM_KUNENA_GEN_FORUM_MARKED'));
+					$this->app->enqueueMessage(Text::_('COM_KUNENA_GEN_FORUM_MARKED'), 'success');
 				}
 			}
 		}
@@ -180,7 +180,7 @@ class CategoryController extends CategoriesController
 
 			if ($success)
 			{
-				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_CATEGORY_USER_SUBCRIBED', $category->name));
+				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_CATEGORY_USER_SUBCRIBED', $category->name), 'success');
 			}
 		}
 
@@ -231,11 +231,11 @@ class CategoryController extends CategoriesController
 
 				if ($success && $userid == $me->userid)
 				{
-					$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_GEN_CATEGORY_NAME_UNSUBCRIBED', $category->name));
+					$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_GEN_CATEGORY_NAME_UNSUBCRIBED', $category->name), 'success');
 				}
 				else
 				{
-					$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_CATEGORY_NAME_MODERATOR_UNSUBCRIBED_USER', $category->name));
+					$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_CATEGORY_NAME_MODERATOR_UNSUBCRIBED_USER', $category->name), 'success');
 				}
 			}
 		}

--- a/src/site/src/Controllers/TopicController.php
+++ b/src/site/src/Controllers/TopicController.php
@@ -620,7 +620,7 @@ class TopicController extends KunenaController
 			}
 			catch (Exception $e)
 			{
-				$this->app->enqueueMessage($e->getMessage(), 'notice');
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 				$this->setRedirectBack();
 
 				return;
@@ -639,7 +639,7 @@ class TopicController extends KunenaController
 			}
 			catch (Exception $e)
 			{
-				$this->app->enqueueMessage($e->getMessage(), 'notice');
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 				$this->setRedirectBack();
 
 				return;
@@ -923,7 +923,7 @@ class TopicController extends KunenaController
 		// Display possible warnings (upload failed etc)
 		foreach ($message->getErrors() as $warning)
 		{
-			$this->app->enqueueMessage($warning, 'notice');
+			$this->app->enqueueMessage($warning, 'error');
 		}
 
 		// Create Poll
@@ -947,18 +947,18 @@ class TopicController extends KunenaController
 
 				if (!$poll->save())
 				{
-					$this->app->enqueueMessage($poll->getError(), 'notice');
+					$this->app->enqueueMessage($poll->getError(), 'error');
 				}
 				else
 				{
 					$topic->poll_id = $poll->id;
 					$topic->save();
-					$this->app->enqueueMessage(Text::_('COM_KUNENA_POLL_CREATED'));
+					$this->app->enqueueMessage(Text::_('COM_KUNENA_POLL_CREATED'), 'success');
 				}
 			}
 			else
 			{
-				$this->app->enqueueMessage($topic->getError(), 'notice');
+				$this->app->enqueueMessage($topic->getError(), 'error');
 			}
 		}
 
@@ -975,7 +975,7 @@ class TopicController extends KunenaController
 		{
 			if ($topic->subscribe(1))
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUBSCRIBED_TOPIC'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUBSCRIBED_TOPIC'), 'success');
 
 				// Activity integration
 				$activity = KunenaFactory::getActivityIntegration();
@@ -983,17 +983,17 @@ class TopicController extends KunenaController
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_SUBSCRIBED_TOPIC') . ' ' . $topic->getError());
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_SUBSCRIBED_TOPIC') . ' ' . $topic->getError(), 'error');
 			}
 		}
 
 		if ($message->hold == 1)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCES_REVIEW'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCES_REVIEW'), 'success');
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_POSTED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_POSTED'), 'success');
 		}
 
 		$category = KunenaCategoryHelper::get($this->return);
@@ -1155,7 +1155,7 @@ class TopicController extends KunenaController
 		// When the bbcode urls and images are removed just remove the others links
 		$text = preg_replace('/(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)(#?[\w \.-]*)(\??[\w \.-]*)(\=?[\w \.-]*)/i', '', $text);
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SAVED_WITHOUT_LINKS_AND_IMAGES'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SAVED_WITHOUT_LINKS_AND_IMAGES'), 'success');
 
 		return $text;
 	}
@@ -1353,7 +1353,7 @@ class TopicController extends KunenaController
 		catch (Exception $e)
 		{
 			$this->app->setUserState('com_kunena.postfields', $fields);
-			$this->app->enqueueMessage($e->getMessage(), 'notice');
+			$this->app->enqueueMessage($e->getMessage(), 'error');
 			$this->setRedirectBack();
 
 			return;
@@ -1469,12 +1469,12 @@ class TopicController extends KunenaController
 				}
 				catch (Exception $e)
 				{
-					$this->app->enqueueMessage($e->getMessage(), 'notice');
+					$this->app->enqueueMessage($e->getMessage(), 'error');
 				}
 
 				if ($message->publish(KunenaForum::DELETED))
 				{
-					$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_DELETE'));
+					$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_DELETE'), 'success');
 				}
 
 				$this->setRedirect($message->getUrl($this->return, false));
@@ -1528,7 +1528,7 @@ class TopicController extends KunenaController
 		// Display possible warnings (upload failed etc)
 		foreach ($message->getErrors() as $warning)
 		{
-			$this->app->enqueueMessage($warning, 'notice');
+			$this->app->enqueueMessage($warning, 'error');
 		}
 
 		$subscribe = $this->app->input->getInt('subscribeMe');
@@ -1573,17 +1573,17 @@ class TopicController extends KunenaController
 					// Create a new poll
 					if (!$topic->isAuthorised('poll.create'))
 					{
-						$this->app->enqueueMessage($topic->getError(), 'notice');
+						$this->app->enqueueMessage($topic->getError(), 'error');
 					}
 					elseif (!$poll->save())
 					{
-						$this->app->enqueueMessage($poll->getError(), 'notice');
+						$this->app->enqueueMessage($poll->getError(), 'error');
 					}
 					else
 					{
 						$topic->poll_id = $poll->id;
 						$topic->save();
-						$this->app->enqueueMessage(Text::_('COM_KUNENA_POLL_CREATED'));
+						$this->app->enqueueMessage(Text::_('COM_KUNENA_POLL_CREATED'), 'success');
 					}
 				}
 				else
@@ -1593,15 +1593,15 @@ class TopicController extends KunenaController
 						// Edit existing poll
 						if (!$topic->isAuthorised('poll.edit'))
 						{
-							$this->app->enqueueMessage($topic->getError(), 'notice');
+							$this->app->enqueueMessage($topic->getError(), 'error');
 						}
 						elseif (!$poll->save())
 						{
-							$this->app->enqueueMessage($poll->getError(), 'notice');
+							$this->app->enqueueMessage($poll->getError(), 'error');
 						}
 						else
 						{
-							$this->app->enqueueMessage(Text::_('COM_KUNENA_POLL_EDITED'));
+							$this->app->enqueueMessage(Text::_('COM_KUNENA_POLL_EDITED'), 'success');
 						}
 					}
 				}
@@ -1612,15 +1612,15 @@ class TopicController extends KunenaController
 				if (!$topic->isAuthorised('poll.delete'))
 				{
 					// Error: No permissions to delete poll
-					$this->app->enqueueMessage($topic->getError(), 'notice');
+					$this->app->enqueueMessage($topic->getError(), 'error');
 				}
 				elseif (!$poll->delete())
 				{
-					$this->app->enqueueMessage($poll->getError(), 'notice');
+					$this->app->enqueueMessage($poll->getError(), 'error');
 				}
 				else
 				{
-					$this->app->enqueueMessage(Text::_('COM_KUNENA_POLL_DELETED'));
+					$this->app->enqueueMessage(Text::_('COM_KUNENA_POLL_DELETED'), 'success');
 				}
 			}
 		}
@@ -1630,7 +1630,7 @@ class TopicController extends KunenaController
 
 		$activity->onAfterEdit($message);
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_EDIT'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_EDIT'), 'success');
 
 		if ($message->hold == 1)
 		{
@@ -1640,7 +1640,7 @@ class TopicController extends KunenaController
 				$message->sendNotification();
 			}
 
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_GEN_MODERATED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_GEN_MODERATED'), 'success');
 		}
 
 		// Redirect edit first message when category is under review
@@ -1755,7 +1755,7 @@ class TopicController extends KunenaController
 
 		if (!$message->isAuthorised($type))
 		{
-			$this->app->enqueueMessage($message->getError());
+			$this->app->enqueueMessage($message->getError(), 'error');
 			$this->setRedirectBack();
 
 			return;
@@ -1773,13 +1773,13 @@ class TopicController extends KunenaController
 			}
 			catch (Exception $e)
 			{
-				$this->app->enqueueMessage($e->getMessage());
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 				$this->setRedirectBack();
 
 				return;
 			}
 
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_THANKYOU_SUCCESS'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_THANKYOU_SUCCESS'), 'success');
 
 			if ($this->config->logModeration)
 			{
@@ -1805,13 +1805,13 @@ class TopicController extends KunenaController
 			}
 			catch (Exception $e)
 			{
-				$this->app->enqueueMessage($e->getMessage());
+				$this->app->enqueueMessage($e->getMessage(), 'error');
 				$this->setRedirectBack();
 
 				return;
 			}
 
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_THANKYOU_REMOVED_SUCCESS'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_THANKYOU_REMOVED_SUCCESS'), 'success');
 
 			if ($this->config->logModeration)
 			{
@@ -1865,7 +1865,7 @@ class TopicController extends KunenaController
 
 		if ($topic->isAuthorised('read') && $topic->subscribe(1))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUBSCRIBED_TOPIC'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUBSCRIBED_TOPIC'), 'success');
 
 			// Activity integration
 			$activity = KunenaFactory::getActivityIntegration();
@@ -1873,7 +1873,7 @@ class TopicController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_SUBSCRIBED_TOPIC') . ' ' . $topic->getError(), 'notice');
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_SUBSCRIBED_TOPIC') . ' ' . $topic->getError(), 'error');
 		}
 
 		$this->setRedirectBack();
@@ -1906,11 +1906,11 @@ class TopicController extends KunenaController
 			}
 			catch (Exception $e)
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_UNSUBSCRIBED_TOPIC') . ' ' . $topic->getError(), 'notice');
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_UNSUBSCRIBED_TOPIC') . ' ' . $topic->getError(), 'error');
 				$this->setRedirectBack();
 			}
 
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_UNSUBSCRIBED_TOPIC'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_UNSUBSCRIBED_TOPIC'), 'success');
 
 			// Activity integration
 			$activity = KunenaFactory::getActivityIntegration();
@@ -1941,7 +1941,7 @@ class TopicController extends KunenaController
 
 		if ($topic->isAuthorised('read') && $topic->favorite(1))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_FAVORITED_TOPIC'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_FAVORITED_TOPIC'), 'success');
 
 			// Activity integration
 			$activity = KunenaFactory::getActivityIntegration();
@@ -1949,7 +1949,7 @@ class TopicController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_FAVORITED_TOPIC') . ' ' . $topic->getError(), 'notice');
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_FAVORITED_TOPIC') . ' ' . $topic->getError(), 'error');
 		}
 
 		$this->setRedirectBack();
@@ -1976,7 +1976,7 @@ class TopicController extends KunenaController
 
 		if ($topic->isAuthorised('read') && $topic->favorite(0))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_UNFAVORITED_TOPIC'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_UNFAVORITED_TOPIC'), 'success');
 
 			// Activity integration
 			$activity = KunenaFactory::getActivityIntegration();
@@ -1984,7 +1984,7 @@ class TopicController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_UNFAVORITED_TOPIC') . ' ' . $topic->getError(), 'notice');
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_UNFAVORITED_TOPIC') . ' ' . $topic->getError(), 'error');
 		}
 
 		$this->setRedirectBack();
@@ -2011,11 +2011,11 @@ class TopicController extends KunenaController
 
 		if (!$topic->isAuthorised('sticky'))
 		{
-			$this->app->enqueueMessage($topic->getError(), 'notice');
+			$this->app->enqueueMessage($topic->getError(), 'error');
 		}
 		elseif ($topic->sticky(1))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_STICKY_SET'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_STICKY_SET'), 'success');
 
 			if ($this->config->logModeration)
 			{
@@ -2034,7 +2034,7 @@ class TopicController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_STICKY_NOT_SET'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_STICKY_NOT_SET'), 'error');
 		}
 
 		$this->setRedirectBack();
@@ -2061,11 +2061,11 @@ class TopicController extends KunenaController
 
 		if (!$topic->isAuthorised('sticky'))
 		{
-			$this->app->enqueueMessage($topic->getError(), 'notice');
+			$this->app->enqueueMessage($topic->getError(), 'error');
 		}
 		elseif ($topic->sticky(0))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_STICKY_UNSET'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_STICKY_UNSET'), 'success');
 
 			if ($this->config->logModeration)
 			{
@@ -2084,7 +2084,7 @@ class TopicController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_STICKY_NOT_UNSET'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_STICKY_NOT_UNSET'), 'error');
 		}
 
 		$this->setRedirectBack();
@@ -2111,11 +2111,11 @@ class TopicController extends KunenaController
 
 		if (!$topic->isAuthorised('lock'))
 		{
-			$this->app->enqueueMessage($topic->getError(), 'notice');
+			$this->app->enqueueMessage($topic->getError(), 'error');
 		}
 		elseif ($topic->lock(1))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_LOCK_SET'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_LOCK_SET'), 'success');
 
 			if ($this->config->logModeration)
 			{
@@ -2134,7 +2134,7 @@ class TopicController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_LOCK_NOT_SET'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_LOCK_NOT_SET'), 'error');
 		}
 
 		$this->setRedirectBack();
@@ -2161,11 +2161,11 @@ class TopicController extends KunenaController
 
 		if (!$topic->isAuthorised('lock'))
 		{
-			$this->app->enqueueMessage($topic->getError(), 'notice');
+			$this->app->enqueueMessage($topic->getError(), 'error');
 		}
 		elseif ($topic->lock(0))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_LOCK_UNSET'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_LOCK_UNSET'), 'success');
 
 			if ($this->config->logModeration)
 			{
@@ -2184,7 +2184,7 @@ class TopicController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_LOCK_NOT_UNSET'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_LOCK_NOT_UNSET'), 'error');
 		}
 
 		$this->setRedirectBack();
@@ -2240,11 +2240,11 @@ class TopicController extends KunenaController
 				);
 			}
 
-			$this->app->enqueueMessage($msg);
+			$this->app->enqueueMessage($msg, 'success');
 		}
 		else
 		{
-			$this->app->enqueueMessage($target->getError(), 'notice');
+			$this->app->enqueueMessage($target->getError(), 'error');
 		}
 
 		if (!$target->isAuthorised('read'))
@@ -2311,11 +2311,11 @@ class TopicController extends KunenaController
 				);
 			}
 
-			$this->app->enqueueMessage($msg);
+			$this->app->enqueueMessage($msg, 'success');
 		}
 		else
 		{
-			$this->app->enqueueMessage($target->getError(), 'notice');
+			$this->app->enqueueMessage($target->getError(), 'error');
 		}
 
 		$this->setRedirect($target->getUrl($this->return, false));
@@ -2375,18 +2375,18 @@ class TopicController extends KunenaController
 
 			if ($topic->exists())
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_DELETE'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_DELETE'), 'success');
 				$url = $topic->getUrl($this->return, false);
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_SUCCESS_DELETE'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_SUCCESS_DELETE'), 'success');
 				$url = $topic->getCategory()->getUrl($this->return, false);
 			}
 		}
 		else
 		{
-			$this->app->enqueueMessage($target->getError(), 'notice');
+			$this->app->enqueueMessage($target->getError(), 'error');
 		}
 
 		if (isset($url))
@@ -2447,7 +2447,7 @@ class TopicController extends KunenaController
 				);
 			}
 
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_APPROVE_SUCCESS'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_APPROVE_SUCCESS'), 'success');
 
 			// Only email if message wasn't modified by the author before approval
 			// TODO: this is just a workaround for #1862, we need to find better solution.
@@ -2461,7 +2461,7 @@ class TopicController extends KunenaController
 		}
 		else
 		{
-			$this->app->enqueueMessage($target->getError(), 'notice');
+			$this->app->enqueueMessage($target->getError(), 'error');
 		}
 
 		$this->setRedirect($target->getUrl($this->return, false));
@@ -2579,11 +2579,11 @@ class TopicController extends KunenaController
 
 		if ($error)
 		{
-			$this->app->enqueueMessage($error, 'notice');
+			$this->app->enqueueMessage($error, 'error');
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_ACTION_TOPIC_SUCCESS_MOVE'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_ACTION_TOPIC_SUCCESS_MOVE'), 'success');
 		}
 
 		if ($targetobject)
@@ -2616,7 +2616,7 @@ class TopicController extends KunenaController
 		if (!$this->me->exists() || $this->config->reportMsg == 0)
 		{
 			// Deny access if report feature has been disabled or user is guest
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_NO_ACCESS'), 'notice');
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_NO_ACCESS'), 'warning');
 			$this->setRedirectBack();
 
 			return;
@@ -2625,7 +2625,7 @@ class TopicController extends KunenaController
 		if (!$this->config->get('sendEmails'))
 		{
 			// Emails have been disabled
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_EMAIL_DISABLED'), 'notice');
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_EMAIL_DISABLED'), 'warning');
 			$this->setRedirectBack();
 
 			return;
@@ -2657,7 +2657,7 @@ class TopicController extends KunenaController
 		if (!$target->isAuthorised('read'))
 		{
 			// Deny access if user cannot read target
-			$this->app->enqueueMessage($target->getError(), 'notice');
+			$this->app->enqueueMessage($target->getError(), 'error');
 			$this->setRedirectBack();
 
 			return;
@@ -2695,7 +2695,7 @@ class TopicController extends KunenaController
 		if (empty($reason) && empty($text))
 		{
 			// Do nothing: empty subject or reason is empty
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_REPORT_FORG0T_SUB_MES'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_REPORT_FORG0T_SUB_MES'), 'error');
 			$this->setRedirectBack();
 
 			return;
@@ -2755,11 +2755,11 @@ class TopicController extends KunenaController
 
 				KunenaEmail::send($mailTemplate, $receivers, $mailer);
 
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_REPORT_SUCCESS'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_REPORT_SUCCESS'), 'success');
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_REPORT_NOT_SEND'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_REPORT_NOT_SEND'), 'success');
 			}
 		}
 
@@ -2804,7 +2804,7 @@ class TopicController extends KunenaController
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_VOTE_SUCCESS'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_VOTE_SUCCESS'), 'success');
 			}
 		}
 		elseif (!$this->config->pollAllowVoteOne)
@@ -2818,7 +2818,7 @@ class TopicController extends KunenaController
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_VOTE_CHANGED_SUCCESS'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_VOTE_CHANGED_SUCCESS'), 'success');
 			}
 		}
 
@@ -2857,7 +2857,7 @@ class TopicController extends KunenaController
 			);
 		}
 
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_VOTE_RESET_SUCCESS'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_TOPIC_VOTE_RESET_SUCCESS'), 'success');
 		$this->setRedirect($topic->getUrl($this->return, false));
 	}
 }

--- a/src/site/src/Controllers/TopicsController.php
+++ b/src/site/src/Controllers/TopicsController.php
@@ -45,7 +45,7 @@ class TopicsController extends KunenaController
 	 */
 	public function none()
 	{
-		$this->app->enqueueMessage(Text::_('COM_KUNENA_CONTROLLER_NO_TASK'));
+		$this->app->enqueueMessage(Text::_('COM_KUNENA_CONTROLLER_NO_TASK'), 'error');
 		$this->setRedirectBack();
 	}
 
@@ -94,7 +94,7 @@ class TopicsController extends KunenaController
 				}
 				else
 				{
-					$this->app->enqueueMessage($topic->getError(), 'notice');
+					$this->app->enqueueMessage($topic->getError(), 'error');
 				}
 			}
 
@@ -163,7 +163,7 @@ class TopicsController extends KunenaController
 				}
 			}
 
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirectBack();
@@ -207,7 +207,7 @@ class TopicsController extends KunenaController
 				}
 				else
 				{
-					$this->app->enqueueMessage($topic->getError(), 'notice');
+					$this->app->enqueueMessage($topic->getError(), 'error');
 				}
 			}
 		}
@@ -229,7 +229,7 @@ class TopicsController extends KunenaController
 				}
 			}
 
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirectBack();
@@ -273,7 +273,7 @@ class TopicsController extends KunenaController
 				}
 				else
 				{
-					$this->app->enqueueMessage($topic->getError(), 'notice');
+					$this->app->enqueueMessage($topic->getError(), 'error');
 				}
 			}
 		}
@@ -295,7 +295,7 @@ class TopicsController extends KunenaController
 				}
 			}
 
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirectBack();
@@ -326,7 +326,7 @@ class TopicsController extends KunenaController
 
 		if (!$topics)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_NO_TOPICS_SELECTED'), 'notice');
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_NO_TOPICS_SELECTED'), 'error');
 			$this->setRedirectBack();
 		}
 		else
@@ -340,7 +340,7 @@ class TopicsController extends KunenaController
 				}
 				else
 				{
-					$this->app->enqueueMessage($topic->getError(), 'notice');
+					$this->app->enqueueMessage($topic->getError(), 'error');
 				}
 			}
 		}
@@ -362,7 +362,7 @@ class TopicsController extends KunenaController
 				}
 			}
 
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirectBack();
@@ -426,7 +426,7 @@ class TopicsController extends KunenaController
 						}
 						else
 						{
-							$this->app->enqueueMessage($topic->getError(), 'notice');
+							$this->app->enqueueMessage($topic->getError(), 'error');
 						}
 					}
 				}
@@ -442,7 +442,7 @@ class TopicsController extends KunenaController
 						}
 						else
 						{
-							$this->app->enqueueMessage($message->getError(), 'notice');
+							$this->app->enqueueMessage($message->getError(), 'error');
 						}
 					}
 				}
@@ -469,7 +469,7 @@ class TopicsController extends KunenaController
 				}
 			}
 
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		$this->setRedirectBack();
@@ -514,11 +514,11 @@ class TopicsController extends KunenaController
 				}
 			}
 
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_UNFAVORITE_YES'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_UNFAVORITE_YES'), 'success');
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_UNFAVORITED_TOPIC'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_NO_UNFAVORITED_TOPIC'), 'success');
 		}
 
 		$this->setRedirectBack();
@@ -550,7 +550,7 @@ class TopicsController extends KunenaController
 
 		if (KunenaTopicHelper::subscribe(array_keys($topics), 0, $userid))
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_UNSUBSCRIBE_YES'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_USER_UNSUBSCRIBE_YES'), 'success');
 		}
 		else
 		{
@@ -598,14 +598,14 @@ class TopicsController extends KunenaController
 				}
 				else
 				{
-					$this->app->enqueueMessage($message->getError(), 'notice');
+					$this->app->enqueueMessage($message->getError(), 'error');
 				}
 			}
 		}
 
 		if ($success)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_APPROVE_SUCCESS'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_APPROVE_SUCCESS'), 'success');
 		}
 
 		$this->setRedirectBack();
@@ -648,14 +648,14 @@ class TopicsController extends KunenaController
 				}
 				else
 				{
-					$this->app->enqueueMessage($message->getError(), 'notice');
+					$this->app->enqueueMessage($message->getError(), 'error');
 				}
 			}
 		}
 
 		if ($success)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_DELETE'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_DELETE'), 'success');
 		}
 
 		$this->setRedirectBack();
@@ -698,14 +698,14 @@ class TopicsController extends KunenaController
 				}
 				else
 				{
-					$this->app->enqueueMessage($message->getError(), 'notice');
+					$this->app->enqueueMessage($message->getError(), 'error');
 				}
 			}
 		}
 
 		if ($success)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_UNDELETE'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_POST_SUCCESS_UNDELETE'), 'success');
 		}
 
 		$this->setRedirectBack();
@@ -748,14 +748,14 @@ class TopicsController extends KunenaController
 				}
 				else
 				{
-					$this->app->enqueueMessage($message->getError(), 'notice');
+					$this->app->enqueueMessage($message->getError(), 'error');
 				}
 			}
 		}
 
 		if ($success)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_BULKMSG_DELETED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_BULKMSG_DELETED'), 'success');
 		}
 
 		$this->setRedirectBack();

--- a/src/site/src/Controllers/UserController.php
+++ b/src/site/src/Controllers/UserController.php
@@ -230,7 +230,7 @@ class UserController extends KunenaController
 		{
 			if (!$this->me->isModerator() && $now - $this->me->karma_time < $karma_delay)
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_WAIT'), 'notice');
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_WAIT'), 'warning');
 				$this->setRedirectBack();
 
 				return;
@@ -241,23 +241,23 @@ class UserController extends KunenaController
 		{
 			if ($this->me->userid == $target->userid)
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_SELF_INCREASE'), 'notice');
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_SELF_INCREASE'), 'warning');
 				$karmaDelta = -10;
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_INCREASED'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_INCREASED'), 'success');
 			}
 		}
 		else
 		{
 			if ($this->me->userid == $target->userid)
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_SELF_DECREASE'), 'notice');
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_SELF_DECREASE'), 'warning');
 			}
 			else
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_DECREASED'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_KARMA_DECREASED'), 'success');
 			}
 		}
 
@@ -265,7 +265,7 @@ class UserController extends KunenaController
 
 		if ($this->me->userid != $target->userid && !$this->me->save())
 		{
-			$this->app->enqueueMessage($this->me->getError(), 'notice');
+			$this->app->enqueueMessage($this->me->getError(), 'error');
 			$this->setRedirectBack();
 
 			return;
@@ -279,7 +279,7 @@ class UserController extends KunenaController
 		}
 		catch (Exception $e)
 		{
-			$this->app->enqueueMessage($e->getMessage(), 'notice');
+			$this->app->enqueueMessage($e->getMessage(), 'error');
 			$this->setRedirectBack();
 
 			return;
@@ -380,12 +380,12 @@ class UserController extends KunenaController
 
 		if ($this->user->userid == $this->me->userid)
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_SAVED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_SAVED'), 'success');
 			$edited_by_moderator = 0;
 		}
 		else
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_SAVED_BY_MODERATOR'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_SAVED_BY_MODERATOR'), 'success');
 			$edited_by_moderator = 1;
 		}
 
@@ -445,14 +445,14 @@ class UserController extends KunenaController
 			// Do a password safety check.
 			if ($post_password != $post_password2)
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_PASSWORD_MISMATCH'), 'notice');
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_PASSWORD_MISMATCH'), 'error');
 
 				return false;
 			}
 
 			if (\strlen($post_password) < $params->get('minimum_length'))
 			{
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_PASSWORD_NOT_MINIMUM'), 'notice');
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_PASSWORD_NOT_MINIMUM'), 'error');
 
 				return false;
 			}
@@ -483,7 +483,7 @@ class UserController extends KunenaController
 			// We set a maximum length to prevent abuse since it is unfiltered.
 			if ($valueLength > 4096)
 			{
-				$this->app->enqueueMessage(Text::_('COM_USERS_MSG_PASSWORD_TOO_LONG'), 'warning');
+				$this->app->enqueueMessage(Text::_('COM_USERS_MSG_PASSWORD_TOO_LONG'), 'error');
 			}
 
 			// We don't allow white space inside passwords
@@ -496,7 +496,7 @@ class UserController extends KunenaController
 			{
 				$this->app->enqueueMessage(
 					Text::_('COM_USERS_MSG_SPACES_IN_PASSWORD'),
-					'warning'
+					'error'
 				);
 
 				$validPassword = false;
@@ -511,7 +511,7 @@ class UserController extends KunenaController
 				{
 					$this->app->enqueueMessage(
 						Text::plural('COM_USERS_MSG_NOT_ENOUGH_INTEGERS_N', $minimumIntegers),
-						'warning'
+						'error'
 					);
 
 					$validPassword = false;
@@ -527,7 +527,7 @@ class UserController extends KunenaController
 				{
 					$this->app->enqueueMessage(
 						Text::plural('COM_USERS_MSG_NOT_ENOUGH_SYMBOLS_N', $minimumSymbols),
-						'warning'
+						'error'
 					);
 
 					$validPassword = false;
@@ -543,7 +543,7 @@ class UserController extends KunenaController
 				{
 					$this->app->enqueueMessage(
 						Text::plural('COM_USERS_MSG_NOT_ENOUGH_UPPERCASE_LETTERS_N', $minimumUppercase),
-						'warning'
+						'error'
 					);
 
 					$validPassword = false;
@@ -557,7 +557,7 @@ class UserController extends KunenaController
 				{
 					$this->app->enqueueMessage(
 						Text::plural('COM_USERS_MSG_PASSWORD_TOO_SHORT_N', $minimumLength),
-						'warning'
+						'error'
 					);
 
 					$validPassword = false;
@@ -634,7 +634,7 @@ class UserController extends KunenaController
 				// When the bbcode urls and images are removed just remove the others links
 				$signature = preg_replace('/(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)(#?[\w \.-]*)(\??[\w \.-]*)(\=?[\w \.-]*)/i', '', $signature);
 
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_SAVED_WITHOUT_LINKS_IMAGES'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_PROFILE_SAVED_WITHOUT_LINKS_IMAGES'), 'success');
 			}
 
 			$user->signature = $signature;
@@ -838,7 +838,7 @@ class UserController extends KunenaController
 				KunenaUserHelper::recountBanned();
 			}
 
-			$this->app->enqueueMessage($message);
+			$this->app->enqueueMessage($message, 'success');
 		}
 
 		if (!empty($DelAvatar) || !empty($DelProfileInfo))
@@ -854,7 +854,7 @@ class UserController extends KunenaController
 
 			$user->avatar = '';
 			$user->save();
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_BAD_AVATAR') . $avatar_deleted);
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_BAD_AVATAR') . $avatar_deleted, 'success');
 		}
 
 		$now       = new Date;
@@ -876,13 +876,13 @@ class UserController extends KunenaController
 			$user->websiteurl  = '';
 			$user->signature   = '';
 			$user->save();
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_BAD_PROFILEINFO'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_BAD_PROFILEINFO'), 'success');
 		}
 		elseif (!empty($DelSignature))
 		{
 			$user->signature = '';
 			$user->save();
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_BAD_SIGNATURE'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_BAD_SIGNATURE'), 'success');
 		}
 
 		if (!empty($banDelPosts))
@@ -902,7 +902,7 @@ class UserController extends KunenaController
 				$mes->publish(KunenaForum::DELETED);
 			}
 
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_BAD_MESSAGES'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_BAD_MESSAGES'), 'success');
 		}
 
 		if (!empty($banDelPostsPerm))
@@ -922,7 +922,7 @@ class UserController extends KunenaController
 				$mes->delete();
 			}
 
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_PERM_BAD_MESSAGES'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_MODERATE_DELETED_PERM_BAD_MESSAGES'), 'success');
 		}
 
 		$this->setRedirect($user->getUrl(false));
@@ -977,6 +977,7 @@ class UserController extends KunenaController
 			}
 			catch (Exception $e)
 			{
+				// Is this empty by design?
 				$this->app->enqueueMessage();
 
 				return false;
@@ -985,7 +986,7 @@ class UserController extends KunenaController
 			if ($result != false)
 			{
 				// Report accepted. There is no need to display the reason
-				$this->app->enqueueMessage(Text::_('COM_KUNENA_STOPFORUMSPAM_REPORT_SUCCESS'));
+				$this->app->enqueueMessage(Text::_('COM_KUNENA_STOPFORUMSPAM_REPORT_SUCCESS'), 'success');
 
 				return true;
 			}
@@ -1133,7 +1134,7 @@ class UserController extends KunenaController
 
 		if ($me->save())
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_STATUS_SAVED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_STATUS_SAVED'), 'success');
 		}
 
 		$this->setRedirectBack();
@@ -1173,7 +1174,7 @@ class UserController extends KunenaController
 
 		if ($me->save())
 		{
-			$this->app->enqueueMessage(Text::_('COM_KUNENA_STATUS_SAVED'));
+			$this->app->enqueueMessage(Text::_('COM_KUNENA_STATUS_SAVED'), 'success');
 		}
 
 		$this->setRedirectBack();
@@ -1461,7 +1462,7 @@ class UserController extends KunenaController
 
 			if ($number > 0)
 			{
-				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_ATTACHMENTS_DELETE_SUCCESSFULLY', $number));
+				$this->app->enqueueMessage(Text::sprintf('COM_KUNENA_ATTACHMENTS_DELETE_SUCCESSFULLY', $number), 'success');
 				$this->setRedirectBack();
 
 				return;

--- a/src/site/src/View/Topic/HtmlView.php
+++ b/src/site/src/View/Topic/HtmlView.php
@@ -1410,7 +1410,7 @@ class HtmlView extends KunenaView
 		if (!$this->topic->category_id)
 		{
 			$msg = Text::sprintf('COM_KUNENA_POST_NEW_TOPIC_NO_PERMISSIONS', $this->topic->getError());
-			$this->app->enqueueMessage($msg, 'notice');
+			$this->app->enqueueMessage($msg, 'error');
 
 			return false;
 		}
@@ -1486,7 +1486,7 @@ class HtmlView extends KunenaView
 		}
 		catch (Exception $e)
 		{
-			$this->app->enqueueMessage($e->getMessage(), 'notice');
+			$this->app->enqueueMessage($e->getMessage(), 'error');
 
 			return false;
 		}
@@ -1548,7 +1548,7 @@ class HtmlView extends KunenaView
 		}
 		catch (Exception $e)
 		{
-			$this->app->enqueueMessage($e->getMessage(), 'notice');
+			$this->app->enqueueMessage($e->getMessage(), 'error');
 
 			return false;
 		}


### PR DESCRIPTION
Pull Request for Issue # . 
on the front-end successful actions (like saving an announcement resulted into a 'notice' message being displayed (blue) where that should be a success message (green), also some error messages where also displayed as notices (blue), where they should be displayed as error (red)
#### Summary of Changes 
I have gone through all enqueueMessage calls and added 'success' when the message was a success messages and replaced some 'notice' into 'error'

#### Testing Instructions