### PR TITLE
[K5.2] Warning: in_array() expects parameter 2 to be array,in topics.php

### DIFF
--- a/src/components/com_kunena/models/topics.php
+++ b/src/components/com_kunena/models/topics.php
@@ -155,7 +155,16 @@ class KunenaModelTopics extends KunenaModel
 				}
 			}
 
-			if (empty($latestcategory) || in_array(0, $latestcategory))
+			if (!empty($latestcategory) && !is_array($latestcategory))
+			{
+				$latestcategory = explode(',', $latestcategory);
+			}
+			else
+			{
+				$latestcategory = array();
+			}
+
+			if (count($latestcategory) == 0)
 			{
 				$latestcategory = false;
 			}


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 

you can see this error when clicking on the Unread tab 
Warning: in_array() expects parameter 2 to be array, string given in components/com_kunena/models/topics.php on line 158

#### Testing Instructions