### PR TITLE
displaying tooltips for PrivateMessages and Birthday although not set…

### DIFF
--- a/src/libraries/kunena/src/User/KunenaUser.php
+++ b/src/libraries/kunena/src/User/KunenaUser.php
@@ -2190,7 +2190,7 @@ class KunenaUser extends CMSObject
 				return '<span class="kicon-profile kicon-profile-gender-' . $gender . '" data-bs-toggle="tooltip" data-placement="right" title="' . $title . '"></span>';
 				break;
 			case 'birthdate' :
-				if (!$this->birthdate)
+				if (!$this->birthdate || $this->birthdate == '0001-01-01')
 				{
 					return false;
 				}
@@ -2228,6 +2228,11 @@ class KunenaUser extends CMSObject
 				break;
 			case 'private' :
 				$pms = KunenaFactory::getPrivateMessaging();
+
+				if (empty($pms->showIcon($this->userid)))
+				{
+					return false;
+				}
 
 				return '<span data-bs-toggle="tooltip" data-placement="right" title="' . Text::_('COM_KUNENA_VIEW_PMS') . '" >' . $pms->showIcon($this->userid) . '</span>';
 				break;


### PR DESCRIPTION
… / configured

Pull Request for Issue # . 
when on message / user profile box > more there is no private message or birthday but the tooltips are still showing
 
#### Summary of Changes 
 
#### Testing Instructions