### PR TITLE
[K6.0] The exist status of an user was wrong, new user wasn't added in #__kunena_users table

### DIFF
--- a/src/libraries/kunena/src/Tables/KunenaUsers.php
+++ b/src/libraries/kunena/src/Tables/KunenaUsers.php
@@ -591,7 +591,7 @@ class KunenaUsers extends KunenaTable
 			return false;
 		}
 
-		if ($data !== null)
+		if ($data['posts'] !== null)
 		{
 			$this->_exists = true;
 		}


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
 
The exist status of an user was wrong, a new user wasn't added in #__kunena_users table and when save user profile the changes was lost

#### Testing Instructions

Create a new user, make changes in his profile and save his profile. The changes should be keeped in his profile