### PR TITLE
fix showing images / attachments to guest when configured to not display

### DIFF
--- a/src/libraries/kunena/src/Attachment/KunenaAttachment.php
+++ b/src/libraries/kunena/src/Attachment/KunenaAttachment.php
@@ -767,7 +767,12 @@ class KunenaAttachment extends KunenaDatabaseObject
 
 				try
 				{
-					$this->$authFunction($user);
+					$exception = $this->$authFunction($user);
+
+					if ($exception)
+					{
+						break;
+					}
 				}
 				catch (Exception $e)
 				{
@@ -1103,7 +1108,7 @@ class KunenaAttachment extends KunenaDatabaseObject
 			return new KunenaExceptionAuthorise(Text::_('COM_KUNENA_ATTACHMENT_NO_ACCESS'), 404);
 		}
 
-		return true;
+		return;
 	}
 
 	/**
@@ -1137,7 +1142,7 @@ class KunenaAttachment extends KunenaDatabaseObject
 			}
 		}
 
-		return true;
+		return;
 	}
 
 	/**
@@ -1156,6 +1161,6 @@ class KunenaAttachment extends KunenaDatabaseObject
 			return new KunenaExceptionAuthorise(Text::_('COM_KUNENA_ATTACHMENT_NO_ACCESS'), 403);
 		}
 
-		return true;
+		return;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #9113  . 
 
#### Summary of Changes
reverted return on functions authoriseRead/Own/Exists()
not for this specific issue (images and attachments showing for guests when not allowed to show) only the authoriseRead return should have changed, but I figured that this issue is also valid for authoriseOwn and authoriseExists
 
#### Testing Instructions
create message with image and or attachment
toggle 'Show Images for Guests' and 'Show Attachments for Guests' and see if the image / attachment display / do not display correct