### PR TITLE
fix BS5 badges no BG

### DIFF
--- a/src/site/template/aurelia/layouts/category/list/default.php
+++ b/src/site/template/aurelia/layouts/category/list/default.php
@@ -29,7 +29,7 @@ use Kunena\Forum\Libraries\Template\KunenaTemplate;
 
             <h3>
 				<?php echo $this->escape($this->headerText); ?>
-                <span class="badge badge-info"><?php echo (int) $this->pagination->total; ?></span>
+                <span class="badge bg-info"><?php echo (int) $this->pagination->total; ?></span>
 
 				<?php if (!empty($this->actions) && !empty($this->categories)) : ?>
                     <div class="form-group">

--- a/src/site/template/aurelia/layouts/message/list/default.php
+++ b/src/site/template/aurelia/layouts/message/list/default.php
@@ -35,7 +35,7 @@ $view    = Factory::getApplication()->input->getWord('view');
                     )
                 </small>
 
-				<?php // ToDo:: <span class="badge badge-success"> <?php echo $this->topics->count->unread; ?/></span>
+				<?php // ToDo:: <span class="badge bg-success"> <?php echo $this->topics->count->unread; ?/></span>
 				?>
             </h1>
         </div>

--- a/src/site/template/aurelia/layouts/topic/list/default.php
+++ b/src/site/template/aurelia/layouts/topic/list/default.php
@@ -54,7 +54,7 @@ if (KunenaConfig::getInstance()->ratingEnabled)
                         (<?php echo KunenaCategory::getInstance()->totalCount($this->pagination->total); ?>)
                     </small>
 				<?php endif; ?>
-				<?php // ToDo:: <span class="badge badge-success"> <?php echo $this->topics->count->unread; ?/></span> ?>
+				<?php // ToDo:: <span class="badge bg-success"> <?php echo $this->topics->count->unread; ?/></span> ?>
             </h1>
         </div>
 

--- a/src/site/template/aurelia/layouts/widget/badge/default.php
+++ b/src/site/template/aurelia/layouts/widget/badge/default.php
@@ -17,7 +17,7 @@ namespace Kunena\Forum\Site;
 $label       = $this->label;
 $tooltip     = 'data-bs-toggle="tooltip"';
 $description = isset($this->description) ? ' ' . $tooltip . ' data-bs-toggle="tooltip" title="' . $this->description . '"' : '';
-$class       = ' class="' . ' badge badge-' . $this->state . '"';
+$class       = ' class="badge bg-' . $this->state . '"';
 ?>
 <span <?php echo $description . $class; ?> >
 	<?php echo $label; ?>

--- a/src/site/template/aurelia/layouts/widget/label/default.php
+++ b/src/site/template/aurelia/layouts/widget/label/default.php
@@ -20,7 +20,7 @@ use Kunena\Forum\Libraries\Factory\KunenaFactory;
 $this->ktemplate = KunenaFactory::getTemplate();
 $icon            = $this->ktemplate->getTopicLabel($this->topic);
 $topicicontype   = $this->ktemplate->params->get('topicicontype');
-$class           = ' class="' . ' badge badge-' . $icon->labeltype . '"';
+$class           = ' class="badge me-1 bg-' . $icon->labeltype . '"';
 
 if ($topicicontype == 'B3')
 {


### PR DESCRIPTION
Pull Request for Issue # . 

labels (like topic labels) which are now BS badges do not have correct background color set
 
#### Summary of Changes 
change badge badge-[color]  to BS5 badge bg-[color]
 
#### Testing Instructions
![image](https://user-images.githubusercontent.com/2733197/198594701-aef98fc2-7a6c-4398-ae01-8d0cf070eb10.png)
