### PR TITLE
Fix: hide caticons on mobile view

### DIFF
--- a/src/site/template/aurelia/layouts/category/index/default.php
+++ b/src/site/template/aurelia/layouts/category/index/default.php
@@ -107,7 +107,7 @@ foreach ($this->sections as $section) :
 				<?php else : ?>
 					<?php if (!empty($this->categories[$section->id])) : ?>
                         <tr>
-                            <td colspan="1">
+                            <td colspan="1" class="d-none d-md-table-cell">
                                 <div class="p-2"></div>
                             </td>
                             <td colspan="7">
@@ -122,7 +122,7 @@ foreach ($this->sections as $section) :
 					foreach ($this->categories[$section->id] as $category) : ?>
                         <tr class="category<?php echo $this->escape($category->class_sfx); ?>"
                             id="category<?php echo $category->id; ?>">
-                            <td colspan="1" id="kcat-icon">
+                            <td colspan="1" id="kcat-icon" class="d-none d-md-table-cell">
 								<?php echo $this->getCategoryLink($category, $this->getCategoryIcon($category), '', null, true, false); ?>
                             </td>
                             <td colspan="6">


### PR DESCRIPTION
Pull Request for Issue #9266  . 
 
#### Summary of Changes
add class to caticons

The underlying issue here is that class hidden-xs-down  that is applied in several views is a BS4 class and doesn't work in BS5.
it should be replaced with 'd-none d-md-table-cell'

same as 'center' should be replaced with 'text-center'

I will do a follow up pr for this
 
#### Testing Instructions