### PR TITLE
[K6.0] If "Visible E-mail Recipient" is the same mail than one #8825

### DIFF
--- a/src/libraries/kunena/src/Forum/Message/KunenaMessage.php
+++ b/src/libraries/kunena/src/Forum/Message/KunenaMessage.php
@@ -557,8 +557,11 @@ class KunenaMessage extends KunenaDatabaseObject
 					continue;
 				}
 
-				$receivers[$emailTo->subscription][] = $emailTo->email;
-				$sentusers[]                         = $emailTo->id;
+				if ($config->emailVisibleAddress != $emailTo->email)
+				{
+					$receivers[$emailTo->subscription][] = $emailTo->email;
+					$sentusers[]                         = $emailTo->id;
+				}
 			}
 
 			$mailnamesender  = !empty($config->email_sender_name) ? MailHelper::cleanAddress($config->email_sender_name) : MailHelper::cleanAddress($config->boardTitle);


### PR DESCRIPTION
Pull Request for Issue #8825. 
 
#### Summary of Changes 
 
If "Visible E-mail Recipient" is the same mail than one present in the receivers list passed to addBCC it just send the mail to the mail set in "Visible E-mail Recipient" 

#### Testing Instructions