### PR TITLE
htmlhelper link to kunenaforum.link

### DIFF
--- a/src/libraries/kunena/src/Layout/KunenaLayout.php
+++ b/src/libraries/kunena/src/Layout/KunenaLayout.php
@@ -404,7 +404,7 @@ class KunenaLayout extends KunenaBase
 			$class .= ' locked';
 		}
 
-		$link = HTMLHelper::_('link', $url, $content, $title, $class, $con);
+		$link = HTMLHelper::_('kunenaforum.link', $url, $content, $title, $class, $con);
 
 		KunenaProfiler::getInstance() ? KunenaProfiler::instance()->stop('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
 

--- a/src/libraries/kunena/src/View/KunenaView.php
+++ b/src/libraries/kunena/src/View/KunenaView.php
@@ -822,6 +822,6 @@ class KunenaView extends HtmlView
 			}
 		}
 
-		return HTMLHelper::_('link', $uri, $content, $title, $class, $rel);
+		return HTMLHelper::_('kunenaforum.link', $uri, $content, $title, $class, $rel);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue # . 
link is wrong for last topic

#### Summary of Changes 
changed htmlhelper from link (joomla) to kunenaforum.link

#### Testing Instructions
on recent topics hover over last message, with this PR the tooltip should be showing and populated with content of last message