### PR TITLE
Fix: stripping HTML from tooltips without encoding

### DIFF
--- a/src/libraries/kunena/src/Layout/KunenaLayout.php
+++ b/src/libraries/kunena/src/Layout/KunenaLayout.php
@@ -15,6 +15,7 @@ namespace Kunena\Forum\Libraries\Layout;
 \defined('_JEXEC') or die();
 
 use Exception;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Kunena\Forum\Libraries\Config\KunenaConfig;
@@ -282,7 +283,8 @@ class KunenaLayout extends KunenaBase
 			if (strpos($class, 'hasTooltip') !== false)
 			{
 				// Tooltips will decode HTML and we don't want the HTML to be parsed
-				$title = $this->escape($title);
+                $filter = InputFilter::getInstance();
+				$title  = $filter->clean($title, 'string');
 			}
 		}
 
@@ -376,8 +378,9 @@ class KunenaLayout extends KunenaBase
 				if (strpos($class, 'hasTooltip') !== false)
 				{
 					// Tooltips will decode HTML and we don't want the HTML to be parsed
-					$title = $this->escape($title);
-				}
+                    $filter = InputFilter::getInstance();
+                    $title  = $filter->clean($title, 'string');
+                }
 			}
 		}
 
@@ -458,7 +461,8 @@ class KunenaLayout extends KunenaBase
 			if (strpos($class, 'hasTooltip') !== false)
 			{
 				// Tooltips will decode HTML and we don't want the HTML to be parsed
-				$title = $this->escape($title);
+                $filter = InputFilter::getInstance();
+				$title  = $filter->clean($title, 'string');
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #9264  . 
 
#### Summary of Changes
Use Joomla API InputFilter for filtering text in tooltips as BS5 is more strict and filtering via escape will generated encoded characters
 
#### Testing Instructions
Install PR and check if tooltips are displaying correct