### PR TITLE
Fix: category identation

### DIFF
--- a/src/admin/src/View/Categories/HtmlView.php
+++ b/src/admin/src/View/Categories/HtmlView.php
@@ -91,7 +91,7 @@ class HtmlView extends BaseHtmlView
 		// Preprocess the list of items to find ordering divisions.
 		$ordering = [];
 
-		foreach ($this->categories as $item)
+        foreach ($this->categories as $item)
 		{
 			$ordering[$item->parentid][] = $item->id;
 		}

--- a/src/libraries/kunena/src/Forum/Category/KunenaCategory.php
+++ b/src/libraries/kunena/src/Forum/Category/KunenaCategory.php
@@ -1404,7 +1404,7 @@ class KunenaCategory extends KunenaDatabaseObject
 
 		$this->params = $registry;
 
-		// Register category if it exists
+        // Register category if it exists
 		if ($exists)
 		{
 			KunenaCategoryHelper::register($this);

--- a/src/libraries/kunena/src/Forum/Category/KunenaCategoryHelper.php
+++ b/src/libraries/kunena/src/Forum/Category/KunenaCategoryHelper.php
@@ -128,7 +128,7 @@ abstract class KunenaCategoryHelper
 			$cat_instances [$id] = $kunenacategory;
 		}
 
-		// TODO: remove this by adding level into table
+        // TODO: remove this by adding level into table
 		self::buildTree($cat_instances);
 		$heap = [null];
 
@@ -237,10 +237,21 @@ abstract class KunenaCategoryHelper
 	{
 		if ($instance->exists())
 		{
-			$instance->level                  = isset(self::$_instances [$instance->parentid]) ? self::$_instances [$instance->parentid]->level + 1 : 0;
-			self::$_instances [$instance->id] = $instance;
+            if ($instance->parentid == 0)
+            {
+                $instance->level = 0;
+            } elseif (isset(self::$_instances [$instance->parentid]))
+            {
+                $instance->level = self::$_instances [$instance->parentid]->level + 1;
+            } else
+            {
+                $parentCategory = self::get($instance->parentid);
+                $instance->level = $parentCategory->level + 1;
+            }
 
-			if (!isset(self::$_tree [(int) $instance->id]))
+            self::$_instances [$instance->id] = $instance;
+
+            if (!isset(self::$_tree [(int) $instance->id]))
 			{
 				self::$_tree [$instance->id]                      = [];
 				self::$_tree [$instance->parentid][$instance->id] = &self::$_tree [$instance->id];
@@ -775,7 +786,7 @@ abstract class KunenaCategoryHelper
 	{
 		$list = [];
 
-		foreach ($parents as $parent)
+        foreach ($parents as $parent)
 		{
 			if ($parent instanceof KunenaCategory)
 			{
@@ -882,7 +893,7 @@ abstract class KunenaCategoryHelper
 			}
 		}
 
-		return $list;
+        return $list;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #9258  . 
 
#### Summary of Changes 
when building the category tree, the categories are read from the database sorted on name. This leads to the issue that a category is processed before it's parent category has been processed. When building the category tree, the category level on a category is set via checking the already processed categories: in this case the child category is processed before the parent category and gets level = 0 instead of parent->level +1

This change checks if the parent category is already processed before processing the child. If not, it will process the parent category and then set the child category level accordingly.

#### Testing Instructions
on fresh install:
create section 'Blog' (id =1)
create category 'Hoofd-zaken' (id = 2, parent is 'Blog')
create category 'Bio-logisch' (id = 3, parent is 'Blog')
create category 'Het-kan-wel' (id = 4, parent is 'Blog')
create category 'O-o-opinie' (id = 5, parent is 'Blog')
create section 'testsection' (id = 6)
create category 'testcategory1' (id = 7, parent is 'testsection')
create category 'testcategory2' (id = 8, parent is 'testsection')

Before this PR: (testcategory1 is handled BEFORE parent testsection if processed because it is sorted on name)
![image](https://user-images.githubusercontent.com/2733197/189894711-9febaaf7-7b26-4ce5-bed9-22fd8b2cdbcf.png)

After this PR
![image](https://user-images.githubusercontent.com/2733197/189894738-f45c4105-1d87-4aa1-a807-c16e56ddb1d2.png)
