### PR TITLE
fix (not) allow anonymous

### DIFF
--- a/src/site/template/aurelia/layouts/topic/edit/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/default.php
@@ -276,7 +276,7 @@ Text::script('COM_KUNENA_POLL_TITLE');
                 </div>
 			<?php endif; ?>
 
-			<?php if ($this->category->allowAnonymous && !$this->me->userid) : ?>
+			<?php if (!$this->category->allowAnonymous && !$this->me->userid) : ?>
                 <div class="alert alert-info"><?php echo Text::_('COM_KUNENA_GEN_INFO_GUEST_CANNOT_EDIT_DELETE_MESSAGE'); ?></div>
                 <div class="form-group row" id="kanynomous-check-name">
                     <label for="kauthorname"


### PR DESCRIPTION
Pull Request for Issue #9111  . 
 
#### Summary of Changes 
allow anonymous on category was toggled wrong

#### Testing Instructions
set allow anonymous on category to yes: when posting as guest no name field (and pst name = anonymous)
set allow anonymous on category to no: when posting name field required (and post name = given name)