### PR TITLE
add markup to mail templates

### DIFF
--- a/src/site/language/en-GB/en-GB.com_kunena.ini
+++ b/src/site/language/en-GB/en-GB.com_kunena.ini
@@ -675,10 +675,10 @@ COM_KUNENA_TOPIC_MESSAGES_ERROR_URL_IN_SUBJECT = "You cannot put an URL in the s
 COM_KUNENA_EMAIL_MESSAGE_LINK_URL = "URL"
 COM_KUNENA_TOPIC_MESSAGE_EMPTY_LINKS_IMAGES_REMOVED_NOT_ALLOWED = "The links and images in your message has been removed, because your aren't allowed to use them, but your message is ended empty so it can't be saved"
 COM_KUNENA_POST_SAVED_WITHOUT_LINKS_AND_IMAGES = "The links or images has been removed from your message because you aren't allowed to add them."
-COM_KUNENA_SENDMAIL_BODY = "A new reply has been posted on the Forum. Message Subject : {SUBJECT}. Posted by : {NAME}. URL : {MESSAGEURL}. Message: {MESSAGE}"
+COM_KUNENA_SENDMAIL_BODY = "A new reply has been posted on the Forum.\n\nMessage Subject : {SUBJECT}.\nPosted by : {NAME}.\nURL : {MESSAGEURL}.\nMessage: {MESSAGE}"
 COM_KUNENA_SENDMAIL_REPLY_SUBJECT = "A new reply has been posted on topic : {SUBJECT}"
 COM_KUNENA_SENDMAIL_REPLYMODERATOR_SUBJECT = "A message has been reported on topic : {SUBJECT}"
-COM_KUNENA_SENDMAIL_BODY_REPORTMODERATOR = "A message has been reported on the Forum with the following reason : {REASON} and with the following message : {REASONMESSAGE}. Message Subject : {SUBJECT}. Posted by : {NAME}. URL : {MESSAGEURL}. Message: {MESSAGE}"
+COM_KUNENA_SENDMAIL_BODY_REPORTMODERATOR = "A message has been reported on the Forum with the following reason : {REASON} and with the following message : {REASONMESSAGE}.\n\nMessage Subject : {SUBJECT}.\nPosted by : {NAME}.\nURL : {MESSAGEURL}.\nMessage: {MESSAGE}"
 COM_KUNENA_SENDMAIL_REPORT_SUBJECT = "Message reported : {SUBJECT}"
 
 ; JROOT/components/com_kunena/controllers/topics.php


### PR DESCRIPTION
Pull Request for Issue

mail templates have body consisting of one single line of text (no 'paragraphs / line breaks) 
 
#### Summary of Changes 

did some markup to the body of the mail send via the MailTemplate 

#### Testing Instructions
create topic / reply to topic / report message

mail received should be multi line instead of one line containing all content.