### PR TITLE
Hidden class

### DIFF
--- a/src/admin/tmpl/attachments/default.php
+++ b/src/admin/tmpl/attachments/default.php
@@ -68,12 +68,12 @@ Joomla.tableOrdering(order, dirn, "");
 										class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
 							</button>
 						</div>
-						<div class="btn-group pull-right hidden-phone">
+						<div class="btn-group pull-right d-none d-md-block">
 							<label for="limit"
 								   class="element-invisible"><?php echo Text::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 							<?php echo $this->pagination->getLimitBox(); ?>
 						</div>
-						<div class="btn-group pull-right hidden-phone">
+						<div class="btn-group pull-right d-none d-md-block">
 							<label for="directionTable"
 								   class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
 							<select name="directionTable" id="directionTable" class="input-medium"
@@ -108,7 +108,7 @@ Joomla.tableOrdering(order, dirn, "");
 							<th><?php echo HTMLHelper::_('grid.sort', 'JGRID_HEADING_ID', 'id', $this->list->Direction, $this->list->Ordering); ?></th>
 						</tr>
 						<tr>
-							<td class="hidden-phone">
+							<td class="d-none d-md-table-cell">
 							</td>
 							<td class="nowrap">
 								<label for="filterTitle"
@@ -166,7 +166,7 @@ Joomla.tableOrdering(order, dirn, "");
 									   value="<?php echo $this->filter->Post; ?>"
 									   title="<?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERSUBMIT') ?>"/>
 							</td>
-							<td class="nowrap center hidden-phone">
+							<td class="nowrap center d-none d-md-table-cell">
 							</td>
 						</tr>
 						</thead>

--- a/src/admin/tmpl/categories/default.php
+++ b/src/admin/tmpl/categories/default.php
@@ -69,12 +69,12 @@ if ($saveOrder && !empty($this->items))
                                         class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
                             </button>
                         </div>
-                        <div class="btn-group pull-right hidden-phone">
+                        <div class="btn-group pull-right d-none d-md-block">
                             <label for="limit"
                                    class="element-invisible"><?php echo Text::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 							<?php echo $this->pagination->getLimitBox(); ?>
                         </div>
-                        <div class="btn-group pull-right hidden-phone">
+                        <div class="btn-group pull-right d-none d-md-block">
                             <label for="directionTable"
                                    class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
                             <select name="directionTable" id="directionTable" class="form-select input-medium"
@@ -105,10 +105,10 @@ if ($saveOrder && !empty($this->items))
                     <table class="table table-striped" id="categoryList">
                         <thead>
                         <tr>
-                            <th width="1%" class="hidden-phone">
+                            <th width="1%" class="d-none d-md-table-cell">
                                 <?php echo HTMLHelper::_('grid.checkall'); ?>
                             </th>
-                            <th width="1%" class="nowrap center hidden-phone">
+                            <th width="1%" class="nowrap center d-none d-md-block">
 								<?php echo HTMLHelper::_('searchtools.sort', '', 'a.lft', $this->list->Direction, $this->list->Ordering, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-sort'); ?>
                             </th>
                             <th width="5%" class="nowrap center">
@@ -120,7 +120,7 @@ if ($saveOrder && !empty($this->items))
                             <th width="51%" class="nowrap">
 								<?php echo HTMLHelper::_('grid.sort', 'JGLOBAL_TITLE', 'p.title', $this->list->Direction, $this->list->Ordering); ?>
                             </th>
-                            <th width="20%" class="nowrap center hidden-phone">
+                            <th width="20%" class="nowrap center d-none d-md-block">
 								<?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_CATEGORIES_LABEL_ACCESS', 'p.access', $this->list->Direction, $this->list->Ordering); ?>
                             </th>
                             <th width="5%" class="nowrap center">
@@ -135,14 +135,14 @@ if ($saveOrder && !empty($this->items))
                             <th width="5%" class="nowrap center">
 								<?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_CATEGORY_ANONYMOUS', 'p.anonymous', $this->list->Direction, $this->list->Ordering); ?>
                             </th>
-                            <th width="1%" class="nowrap center hidden-phone">
+                            <th width="1%" class="nowrap center d-none d-md-block">
 								<?php echo HTMLHelper::_('grid.sort', 'JGRID_HEADING_ID', 'p.id', $this->list->Direction, $this->list->Ordering); ?>
                             </th>
                         </tr>
                         <tr>
-                            <td class="hidden-phone">
+                            <td class="d-none d-md-table-cell">
                             </td>
-                            <td class="hidden-phone">
+                            <td class="d-none d-md-table-cell">
                             </td>
                             <td class="nowrap center">
                                 <label for="filter_published"
@@ -166,7 +166,7 @@ if ($saveOrder && !empty($this->items))
                                        value="<?php echo $this->filter->Title; ?>"
                                        title="<?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERSUBMIT') ?>"/>
                             </td>
-                            <td class="nowrap center hidden-phone">
+                            <td class="nowrap center d-none d-md-table-cell">
                                 <label for="filterAccess"
                                        class="element-invisible"><?php echo Text::_('COM_KUNENA_FIELD_LABEL_ALL'); ?></label>
                                 <select name="filterAccess" id="filterAccess"
@@ -216,7 +216,7 @@ if ($saveOrder && !empty($this->items))
 									<?php echo HTMLHelper::_('select.options', $this->anonymousOptions(), 'value', 'text', $this->filter->Anonymous); ?>
                                 </select>
                             </td>
-                            <td class="nowrap center hidden-phone">
+                            <td class="nowrap center d-none d-md-table-cell">
                             </td>
                         </tr>
                         </thead>
@@ -307,13 +307,13 @@ if ($saveOrder && !empty($this->items))
 											<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
                                         </small>
                                     </td>
-                                    <td class="center hidden-phone">
+                                    <td class="center d-none d-md-table-cell">
                                         <span><?php echo $item->accessname; ?></span>
                                         <small>
 											<?php echo Text::sprintf('(Access: %s)', $this->escape($item->accesstype)); ?>
                                         </small>
                                     </td>
-                                    <td class="center hidden-phone">
+                                    <td class="center d-none d-md-table-cell">
                                         <a class="btn btn-micro <?php echo $item->locked ? 'active' : ''; ?>"
                                            href="javascript: void(0);"
                                            onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','<?php echo($item->locked ? 'un' : '') . 'lock'; ?>')">
@@ -323,28 +323,28 @@ if ($saveOrder && !empty($this->items))
 									<?php if ($item->isSection())
 										:
 										?>
-                                        <td class="center hidden-phone" colspan="3">
+                                        <td class="center d-none d-md-table-cell" colspan="3">
 											<?php echo Text::_('COM_KUNENA_SECTION'); ?>
                                         </td>
 									<?php else
 
 										:
 										?>
-                                        <td class="center hidden-phone">
+                                        <td class="center d-none d-md-table-cell">
                                             <a class="btn btn-micro <?php echo $item->review ? 'active' : ''; ?>"
                                                href="javascript: void(0);"
                                                onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','<?php echo($item->review ? 'un' : '') . 'review'; ?>')">
 												<?php echo $item->review == 1 ? $img_yes : $img_no; ?>
                                             </a>
                                         </td>
-                                        <td class="center hidden-phone">
+                                        <td class="center d-none d-md-table-cell">
                                             <a class="btn btn-micro <?php echo $item->allowPolls ? 'active' : ''; ?>"
                                                href="javascript: void(0);"
                                                onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','<?php echo($item->allowPolls ? 'deny' : 'allow') . '_polls'; ?>')">
 												<?php echo $item->allowPolls == 1 ? $img_yes : $img_no; ?>
                                             </a>
                                         </td>
-                                        <td class="center hidden-phone">
+                                        <td class="center d-none d-md-table-cell">
                                             <a class="btn btn-micro <?php echo $item->allowAnonymous ? 'active' : ''; ?>"
                                                href="javascript: void(0);"
                                                onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','<?php echo($item->allowAnonymous ? 'deny' : 'allow') . '_anonymous'; ?>')">
@@ -353,7 +353,7 @@ if ($saveOrder && !empty($this->items))
                                         </td>
 									<?php endif; ?>
 
-                                    <td class="center hidden-phone">
+                                    <td class="center d-none d-md-table-cell">
 										<?php echo (int) $item->id; ?>
                                     </td>
                                 </tr>

--- a/src/admin/tmpl/logs/default.php
+++ b/src/admin/tmpl/logs/default.php
@@ -67,12 +67,12 @@ $filterItem = $this->escape($this->state->get('item.id'));
                                         class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
                             </button>
                         </div>
-                        <div class="btn-group pull-right hidden-phone">
+                        <div class="btn-group pull-right d-none d-md-block">
                             <label for="limit"
                                    class="element-invisible"><?php echo Text::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 							<?php echo $this->pagination->getLimitBox(); ?>
                         </div>
-                        <div class="btn-group pull-right hidden-phone">
+                        <div class="btn-group pull-right d-none d-md-block">
                             <label for="directionTable"
                                    class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
                             <select name="directionTable" id="directionTable" class="input-medium"

--- a/src/admin/tmpl/plugins/default.php
+++ b/src/admin/tmpl/plugins/default.php
@@ -61,12 +61,12 @@ if ($saveOrder)
                                         class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
                             </button>
                         </div>
-                        <div class="btn-group pull-right hidden-phone">
+                        <div class="btn-group pull-right d-none d-md-block">
                             <label for="limit"
                                    class="element-invisible"><?php echo Text::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 							<?php echo $this->pagination->getLimitBox(); ?>
                         </div>
-                        <div class="btn-group pull-right hidden-phone">
+                        <div class="btn-group pull-right d-none d-md-block">
                             <label for="directionTable"
                                    class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
                             <select name="directionTable" id="directionTable" class="input-medium"
@@ -88,7 +88,7 @@ if ($saveOrder)
                     <table class="table table-striped" id="articleList">
                         <thead>
                         <tr>
-                            <th width="1%" class="hidden-phone">
+                            <th width="1%" class="d-none d-md-table-cell">
                                 <input type="checkbox" name="checkall-toggle" value=""
                                        title="<?php echo Text::_('JGLOBAL_CHECK_ALL'); ?>"
                                        onclick="Joomla.checkAll(this)"/>
@@ -99,18 +99,18 @@ if ($saveOrder)
                             <th class="title">
 								<?php echo HTMLHelper::_('grid.sort', 'COM_PLUGINS_NAME_HEADING', 'name', $this->list->Direction, $this->list->Ordering); ?>
                             </th>
-                            <th width="15%" class="nowrap hidden-phone">
+                            <th width="15%" class="nowrap d-none d-md-table-cell">
 								<?php echo HTMLHelper::_('grid.sort', 'COM_PLUGINS_ELEMENT_HEADING', 'element', $this->list->Direction, $this->list->Ordering); ?>
                             </th>
-                            <th width="10%" class="hidden-phone center">
+                            <th width="10%" class="d-none d-md-table-cell center">
 								<?php echo HTMLHelper::_('grid.sort', 'JGRID_HEADING_ACCESS', 'access', $this->list->Direction, $this->list->Ordering); ?>
                             </th>
-                            <th width="1%" class="nowrap center hidden-phone">
+                            <th width="1%" class="nowrap center d-none d-md-table-cell">
 								<?php echo HTMLHelper::_('grid.sort', 'JGRID_HEADING_ID', 'extension_id', $this->list->Direction, $this->list->Ordering); ?>
                             </th>
                         </tr>
                         <tr>
-                            <td class="hidden-phone">
+                            <td class="d-none d-md-table-cell">
                             </td>
                             <td class="nowrap center">
                                 <label for="filter_enabled"
@@ -152,7 +152,7 @@ if ($saveOrder)
 									<?php echo HTMLHelper::_('select.options', HTMLHelper::_('access.assetgroups'), 'value', 'text', $this->filter->Access, true); ?>
                                 </select>
                             </td>
-                            <td class="nowrap center hidden-phone">
+                            <td class="nowrap center d-none d-md-table-cell">
                             </td>
                         </tr>
                         </thead>
@@ -174,7 +174,7 @@ if ($saveOrder)
 								$canChange  = $this->user->authorise('core.edit.state', 'com_plugins') && $canCheckin;
 								?>
                                 <tr>
-                                    <td class="center hidden-phone">
+                                    <td class="center d-none d-md-table-cell">
 										<?php echo HTMLHelper::_('grid.id', $i, $item->extension_id); ?>
                                     </td>
                                     <td class="center">
@@ -218,13 +218,13 @@ if ($saveOrder)
 											<?php echo $item->name; ?>
 										<?php endif; ?>
                                     </td>
-                                    <td class="nowrap small hidden-phone">
+                                    <td class="nowrap small d-none d-md-table-cell">
 										<?php echo $this->escape($item->element); ?>
                                     </td>
-                                    <td class="small hidden-phone center">
+                                    <td class="small d-none d-md-table-cell center">
 										<?php echo $this->escape($item->access_level); ?>
                                     </td>
-                                    <td class="center hidden-phone">
+                                    <td class="center d-none d-md-table-cell">
 										<?php echo (int) $item->extension_id; ?>
                                     </td>
                                 </tr>

--- a/src/admin/tmpl/ranks/default.php
+++ b/src/admin/tmpl/ranks/default.php
@@ -93,10 +93,10 @@ $wa->useScript('multiselect');
                                                 <i class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
                                             </button>
                                         </div>
-                                        <div class="btn-group pull-right hidden-phone">
+                                        <div class="btn-group pull-right d-none d-md-block">
 											<?php echo $this->pagination->getLimitBox(); ?>
                                         </div>
-                                        <div class="btn-group pull-right hidden-phone">
+                                        <div class="btn-group pull-right d-none d-md-block">
                                             <label for="directionTable"
                                                    class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
                                             <select name="directionTable" id="directionTable" class="input-medium"
@@ -136,14 +136,14 @@ $wa->useScript('multiselect');
                                             <th width="10%" class="nowrap center">
 												<?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_RANKSMIN', 'min', $this->list->Direction, $this->list->Ordering); ?>
                                             </th>
-                                            <th width="1%" class="nowrap center hidden-phone">
+                                            <th width="1%" class="nowrap center d-none d-md-table-cell">
 												<?php echo HTMLHelper::_('grid.sort', 'JGRID_HEADING_ID', 'id', $this->list->Direction, $this->list->Ordering); ?>
                                             </th>
                                         </tr>
                                         <tr>
-                                            <td class="hidden-phone">
+                                            <td class="d-none d-md-table-cell">
                                             </td>
-                                            <td class="hidden-phone">
+                                            <td class="d-none d-md-table-cell">
                                             </td>
                                             <td class="nowrap">
                                                 <label for="filterTitle"
@@ -175,7 +175,7 @@ $wa->useScript('multiselect');
                                                        value="<?php echo $this->filter->MinPostCount; ?>"
                                                        title="<?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERSUBMIT') ?>"/>
                                             </td>
-                                            <td class="hidden-phone">
+                                            <td class="d-none d-md-table-cell">
                                             </td>
                                         </tr>
                                         </thead>

--- a/src/admin/tmpl/smilies/default.php
+++ b/src/admin/tmpl/smilies/default.php
@@ -94,10 +94,10 @@ $wa->useScript('multiselect');
                                                 <i class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
                                             </button>
                                         </div>
-                                        <div class="btn-group pull-right hidden-phone">
+                                        <div class="btn-group pull-right d-none d-md-block">
 											<?php echo $this->pagination->getLimitBox(); ?>
                                         </div>
-                                        <div class="btn-group pull-right hidden-phone">
+                                        <div class="btn-group pull-right d-none d-md-block">
                                             <label for="directionTable"
                                                    class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
                                             <select name="directionTable" id="directionTable" class="input-medium"
@@ -128,14 +128,14 @@ $wa->useScript('multiselect');
                                                 class="center"><?php echo Text::_('COM_KUNENA_EMOTICON'); ?></th>
                                             <th width="8%"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_EMOTICONS_CODE', 'code', $this->list->Direction, $this->list->Ordering); ?></th>
                                             <th><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_EMOTICONS_URL', 'location', $this->list->Direction, $this->list->Ordering); ?></th>
-                                            <th width="1%" class="nowrap center hidden-phone">
+                                            <th width="1%" class="nowrap center d-none d-md-table-cell">
 												<?php echo HTMLHelper::_('grid.sort', 'JGRID_HEADING_ID', 'id', $this->list->Direction, $this->list->Ordering); ?>
                                             </th>
                                         </tr>
                                         <tr>
-                                            <td class="hidden-phone center">
+                                            <td class="d-none d-md-table-cell center">
                                             </td>
-                                            <td class="hidden-phone center">
+                                            <td class="d-none d-md-table-cell center">
                                             </td>
                                             <td class="nowrap center">
                                                 <label for="filter_code"
@@ -158,7 +158,7 @@ $wa->useScript('multiselect');
                                                        value="<?php echo $this->filter->Location; ?>"
                                                        title="<?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERSUBMIT') ?>"/>
                                             </td>
-                                            <td class="hidden-phone center">
+                                            <td class="d-none d-md-table-cell center">
                                             </td>
                                         </tr>
                                         </thead>
@@ -179,12 +179,12 @@ $wa->useScript('multiselect');
 												:
 												?>
                                                 <tr>
-                                                    <td class="hidden-phone center">
+                                                    <td class="d-none d-md-table-cell center">
                                                         <input type="checkbox" id="cb<?php echo $id; ?>" name="cid[]"
                                                                value="<?php echo $this->escape($row->id); ?>"
                                                                onclick="Joomla.isChecked(this.checked);"/>
                                                     </td>
-                                                    <td class="hidden-phone center">
+                                                    <td class="d-none d-md-table-cell center">
                                                         <a href="#edit"
                                                            onclick="return Joomla.listItemTask('cb<?php echo $id; ?>','smiley.edit')">
                                                             <img loading=lazy
@@ -192,7 +192,7 @@ $wa->useScript('multiselect');
                                                                  alt="<?php echo $this->escape($row->location); ?>"/>
                                                         </a>
                                                     </td>
-                                                    <td class="hidden-phone">
+                                                    <td class="d-none d-md-table-cell">
 														<?php echo $this->escape($row->code); ?>
                                                     </td>
                                                     <td>

--- a/src/admin/tmpl/statistics/default.php
+++ b/src/admin/tmpl/statistics/default.php
@@ -62,12 +62,12 @@ use Kunena\Forum\Libraries\User\KunenaUserHelper;
 										class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
 							</button>
 						</div>
-						<div class="btn-group pull-right hidden-phone">
+						<div class="btn-group pull-right d-none d-md-block">
 							<label for="limit"
 								   class="element-invisible"><?php echo Text::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 							<?php echo $this->pagination->getLimitBox(); ?>
 						</div>
-						<div class="btn-group pull-right hidden-phone">
+						<div class="btn-group pull-right d-none d-md-block">
 							<label for="directionTable"
 								   class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
 							<select name="directionTable" id="directionTable" class="input-medium"

--- a/src/admin/tmpl/template.php
+++ b/src/admin/tmpl/template.php
@@ -97,14 +97,14 @@ class KunenaAdminTemplate
 		{
 			$limit = 'limitstart.value=' . (int) $item->base;
 
-			return '<li class="page-item hidden-sm-down"><a class="page-link" href="#" title="' . $item->text . '" onclick="document.adminForm.' . $item->prefix . $limit . ';
+			return '<li class="page-item d-none d-md-block"><a class="page-link" href="#" title="' . $item->text . '" onclick="document.adminForm.' . $item->prefix . $limit . ';
 			 Joomla.submitform();return false;">' . $display . '</a></li>';
 		}
 
 		// Check if the item is the active (or current) page.
 		if (!empty($item->active))
 		{
-			return '<li class="page-item active hidden-sm-down"><a class="page-link">' . $display . '</a></li>';
+			return '<li class="page-item active d-none d-md-block"><a class="page-link">' . $display . '</a></li>';
 		}
 
 		// Doesn't match any other condition, render disabled item.

--- a/src/admin/tmpl/templates/default.php
+++ b/src/admin/tmpl/templates/default.php
@@ -34,7 +34,7 @@ $wa->useScript('multiselect');
 					<input type="hidden" name="boxchecked" value="0"/>
 					<?php echo HTMLHelper::_('form.token'); ?>
 
-					<div class="btn-group pull-right hidden-phone">
+					<div class="btn-group pull-right d-none d-md-block">
 						<label for="limit"
 							   class="element-invisible"><?php echo Text::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 					</div>

--- a/src/admin/tmpl/tools/subscriptions.php
+++ b/src/admin/tmpl/tools/subscriptions.php
@@ -38,7 +38,7 @@ use Kunena\Forum\Libraries\Route\KunenaRoute;
 						:
 							?>
 							<tr>
-								<td class="hidden-phone center">
+								<td class="d-none d-md-table-cell center">
 									<input type="checkbox" id="cb<?php echo $user->id; ?>" name="cid[]"
 										   value="<?php echo $this->escape($user->id); ?>"
 										   onclick="Joomla.isChecked(this.checked);"/>
@@ -56,7 +56,7 @@ use Kunena\Forum\Libraries\Route\KunenaRoute;
 						:
 							?>
 							<tr>
-								<td class="hidden-phone center">
+								<td class="d-none d-md-table-cell center">
 									<input type="checkbox" id="cb<?php echo $user->id; ?>" name="cid[]"
 										   value="<?php echo $this->escape($user->id); ?>"
 										   onclick="Joomla.isChecked(this.checked);"/>
@@ -74,7 +74,7 @@ use Kunena\Forum\Libraries\Route\KunenaRoute;
 						:
 							?>
 							<tr>
-								<td class="hidden-phone center">
+								<td class="d-none d-md-table-cell center">
 									<input type="checkbox" id="cb<?php echo $sub->id; ?>" name="cid[]"
 										   value="<?php echo $this->escape($sub->id); ?>"
 										   onclick="Joomla.isChecked(this.checked);"/>

--- a/src/admin/tmpl/trash/messages.php
+++ b/src/admin/tmpl/trash/messages.php
@@ -66,12 +66,12 @@ $wa->useScript('multiselect');
 											class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
 								</button>
 							</div>
-							<div class="btn-group pull-right hidden-phone">
+							<div class="btn-group pull-right d-none d-md-block">
 								<label for="limit"
 									   class="element-invisible"><?php echo Text::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 								<?php echo $this->pagination->getLimitBox(); ?>
 							</div>
-							<div class="btn-group pull-right hidden-phone">
+							<div class="btn-group pull-right d-none d-md-block">
 								<label for="directionTable"
 									   class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
 								<select name="directionTable" id="directionTable" class="input-medium"
@@ -123,11 +123,11 @@ $wa->useScript('multiselect');
 								</th>
 							</tr>
 							<tr>
-								<td class="hidden-phone">
+								<td class="d-none d-md-table-cell">
 								</td>
-								<td class="hidden-phone">
+								<td class="d-none d-md-table-cell">
 								</td>
-								<td class="hidden-phone">
+								<td class="d-none d-md-table-cell">
 									<label for="filterTitle"
 										   class="element-invisible"><?php echo Text::_('COM_KUNENA_FIELD_LABEL_SEARCHIN'); ?></label>
 									<input class="input-block-level input-filter form-control" type="text"
@@ -137,7 +137,7 @@ $wa->useScript('multiselect');
 										   value="<?php echo $this->filterTitle; ?>"
 										   title="<?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERSUBMIT') ?>"/>
 								</td>
-								<td class="hidden-phone">
+								<td class="d-none d-md-table-cell">
 									<label for="filter_topic"
 										   class="element-invisible"><?php echo Text::_('COM_KUNENA_FIELD_LABEL_SEARCHIN'); ?></label>
 									<input class="input-block-level input-filter form-control" type="text"
@@ -147,7 +147,7 @@ $wa->useScript('multiselect');
 										   value="<?php echo $this->filterTopic; ?>"
 										   title="<?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERSUBMIT'); ?>"/>
 								</td>
-								<td class="hidden-phone">
+								<td class="d-none d-md-table-cell">
 									<label for="filter_category"
 										   class="element-invisible"><?php echo Text::_('COM_KUNENA_FIELD_LABEL_SEARCHIN'); ?></label>
 									<input class="input-block-level input-filter form-control" type="text"

--- a/src/admin/tmpl/trash/topics.php
+++ b/src/admin/tmpl/trash/topics.php
@@ -66,12 +66,12 @@ $wa->useScript('multiselect');
 											class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
 								</button>
 							</div>
-							<div class="btn-group pull-right hidden-phone">
+							<div class="btn-group pull-right d-none d-md-block">
 								<label for="limit"
 									   class="element-invisible"><?php echo Text::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 								<?php echo $this->pagination->getLimitBox(); ?>
 							</div>
-							<div class="btn-group pull-right hidden-phone">
+							<div class="btn-group pull-right d-none d-md-block">
 								<label for="directionTable"
 									   class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
 								<select name="directionTable" id="directionTable" class="input-medium"
@@ -118,11 +118,11 @@ $wa->useScript('multiselect');
 								</th>
 							</tr>
 							<tr>
-								<td class="hidden-phone">
+								<td class="d-none d-md-table-cell">
 								</td>
-								<td class="hidden-phone">
+								<td class="d-none d-md-table-cell">
 								</td>
-								<td class="hidden-phone">
+								<td class="d-none d-md-table-cell">
 									<label for="filterTitle"
 										   class="element-invisible"><?php echo Text::_('COM_KUNENA_FIELD_LABEL_SEARCHIN'); ?></label>
 									<input class="input-block-level input-filter form-control" type="text"
@@ -132,7 +132,7 @@ $wa->useScript('multiselect');
 										   value="<?php echo $this->filterTitle; ?>"
 										   title="<?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERSUBMIT') ?>"/>
 								</td>
-								<td class="hidden-phone">
+								<td class="d-none d-md-table-cell">
 									<label for="filter_category"
 										   class="element-invisible"><?php echo Text::_('COM_KUNENA_FIELD_LABEL_SEARCHIN'); ?></label>
 									<input class="input-block-level input-filter form-control" type="text"

--- a/src/admin/tmpl/user/edit.php
+++ b/src/admin/tmpl/user/edit.php
@@ -303,7 +303,7 @@ jQuery(function($) {
                                                     <thead>
                                                     <tr>
 														<?php /*
-															<th width="1%" class="hidden-phone">
+															<th width="1%" class="d-none d-md-table-cell">
 																<input type="checkbox" name="checkall-toggle" value="" title="<?php echo Text::_('JGLOBAL_CHECK_ALL'); ?>" onclick="checkAll(<?php echo count($this->categories); ?>);" />
 															</th>
 															*/ ?>
@@ -342,7 +342,7 @@ jQuery(function($) {
                                                     <thead>
                                                     <tr>
 														<?php /*
-															<th width="1%" class="hidden-phone">
+															<th width="1%" class="d-none d-md-table-cell">
 																<input type="checkbox" name="checkall-toggle" value="" title="<?php echo Text::_('JGLOBAL_CHECK_ALL'); ?>" onclick="checkAll(<?php echo count($this->categories); ?>);" />
 															</th>
 															*/ ?>

--- a/src/admin/tmpl/users/default.php
+++ b/src/admin/tmpl/users/default.php
@@ -72,12 +72,12 @@ $wa->useScript('multiselect');
                                         class="icon-remove"></i> <?php echo Text::_('COM_KUNENA_SYS_BUTTON_FILTERRESET'); ?>
                             </button>
                         </div>
-                        <div class="btn-group pull-right hidden-phone">
+                        <div class="btn-group pull-right d-none d-md-block">
                             <label for="limit"
                                    class="element-invisible"><?php echo Text::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC'); ?></label>
 							<?php echo $this->pagination->getLimitBox(); ?>
                         </div>
-                        <div class="btn-group pull-right hidden-phone">
+                        <div class="btn-group pull-right d-none d-md-block">
                             <label for="directionTable"
                                    class="element-invisible"><?php echo Text::_('JFIELD_ORDERING_DESC'); ?></label>
                             <select name="directionTable" id="directionTable" class="input-medium"
@@ -103,24 +103,24 @@ $wa->useScript('multiselect');
                             <th width="1%" class="nowrap center"><input type="checkbox" name="toggle" value=""
                                                                         onclick="Joomla.checkAll(this)"/></th>
                             <th><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_USRL_USERNAME', 'username', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
-                            <th class="hidden-phone"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_GEN_EMAIL', 'email', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
+                            <th class="d-none d-md-table-cell"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_GEN_EMAIL', 'email', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
                             <th width="5%"
-                                class="hidden-phone"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_GEN_IP', 'ip', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
+                                class="d-none d-md-table-cell"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_GEN_IP', 'ip', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
                             <th width="10%"
-                                class="nowrap hidden-phone hidden-tablet"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_A_RANKS', 'rank', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
+                                class="nowrap d-none d-md-table-cell"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_A_RANKS', 'rank', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
                             <th width="5%"
-                                class="nowrap center hidden-phone hidden-tablet"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_GEN_SIGNATURE', 'signature', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
+                                class="nowrap center d-none d-lg-table-cell"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_GEN_SIGNATURE', 'signature', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
                             <th width="5%"
-                                class="nowrap center hidden-phone"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_USRL_ENABLED', 'enabled', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
+                                class="nowrap center d-none d-md-table-cell"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_USRL_ENABLED', 'enabled', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
                             <th width="5%"
-                                class="nowrap center hidden-phone"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_USRL_BANNED', 'banned', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
+                                class="nowrap center d-none d-md-table-cell"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_USRL_BANNED', 'banned', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
                             <th width="5%"
-                                class="nowrap center hidden-phone hidden-tablet"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_VIEW_MODERATOR', 'moderator', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
+                                class="nowrap center d-none d-lg-table-cell"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_VIEW_MODERATOR', 'moderator', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
                             <th width="1%"
                                 class="nowrap center"><?php echo HTMLHelper::_('grid.sort', 'COM_KUNENA_ANN_ID', 'id', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?></th>
                         </tr>
                         <tr>
-                            <td class="hidden-phone">
+                            <td class="d-none d-md-table-cell">
                             </td>
                             <td class="nowrap">
                                 <label for="filter_username"
@@ -161,7 +161,7 @@ $wa->useScript('multiselect');
 									<?php echo HTMLHelper::_('select.options', $this->ranksOptions(), 'value', 'text', $this->filter->Rank); ?>
                                 </select>
                             </td>
-                            <td class="nowrap center hidden-phone">
+                            <td class="nowrap center d-none d-md-table-cell">
                                 <label for="filter_signature"
                                        class="element-invisible"><?php echo Text::_('COM_KUNENA_FIELD_LABEL_ALL'); ?></label>
                                 <select name="filter_signature" id="filter_signature"
@@ -200,7 +200,7 @@ $wa->useScript('multiselect');
 									<?php echo HTMLHelper::_('select.options', $this->moderatorOptions(), 'value', 'text', $this->filter->Moderator); ?>
                                 </select>
                             </td>
-                            <td class="nowrap center hidden-phone">
+                            <td class="nowrap center d-none d-md-table-cell">
                             </td>
                         </tr>
                         </thead>
@@ -253,12 +253,12 @@ $wa->useScript('multiselect');
                                            title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape($user->name); ?>">
 											<?php echo $this->escape($user->ip); ?></a>
                                     </td>
-                                    <td class="hidden-phone hidden-tablet">
+                                    <td class="d-none d-lg-table-cell">
                                         <a href="<?php echo Route::_('index.php?option=com_kunena&view=user&layout=edit&userid=' . (int) $user->userid); ?>"
                                            title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape($user->name); ?>">
 											<?php echo $this->escape($user->getRank(0, 'title')); ?></a>
                                     </td>
-                                    <td class="center hidden-phone hidden-tablet">
+                                    <td class="center d-none d-lg-table-cell">
 										<span class="editlinktip <?php echo $user->signature ? 'hasTip' : ''; ?>"
                                               title="<?php echo $this->escape($user->signature); ?> ">
 											<?php
@@ -276,21 +276,21 @@ $wa->useScript('multiselect');
 											<?php } ?>
 										</span>
                                     </td>
-                                    <td class="center hidden-phone">
+                                    <td class="center d-none d-md-table-cell">
                                         <a class="btn btn-micro <?php echo !$user->isBlocked() ? 'active' : ''; ?>"
                                            href="javascript: void(0);"
                                            onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','<?php echo $userBlockTask ?>')">
 											<?php echo !$user->isBlocked() ? $img_yes : $img_no; ?>
                                         </a>
                                     </td>
-                                    <td class="center hidden-phone">
+                                    <td class="center d-none d-md-table-cell">
                                         <a class="btn btn-micro <?php echo $user->isBanned() ? 'active' : ''; ?>"
                                            href="javascript: void(0);"
                                            onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','<?php echo $userBannedTask ?>')">
 											<?php echo $user->isBanned() ? $img_yes : $img_no; ?>
                                         </a>
                                     </td>
-                                    <td class="center hidden-phone hidden-tablet">
+                                    <td class="center d-none d-lg-table-cell">
 										<?php if ($user->moderator)
 											:
 											?>

--- a/src/site/template/aurelia/layouts/announcement/listing/row/default.php
+++ b/src/site/template/aurelia/layouts/announcement/listing/row/default.php
@@ -23,7 +23,7 @@ $announcement = $this->announcement;
 ?>
 
 <tr>
-    <td class="nowrap hidden-xs-down">
+    <td class="nowrap d-none d-md-table-cell">
 		<?php echo $announcement->displayField('created', 'date_today'); ?>
     </td>
 
@@ -91,7 +91,7 @@ $announcement = $this->announcement;
 		<?php endif; ?>
     </td>
 
-    <td class="center hidden-xs-down">
+    <td class="center d-none d-md-table-cell">
 		<?php echo $announcement->displayField('id'); ?>
     </td>
 

--- a/src/site/template/aurelia/layouts/category/index/default.php
+++ b/src/site/template/aurelia/layouts/category/index/default.php
@@ -78,7 +78,7 @@ foreach ($this->sections as $section) :
 
         <h1 class="card-header">
 			<?php echo $this->getCategoryLink($section, $this->escape($section->name), null, KunenaTemplate::getInstance()->tooltips(), true, false); ?>
-            <small class="hidden-xs-down nowrap" id="ksection-count<?php echo $section->id; ?>">
+            <small class="d-none d-sm-block nowrap" id="ksection-count<?php echo $section->id; ?>">
 				<?php echo KunenaCategory::getInstance()->totalCount($section->getTopics()); ?>
             </small>
         </h1>
@@ -155,7 +155,7 @@ foreach ($this->sections as $section) :
                                 </div>
 
 								<?php if (!empty($category->description)) : ?>
-                                    <div class="hidden-xs-down header-desc"><?php echo $category->displayField('description'); ?></div>
+                                    <div class="d-none d-sm-block header-desc"><?php echo $category->displayField('description'); ?></div>
 								<?php endif; ?>
 
 								<?php
@@ -169,10 +169,10 @@ foreach ($this->sections as $section) :
 													<?php $totaltopics = KunenaCategory::getInstance()->totalCount($subcategory->getTopics()); ?>
 
 													<?php if (KunenaConfig::getInstance()->showChildCatIcon) : ?>
-														<?php echo $this->getCategoryLink($subcategory, $this->getSmallCategoryIcon($subcategory), '', null, true, false) . $this->getCategoryLink($subcategory, '', null, KunenaTemplate::getInstance()->tooltips(), true, false) . '<small class="hidden-xs-down muted"> ('
+														<?php echo $this->getCategoryLink($subcategory, $this->getSmallCategoryIcon($subcategory), '', null, true, false) . $this->getCategoryLink($subcategory, '', null, KunenaTemplate::getInstance()->tooltips(), true, false) . '<small class="d-none d-sm-block muted"> ('
 															. $totaltopics . ')</small>';
 													else : ?>
-														<?php echo $this->getCategoryLink($subcategory, '', null, KunenaTemplate::getInstance()->tooltips(), true, false) . '<small class="hidden-xs-down muted"> ('
+														<?php echo $this->getCategoryLink($subcategory, '', null, KunenaTemplate::getInstance()->tooltips(), true, false) . '<small class="d-none d-sm-block muted"> ('
 															. $totaltopics . ')</small>';
 													endif;
 
@@ -187,7 +187,7 @@ foreach ($this->sections as $section) :
 											<?php if (!empty($this->more[$category->id])) : ?>
                                                 <li>
 													<?php echo $this->getCategoryLink($category, Text::_('COM_KUNENA_SEE_MORE'), null, KunenaTemplate::getInstance()->tooltips(), true, false); ?>
-                                                    <small class="hidden-xs-down muted">
+                                                    <small class="d-none d-sm-block muted">
                                                         (<?php echo Text::sprintf('COM_KUNENA_X_HIDDEN', (int) $this->more[$category->id]); ?>
                                                         )
                                                     </small>
@@ -233,7 +233,7 @@ foreach ($this->sections as $section) :
 								$avatar = $this->config->avatarOnCategory ? $author->getAvatarImage($this->ktemplate->params->get('avatarType'), 'thumb') : null;
 								?>
 
-                                <td colspan="5" class="hidden-xs-down">
+                                <td colspan="5" class="d-none d-md-table-cell">
                                     <div class="row">
 										<?php if ($avatar) : ?>
                                         <div class="col-xs-6 col-md-3" id="kcat-avatar">

--- a/src/site/template/aurelia/layouts/category/item/default.php
+++ b/src/site/template/aurelia/layouts/category/item/default.php
@@ -70,16 +70,16 @@ $this->addStyleSheet('rating.css');
         <table class="table<?php echo KunenaTemplate::getInstance()->borderless(); ?>">
             <thead>
             <tr>
-                <th scope="col" class="center hidden-xs-down">
+                <th scope="col" class="center d-none d-md-table-cell">
                     <a id="forumtop"> </a>
                     <a href="#forumbottom" rel="nofollow">
 						<?php echo KunenaIcons::arrowdown(); ?>
                     </a>
                 </th>
-                <th scope="col" class="hidden-xs-down"><?php echo Text::_('COM_KUNENA_GEN_SUBJECT'); ?></th>
-                <th scope="col" class="hidden-xs-down"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>
+                <th scope="col" class="d-none d-md-table-cell"><?php echo Text::_('COM_KUNENA_GEN_SUBJECT'); ?></th>
+                <th scope="col" class="d-none d-md-table-cell"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>
                     / <?php echo Text::_('COM_KUNENA_GEN_HITS'); ?></th>
-                <th scope="col" class="hidden-xs-down"><?php echo Text::_('COM_KUNENA_GEN_LAST_POST'); ?></th>
+                <th scope="col" class="d-none d-md-table-cell"><?php echo Text::_('COM_KUNENA_GEN_LAST_POST'); ?></th>
 
 				<?php if (!empty($this->topicActions)) : ?>
                     <th scope="col" class="center"><input class="kcheckall" type="checkbox" name="toggle" value=""/>
@@ -107,14 +107,14 @@ $this->addStyleSheet('rating.css');
             <tfoot>
 			<?php if ($this->topics) : ?>
                 <tr>
-                    <th scope="col" class="center hidden-xs-down">
+                    <th scope="col" class="center d-none d-md-table-cell">
                         <a id="forumbottom"> </a>
                         <a href="#forumtop" rel="nofollow">
                             <span class="dropdown-divider"></span>
 							<?php echo KunenaIcons::arrowup(); ?>
                         </a>
                     </th>
-                    <th scope="col" class="hidden-xs-down">
+                    <th scope="col" class="d-none d-md-table-cell">
                         <div class="form-group">
                             <div class="input-group" role="group">
 								<?php if (!empty($this->moreUri))

--- a/src/site/template/aurelia/layouts/category/list/row/default.php
+++ b/src/site/template/aurelia/layouts/category/list/row/default.php
@@ -28,7 +28,7 @@ $avatar = $this->config->avatarOnCategory ? $topic->getAuthor()->getAvatarImage(
 	<td>
 		<h3>
 			<?php echo $this->getCategoryLink($this->category); ?>
-			<small class="hidden-xs-down">
+			<small class="d-none d-sm-block">
 				(<?php echo Text::sprintf('COM_KUNENA_X_TOPICS_MORE', $this->formatLargeNumber($this->category->getTopics())); ?>
 				)
 			</small>
@@ -51,7 +51,7 @@ $avatar = $this->config->avatarOnCategory ? $topic->getAuthor()->getAvatarImage(
 		:
 		?>
 		<td class="center">
-		<span class="hidden-xs-down">
+		<span class="d-none d-sm-block">
 			<?php echo $topic->getLastPostAuthor()->getLink($avatar); ?>
 		</span>
 		</td>

--- a/src/site/template/aurelia/layouts/message/item/bottom/default.php
+++ b/src/site/template/aurelia/layouts/message/item/bottom/default.php
@@ -177,7 +177,7 @@ else
 			$dateshown = KunenaDate::getInstance($message->modified_time)->toKunena('config_postDateFormat') . ' ';
 		}
 		?>
-        <div class="alert alert-info hidden-xs-down" <?php echo $datehover ?>>
+        <div class="alert alert-info d-none d-sm-block" <?php echo $datehover ?>>
 			<?php echo Text::sprintf('COM_KUNENA_EDITING_LASTEDIT_ON_BY', $dateshown, $message->getModifier()->getLink(null, null, '', '', null, $this->category->id)); ?>
 			<?php if ($message->modified_reason)
 			{

--- a/src/site/template/aurelia/layouts/message/item/default.php
+++ b/src/site/template/aurelia/layouts/message/item/default.php
@@ -162,7 +162,7 @@ endif; ?>
 		$dateshown = KunenaDate::getInstance($message->modified_time)->toKunena('config_postDateFormat') . ' ';
 	}
 	?>
-    <div class="alert alert-info hidden-xs-down" <?php echo $datehover ?>>
+    <div class="alert alert-info d-none d-sm-block" <?php echo $datehover ?>>
 		<?php echo Text::sprintf('COM_KUNENA_EDITING_LASTEDIT_ON_BY', $dateshown, $message->getModifier()->getLink(null, null, '', '', null, $this->category->id)); ?>
 		<?php if ($message->modified_reason)
 		{

--- a/src/site/template/aurelia/layouts/message/item/top/default.php
+++ b/src/site/template/aurelia/layouts/message/item/top/default.php
@@ -179,7 +179,7 @@ endif; ?>
 		$dateshown = KunenaDate::getInstance($message->modified_time)->toKunena('config_postDateFormat') . ' ';
 	}
 	?>
-    <div class="alert alert-info hidden-xs-down" <?php echo $datehover ?>>
+    <div class="alert alert-info d-none d-sm-block" <?php echo $datehover ?>>
 		<?php echo Text::sprintf('COM_KUNENA_EDITING_LASTEDIT_ON_BY', $dateshown, $message->getModifier()->getLink(null, null, '', '', null, $this->category->id)); ?>
 		<?php if ($message->modified_reason)
 		{

--- a/src/site/template/aurelia/layouts/message/list/default.php
+++ b/src/site/template/aurelia/layouts/message/list/default.php
@@ -30,7 +30,7 @@ $view    = Factory::getApplication()->input->getWord('view');
         <div class="float-start">
             <h1>
 				<?php echo $this->escape($this->headerText); ?>
-                <small class="hidden-xs-down">
+                <small class="d-none d-sm-block">
                     (<?php echo Text::sprintf($this->messagemore, $this->formatLargeNumber($this->pagination->total)); ?>
                     )
                 </small>
@@ -47,7 +47,7 @@ $view    = Factory::getApplication()->input->getWord('view');
                 <h2 class="filter-time float-end" id="filter-time"></h2>
                 <form action="<?php echo $this->escape(Uri::getInstance()->toString()); ?>"
                       id="timeselect" name="timeselect"
-                      method="post" target="_self" class="form-inline hidden-xs-down">
+                      method="post" target="_self" class="form-inline d-none d-sm-block">
                     <?php $this->displayTimeFilter('sel'); ?>
                     <?php echo HTMLHelper::_('form.token'); ?>
                 </form>
@@ -79,16 +79,16 @@ $view    = Factory::getApplication()->input->getWord('view');
                 <th scope="row">&nbsp;</th>
             </tr>
 		<?php else : ?>
-            <th scope="col" class="center hidden-xs-down">
+            <th scope="col" class="center d-none d-md-table-cell">
                 <a id="forumtop"> </a>
                 <a href="#forumbottom" rel="nofollow">
 					<?php echo KunenaIcons::arrowdown(); ?>
                 </a>
             </th>
-            <th scope="col" class="hidden-xs-down"><?php echo Text::_('COM_KUNENA_GEN_SUBJECT'); ?></th>
-            <th scope="col" class="hidden-xs-down"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>
+            <th scope="col" class="d-none d-md-table-cell"><?php echo Text::_('COM_KUNENA_GEN_SUBJECT'); ?></th>
+            <th scope="col" class="d-none d-md-table-cell"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>
                 / <?php echo Text::_('COM_KUNENA_GEN_HITS'); ?></th>
-            <th scope="col" class="hidden-xs-down"><?php echo Text::_('COM_KUNENA_GEN_LAST_POST'); ?></th>
+            <th scope="col" class="d-none d-md-table-cell"><?php echo Text::_('COM_KUNENA_GEN_LAST_POST'); ?></th>
 
 			<?php if (!empty($this->actions)) : ?>
                 <th scope="col" class="center"><input class="kcheckall" type="checkbox" name="toggle" value=""/></th>
@@ -99,7 +99,7 @@ $view    = Factory::getApplication()->input->getWord('view');
         <tfoot>
 		<?php if (!empty($this->messages)) : ?>
             <tr>
-                <th scope="col" class="center hidden-xs-down">
+                <th scope="col" class="center d-none d-md-table-cell">
                     <a id="forumbottom"> </a>
                     <a href="#forumtop" rel="nofollow">
                         <span class="dropdown-divider"></span>
@@ -107,7 +107,7 @@ $view    = Factory::getApplication()->input->getWord('view');
                     </a>
                 </th>
 				<?php if (!empty($this->actions)) : ?>
-                    <th scope="col" class="hidden-xs-down">
+                    <th scope="col" class="d-none d-md-table-cell">
                         <div class="form-group">
                             <div class="input-group" role="group">
 								<?php if (!empty($this->moreUri))

--- a/src/site/template/aurelia/layouts/message/row/default.php
+++ b/src/site/template/aurelia/layouts/message/row/default.php
@@ -40,14 +40,14 @@ $topicPages      = $topic->getPagination(null, KunenaConfig::getInstance()->mess
 	if ($topic->unread)
 		:
 		?>
-        <th scope="row" class="hidden-xs-down topic-item-unread">
+        <th scope="row" class="d-none d-md-table-cell topic-item-unread">
 			<?php echo $this->getTopicLink($topic, 'unread', $topic->getIcon($topic->getCategory()->iconset), '', null, $category, true, true); ?>
         </th>
 	<?php else
 
 		:
 		?>
-        <th scope="row" class="hidden-xs-down">
+        <th scope="row" class="d-none d-md-table-cell">
 			<?php echo $this->getTopicLink($topic, $this->message, $topic->getIcon($topic->getCategory()->iconset), '', null, $category, true, false); ?>
         </th>
 	<?php endif; ?>
@@ -151,14 +151,14 @@ $topicPages      = $topic->getPagination(null, KunenaConfig::getInstance()->mess
         </div>
     </td>
 
-    <td class="hidden-xs-down">
+    <td class="d-none d-md-table-cell">
         <div class="replies"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>:<span
                     class="repliesnum"><?php echo $this->formatLargeNumber($topic->getReplies()); ?></span></div>
         <div class="views"><?php echo Text::_('COM_KUNENA_GEN_HITS'); ?>:<span
                     class="viewsnum"><?php echo $this->formatLargeNumber($topic->hits); ?></span></div>
     </td>
 
-    <td class="hidden-xs-down">
+    <td class="d-none d-md-table-cell">
         <div class="row">
 			<?php if ($config->avatarOnCategory)
 			:

--- a/src/site/template/aurelia/layouts/search/results/row/default.php
+++ b/src/site/template/aurelia/layouts/search/results/row/default.php
@@ -42,7 +42,7 @@ $subjectlengthmessage = $this->ktemplate->params->get('SubjectLengthMessage', 20
 	</div>
 
 	<div class="col-md-10">
-		<small class="text-muted float-end hidden-phone"
+		<small class="text-muted float-end d-none d-md-block"
 		       style="margin-top:-5px;"> <?php echo KunenaIcons::clock(); ?> <?php echo $message->getTime()->toSpan(); ?><?php if ($message->modified_time)
 				:
 				?> - <?php echo KunenaIcons::edit() . ' ' . $message->getModifiedTime()->toSpan();

--- a/src/site/template/aurelia/layouts/topic/edit/history/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/history/default.php
@@ -56,7 +56,7 @@ use Kunena\Forum\Libraries\Icons\KunenaIcons;
                 </ul>
             </div>
             <div class="col-md-10">
-                <small class="text-muted float-end hidden-xs-down" style="margin-top:-5px;">
+                <small class="text-muted float-end d-none d-sm-block" style="margin-top:-5px;">
 					<?php echo KunenaIcons::clock(); ?><?php echo $this->message->getTime()->toSpan('config_postDateFormat', 'config_postDateFormatHover'); ?>
                 </small>
                 <div class="badger-left badger-info khistory"

--- a/src/site/template/aurelia/layouts/topic/item/message/default.php
+++ b/src/site/template/aurelia/layouts/topic/item/message/default.php
@@ -19,7 +19,7 @@ $quick        = $this->ktemplate->params->get('quick');
 
 if ($direction === "left") : ?>
     <div class="row message">
-        <div class="col-md-2 shadow rounded hidden-xs-down">
+        <div class="col-md-2 shadow rounded d-none d-sm-block">
 			<?php
 			echo $sideProfile ? $sideProfile : $this->subLayout('User/Profile')
 				->set('user', $this->profile)
@@ -51,7 +51,7 @@ if ($direction === "left") : ?>
 					->set('captchaEnabled', $this->captchaEnabled)->setLayout('quickReply'); ?>
 			<?php endif; ?>
         </div>
-        <div class="col-md-2 shadow rounded hidden-xs-down">
+        <div class="col-md-2 shadow rounded d-none d-sm-block">
 			<?php
 			echo $sideProfile ? $sideProfile : $this->subLayout('User/Profile')
 				->set('user', $this->profile)

--- a/src/site/template/aurelia/layouts/topic/list/default.php
+++ b/src/site/template/aurelia/layouts/topic/list/default.php
@@ -50,7 +50,7 @@ if (KunenaConfig::getInstance()->ratingEnabled)
 				<?php echo $this->escape($this->headerText); ?>
 
 				<?php if ($layout != 'unread') : ?>
-                    <small class="hidden-xs-down">
+                    <small class="d-none d-sm-block">
                         (<?php echo KunenaCategory::getInstance()->totalCount($this->pagination->total); ?>)
                     </small>
 				<?php endif; ?>
@@ -63,7 +63,7 @@ if (KunenaConfig::getInstance()->ratingEnabled)
                 <h2 class="filter-sel float-end"></h2>
                 <form action="<?php echo $this->escape(Uri::getInstance()->toString()); ?>"
                       id="timeselect" name="timeselect"
-                      method="post" target="_self" class="form-inline hidden-xs-down">
+                      method="post" target="_self" class="form-inline d-none d-sm-block">
                     <?php $this->displayTimeFilter('sel'); ?>
                     <?php echo HTMLHelper::_('form.token'); ?>
                 </form>
@@ -101,16 +101,16 @@ if ($this->config->enableForumJump && !$this->embedded && $this->topics)
         <table class="table<?php echo KunenaTemplate::getInstance()->borderless(); ?> shadow-lg rounded">
             <thead>
             <tr>
-                <th scope="col" class="center hidden-xs-down">
+                <th scope="col" class="center d-none d-md-table-cell">
                     <a id="forumtop"> </a>
                     <a href="#forumbottom" rel="nofollow">
 						<?php echo KunenaIcons::arrowdown(); ?>
                     </a>
                 </th>
-                <th scope="col" class="hidden-xs-down"><?php echo Text::_('COM_KUNENA_GEN_SUBJECT'); ?></th>
-                <th scope="col" class="hidden-xs-down"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>
+                <th scope="col" class="d-none d-md-table-cell"><?php echo Text::_('COM_KUNENA_GEN_SUBJECT'); ?></th>
+                <th scope="col" class="d-none d-md-table-cell"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>
                     / <?php echo Text::_('COM_KUNENA_GEN_HITS'); ?></th>
-                <th scope="col" class="hidden-xs-down"><?php echo Text::_('COM_KUNENA_GEN_LAST_POST'); ?></th>
+                <th scope="col" class="d-none d-md-table-cell"><?php echo Text::_('COM_KUNENA_GEN_LAST_POST'); ?></th>
 
 				<?php if (!empty($this->actions)) : ?>
                     <th scope="col" class="center"><input class="kcheckall" type="checkbox" name="toggle" value=""/>
@@ -120,7 +120,7 @@ if ($this->config->enableForumJump && !$this->embedded && $this->topics)
             </thead>
             <tfoot>
             <tr>
-                <th scope="col" class="center hidden-xs-down">
+                <th scope="col" class="center d-none d-md-table-cell">
                     <a id="forumbottom"> </a>
                     <a href="#forumtop" rel="nofollow">
                         <span class="dropdown-divider"></span>
@@ -128,7 +128,7 @@ if ($this->config->enableForumJump && !$this->embedded && $this->topics)
                     </a>
                 </th>
 				<?php if (!empty($this->actions) || !empty($this->moreUri)) : ?>
-                    <th scope="col" class="hidden-xs-down">
+                    <th scope="col" class="d-none d-md-table-cell">
                         <div class="form-group">
                             <div class="input-group" role="group">
 								<?php if (!empty($this->topics) && !empty($this->moreUri))

--- a/src/site/template/aurelia/layouts/topic/row/category.php
+++ b/src/site/template/aurelia/layouts/topic/row/category.php
@@ -60,11 +60,11 @@ if (!empty($this->spacing)) : ?>
 
 <tr class="category<?php echo $this->escape($category->class_sfx) . $txt; ?>">
 	<?php if ($topic->unread) : ?>
-        <th scope="row" class="hidden-xs-down center topic-item-unread">
+        <th scope="row" class="d-none d-md-table-cell center topic-item-unread">
 			<?php echo $this->getTopicLink($topic, 'unread', $topic->getIcon($topic->getCategory()->iconset), '', null, $category, true, true); ?>
         </th>
 	<?php else : ?>
-        <th scope="row" class="hidden-xs-down center">
+        <th scope="row" class="d-none d-md-table-cell center">
 			<?php echo $this->getTopicLink($topic, null, $topic->getIcon($topic->getCategory()->iconset), '', null, $category, true, false); ?>
         </th>
 	<?php endif; ?>
@@ -144,14 +144,14 @@ if (!empty($this->spacing)) : ?>
         </div>
     </td>
 
-    <td class="hidden-xs-down">
+    <td class="d-none d-md-table-cell">
         <div class="replies"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>:<span
                     class="repliesnum"><?php echo $this->formatLargeNumber($topic->getReplies()); ?></span></div>
         <div class="views"><?php echo Text::_('COM_KUNENA_GEN_HITS'); ?>:<span
                     class="viewsnum"><?php echo $this->formatLargeNumber($topic->hits); ?></span></div>
     </td>
 
-    <td class="hidden-xs-down">
+    <td class="d-none d-md-table-cell">
         <div class="row">
 			<?php if ($config->avatarOnCategory) : ?>
             <div class="col-xs-6 col-md-3">

--- a/src/site/template/aurelia/layouts/topic/row/default.php
+++ b/src/site/template/aurelia/layouts/topic/row/default.php
@@ -59,11 +59,11 @@ if (!empty($this->spacing)) : ?>
 
 <tr class="category<?php echo $this->escape($category->class_sfx) . $txt; ?>">
 	<?php if ($topic->unread) : ?>
-        <th scope="row" class="hidden-xs-down center topic-item-unread">
+        <th scope="row" class="d-none d-md-table-cell center topic-item-unread">
 			<?php echo $this->getTopicLink($topic, 'unread', KunenaTemplate::getInstance()->getTopicIcon($topic), '', null, $category, true, true); ?>
         </th>
 	<?php else : ?>
-        <th scope="row" class="center hidden-xs-down">
+        <th scope="row" class="center d-none d-md-table-cell">
 			<?php echo $this->getTopicLink($topic, null, KunenaTemplate::getInstance()->getTopicIcon($topic), '', null, $category, true, false); ?>
         </th>
 	<?php endif; ?>
@@ -145,14 +145,14 @@ if (!empty($this->spacing)) : ?>
         </div>
     </td>
 
-    <td class="hidden-xs-down">
+    <td class="d-none d-md-table-cell">
         <div class="replies"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>:<span
                     class="repliesnum"><?php echo $this->formatLargeNumber($topic->getReplies()); ?></span></div>
         <div class="views"><?php echo Text::_('COM_KUNENA_GEN_HITS'); ?>:<span
                     class="viewsnum"><?php echo $this->formatLargeNumber($topic->hits); ?></span></div>
     </td>
 
-    <td class="hidden-xs-down">
+    <td class="d-none d-md-table-cell">
         <div class="row">
 			<?php if ($config->avatarOnCategory) : ?>
             <div class="col-xs-6 col-md-3">

--- a/src/site/template/aurelia/layouts/topic/row/user.php
+++ b/src/site/template/aurelia/layouts/topic/row/user.php
@@ -70,11 +70,11 @@ if (!empty($this->spacing)) : ?>
 
 <tr class="category<?php echo $this->escape($category->class_sfx) . $txt; ?>">
 	<?php if ($topic->unread) : ?>
-        <th scope="row" class="hidden-xs-down topic-item-unread center">
+        <th scope="row" class="d-none d-md-table-cell topic-item-unread center">
 			<?php echo $this->getTopicLink($topic, 'unread', KunenaTemplate::getInstance()->getTopicIcon($topic), '', null, $category, true, true); ?>
         </th>
 	<?php else : ?>
-        <th scope="row" class="hidden-xs-down center">
+        <th scope="row" class="d-none d-md-table-cell center">
 			<?php echo $this->getTopicLink($topic, null, KunenaTemplate::getInstance()->getTopicIcon($topic), '', null, $category, true, false); ?>
         </th>
 	<?php endif; ?>
@@ -153,14 +153,14 @@ if (!empty($this->spacing)) : ?>
         </div>
     </td>
 
-    <td class="hidden-xs-down">
+    <td class="d-none d-md-table-cell">
         <div class="replies"><?php echo Text::_('COM_KUNENA_GEN_REPLIES'); ?>:<span
                     class="repliesnum"><?php echo $this->formatLargeNumber($topic->getReplies()); ?></span></div>
         <div class="views"><?php echo Text::_('COM_KUNENA_GEN_HITS'); ?>:<span
                     class="viewsnum"><?php echo $this->formatLargeNumber($topic->hits); ?></span></div>
     </td>
 
-    <td class="hidden-xs-down">
+    <td class="d-none d-md-table-cell">
         <div class="row">
 			<?php if ($config->avatarOnCategory) : ?>
             <div class="col-xs-6 col-md-3">

--- a/src/site/template/aurelia/layouts/user/list/default.php
+++ b/src/site/template/aurelia/layouts/user/list/default.php
@@ -55,7 +55,7 @@ $this->addScript('assets/js/search.js');
 	<table class="table table-bordered table-striped">
 		<thead>
 		<tr>
-			<th class="col-md-1 center hidden-xs-down">
+			<th class="col-md-1 center d-none d-md-table-cell">
 				<a id="forumtop"> </a>
 				<a href="#forumbottom" rel="nofollow">
 					<?php echo KunenaIcons::arrowdown(); ?>
@@ -65,7 +65,7 @@ $this->addScript('assets/js/search.js');
 			<?php if ($config->userlistOnline && $config->userStatus)
 :
 				$cols++; ?>
-				<th class="col-md-1 center hidden-xs-down">
+				<th class="col-md-1 center d-none d-md-table-cell">
 					<?php echo Text::_('COM_KUNENA_USRL_ONLINE'); ?>
 				</th>
 			<?php endif; ?>
@@ -73,7 +73,7 @@ $this->addScript('assets/js/search.js');
 			<?php if ($config->userlistAvatar)
 :
 				$cols++; ?>
-				<th class="col-md-1 center hidden-xs-down">
+				<th class="col-md-1 center d-none d-md-table-cell">
 					<?php echo Text::_('COM_KUNENA_USRL_AVATAR'); ?>
 				</th>
 			<?php endif; ?>
@@ -119,7 +119,7 @@ $this->addScript('assets/js/search.js');
 			:
 				$cols++;
 				?>
-				<th class="col-md-1 center hidden-xs-down">
+				<th class="col-md-1 center d-none d-md-table-cell">
 					<?php echo HTMLHelper::_(
 					'kunenagrid.sort',
 					'COM_KUNENA_USRL_POSTS',
@@ -139,7 +139,7 @@ $this->addScript('assets/js/search.js');
 			:
 				$cols++;
 				?>
-				<th class="col-md-1 center hidden-xs-down">
+				<th class="col-md-1 center d-none d-md-table-cell">
 					<?php echo HTMLHelper::_(
 					'kunenagrid.sort',
 					'COM_KUNENA_USRL_KARMA',
@@ -159,7 +159,7 @@ $this->addScript('assets/js/search.js');
 			:
 				$cols++;
 				?>
-			<th class="col-md-1 hidden-xs-down">
+			<th class="col-md-1 d-none d-md-table-cell">
 				<?php echo HTMLHelper::_(
 					'kunenagrid.sort',
 					'COM_KUNENA_USRL_EMAIL',
@@ -178,7 +178,7 @@ $this->addScript('assets/js/search.js');
 				:
 					$cols++;
 					?>
-			<th class="col-md-2 hidden-xs-down">
+			<th class="col-md-2 d-none d-md-table-cell">
 					<?php echo HTMLHelper::_(
 						'kunenagrid.sort',
 						'COM_KUNENA_USRL_JOIN_DATE',
@@ -198,7 +198,7 @@ $this->addScript('assets/js/search.js');
 			:
 				$cols++;
 				?>
-				<th class="col-md-2 hidden-xs-down">
+				<th class="col-md-2 d-none d-md-table-cell">
 					<?php echo HTMLHelper::_(
 					'kunenagrid.sort',
 					'COM_KUNENA_USRL_LAST_LOGIN',
@@ -217,7 +217,7 @@ $this->addScript('assets/js/search.js');
 			<?php if ($config->userlistUserHits)
 			:
 				?>
-				<th class="col-md-1 center hidden-xs-down">
+				<th class="col-md-1 center d-none d-md-table-cell">
 					<?php echo HTMLHelper::_(
 					'kunenagrid.sort',
 					'COM_KUNENA_USRL_HITS',
@@ -251,7 +251,7 @@ $this->addScript('assets/js/search.js');
 				<?php if ($config->userlistOnline && $config->userStatus)
 				:
 					?>
-					<td class="col-md-1 center hidden-xs-down">
+					<td class="col-md-1 center d-none d-md-table-cell">
 						<?php echo $this->subLayout('User/Item/Status')->set('user', $user); ?>
 					</td>
 				<?php endif; ?>
@@ -259,7 +259,7 @@ $this->addScript('assets/js/search.js');
 				<?php if ($avatar)
 				:
 					?>
-					<td class="col-md-1 center hidden-xs-down">
+					<td class="col-md-1 center d-none d-md-table-cell">
 						<div class="post-image kwho-<?php echo $user->getType(0, true); ?>">
 							<?php echo $avatar; ?>
 						</div>
@@ -273,7 +273,7 @@ $this->addScript('assets/js/search.js');
 				<?php if ($config->userlistPosts)
 				:
 					?>
-					<td class="col-md-1 center hidden-xs-down">
+					<td class="col-md-1 center d-none d-md-table-cell">
 						<?php echo (int) $user->posts; ?>
 					</td>
 				<?php endif; ?>
@@ -281,7 +281,7 @@ $this->addScript('assets/js/search.js');
 				<?php if ($config->userlistKarma)
 				:
 					?>
-					<td class="col-md-1 center hidden-xs-down">
+					<td class="col-md-1 center d-none d-md-table-cell">
 						<?php echo (int) $user->karma; ?>
 					</td>
 				<?php endif; ?>
@@ -289,7 +289,7 @@ $this->addScript('assets/js/search.js');
 				<?php if ($config->userlistEmail)
 				:
 					?>
-					<td class="col-md-1 hidden-xs-down">
+					<td class="col-md-1 d-none d-md-table-cell">
 						<?php echo $user->email ? HTMLHelper::_('email.cloak', $user->email) : '' ?>
 					</td>
 				<?php endif; ?>
@@ -298,7 +298,7 @@ $this->addScript('assets/js/search.js');
 				:
 					?>
 					<td data-bs-toggle="tooltip" title="<?php echo $user->getRegisterDate()->toKunena('ago'); ?>"
-						class="col-md-2 hidden-xs-down">
+						class="col-md-2 d-none d-sm-block">
 						<?php echo $user->getRegisterDate()->toKunena('datetime_today'); ?>
 					</td>
 				<?php endif; ?>
@@ -307,7 +307,7 @@ $this->addScript('assets/js/search.js');
 				:
 					?>
 					<td data-bs-toggle="tooltip" title="<?php echo $user->getLastVisitDate()->toKunena('ago'); ?>"
-						class="col-md-2 hidden-xs-down">
+						class="col-md-2 d-none d-sm-block">
 						<?php echo $user->getLastVisitDate()->toKunena('datetime_today'); ?>
 					</td>
 				<?php endif; ?>
@@ -315,7 +315,7 @@ $this->addScript('assets/js/search.js');
 				<?php if ($config->userlistUserHits)
 				:
 					?>
-					<td class="col-md-1 center hidden-xs-down">
+					<td class="col-md-1 center d-none d-md-table-cell">
 						<?php echo (int) $user->uhits; ?>
 					</td>
 				<?php endif; ?>
@@ -325,13 +325,13 @@ $this->addScript('assets/js/search.js');
 
 		<tfoot>
 		<tr>
-			<td class="col-md-1 center hidden-xs-down">
+			<td class="col-md-1 center d-none d-md-table-cell">
 				<a id="forumbottom"> </a>
 				<a href="#forumtop" rel="nofollow">
 					<?php echo KunenaIcons::arrowup(); ?>
 				</a>
 			</td>
-			<td colspan="8" class="hidden-xs-down">
+			<td colspan="8" class="d-none d-md-table-cell">
 			</td>
 		</tr>
 		</tfoot>

--- a/src/site/template/aurelia/layouts/user/profile/default.php
+++ b/src/site/template/aurelia/layouts/user/profile/default.php
@@ -60,7 +60,7 @@ if ($config->showKarma)
 				if (isset($this->topic_starter) && $this->topic_starter)
 					:
 					?>
-                    <span class="hidden-sm hidden-md topic-starter"><?php echo Text::_('COM_KUNENA_TOPIC_AUTHOR') ?></span>
+                    <span class="d-none d-lg-block topic-starter"><?php echo Text::_('COM_KUNENA_TOPIC_AUTHOR') ?></span>
 				<?php endif;
 				?>
 				<?php /*if (!$this->topic_starter && $user->isModerator()) : */ ?><!--

--- a/src/site/template/aurelia/layouts/user/profile/horizontal.php
+++ b/src/site/template/aurelia/layouts/user/profile/horizontal.php
@@ -62,7 +62,7 @@ if ($config->showKarma)
 				<?php if (isset($this->topic_starter) && $this->topic_starter)
 				:
 				?>
-				<span class="hidden-sm hidden-md topic-starter"><?php echo Text::_('COM_KUNENA_TOPIC_AUTHOR') ?></span>
+				<span class="d-none d-lg-block topic-starter"><?php echo Text::_('COM_KUNENA_TOPIC_AUTHOR') ?></span>
 				<?php endif; ?>
 
 				<?php // If (!$this->topic_starter && $user->isModerator()) :

--- a/src/site/template/aurelia/layouts/widget/pagination/list/default.php
+++ b/src/site/template/aurelia/layouts/widget/pagination/list/default.php
@@ -30,7 +30,7 @@ elseif ($count == 1 && empty($display))
 $last = 0;
 ?>
 
-<nav class="hidden-xs-down">
+<nav class="d-none d-sm-block">
 	<ul class="pagination ms-0">
 		<?php
 		echo $this->subLayout('Widget/Pagination/Item')->set('item', $data->start);


### PR DESCRIPTION
Pull Request for Issue #- . 
 
#### Summary of Changes
replace hidden-phone, hidden-tablet, hidden-* BS3/4 classes with BS5 classes
 
#### Replacement Information
Show/hide for breakpoint and down:

-     hidden-xs-down (hidden-xs) = d-none d-sm-block
-     hidden-sm-down (hidden-sm hidden-xs) = d-none d-md-block
-     hidden-md-down (hidden-md hidden-sm hidden-xs) = d-none d-lg-block
-     hidden-lg-down = d-none d-xl-block
-     hidden-xl-down (n/a 3.x) = d-none (same as hidden)

Show/hide for breakpoint and up:

-     hidden-xs-up = d-none (same as hidden)
-     hidden-sm-up = d-sm-none
-     hidden-md-up = d-md-none
-     hidden-lg-up = d-lg-none
-     hidden-xl-up (n/a 3.x) = d-xl-none

Show/hide only for a single breakpoint:

-     hidden-xs (only) = d-none d-sm-block (same as hidden-xs-down)
-     hidden-sm (only) = d-block d-sm-none d-md-block
-     hidden-md (only) = d-block d-md-none d-lg-block
-     hidden-lg (only) = d-block d-lg-none d-xl-block
-     hidden-xl (n/a 3.x) = d-block d-xl-none
-     visible-xs (only) = d-block d-sm-none
-     visible-sm (only) = d-none d-sm-block d-md-none
-     visible-md (only) = d-none d-md-block d-lg-none
-     visible-lg (only) = d-none d-lg-block d-xl-none
-     visible-xl (n/a 3.x) = d-none d-xl-block


Also, note that d-*-block can be replaced with d-*-inline, d-*-flex, d-*-table-cell, d-*-table etc.. depending on the display type of the element.