### PR TITLE
fixed topicicons + svg icons on labels

### DIFF
--- a/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
+++ b/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
@@ -52,11 +52,19 @@ class KunenaSvgIcons
 		}
 		elseif ($group == 'systemtopicIcons')
 		{
-			$file = JPATH_SITE . '/media/kunena/core/svg/' . $iconset . '/system/' . $svgname;
+			$file = JPATH_SITE . '/media/kunena/topic_icons/' . $iconset . '/system/svg/' . $svgname;
+
+            if (!\file_exists($file . '.svg')) {
+                $file = JPATH_SITE . '/media/kunena/core/svg/' . $svgname;
+            }
 		}
 		elseif ($group == 'usertopicIcons')
 		{
-			$file = JPATH_SITE . '/media/kunena/core/svg/' . $iconset . '/user/' . $svgname;
+			$file = JPATH_SITE . '/media/kunena/topic_icons/' . $iconset . '/user/svg/' . $svgname;
+
+            if (!\file_exists($file . '.svg')) {
+                $file = JPATH_SITE . '/media/kunena/core/svg/' . $svgname;
+            }
 		}
 		else
 		{

--- a/src/libraries/kunena/src/Template/KunenaTemplate.php
+++ b/src/libraries/kunena/src/Template/KunenaTemplate.php
@@ -1378,10 +1378,10 @@ HTML;
 			{
 				if ($categoryIconset != 'default')
 				{
-					return KunenaSvgIcons::loadsvg($icon->svg, 'usertopicIcons', $categoryIconset . '/' . $icon->src);
+					return KunenaSvgIcons::loadsvg($icon->svg, 'usertopicIcons', $categoryIconset);
 				}
 
-				return KunenaSvgIcons::loadsvg($icon->svg);
+				return KunenaSvgIcons::loadsvg($icon->svg, 'usertopicIcons');
 			}
 			elseif ($topicicontype == 'fa')
 			{

--- a/src/media/kunena/labels/labels.xml
+++ b/src/media/kunena/labels/labels.xml
@@ -12,19 +12,19 @@
     <description>Default Labels for Kunena</description>
 
     <labels type="qa" width="48" height="48">
-        <label id="0" name="COM_KUNENA_LABELS_QUESTION" b2="question-sign" b3="question-sign" fa="question-circle" labeltype="primary"/>
-        <label id="1" name="COM_KUNENA_LABELS_IMPORTANT" b2="notification-circle" b3="exclamation-sign" fa="exclamation-circle" labeltype="primary"/>
-        <label id="2" name="COM_KUNENA_LABELS_QUESTION" b2="question-sign" b3="question-sign" fa="question-circle" labeltype="primary"/>
-        <label id="3" name="COM_KUNENA_LABELS_IDEA" b2="lamp" b3="lamp" fa="lightbulb" labeltype="primary"/>
-        <label id="4" name="COM_KUNENA_LABELS_LOVED" b2="heart" b3="heart" fa="heart" labeltype="danger label-important"/>
-        <!-- <label id="5" name="Bug" b2="file" b3="file" fa="file" labeltype="primary"/> -->
-        <!-- <label id="6" name="Bug" b2="file" b3="file" fa="file" labeltype="primary"/> -->
-        <!-- <label id="7" name="Bug" b2="file" b3="file" fa="file" labeltype="primary"/> -->
-        <label id="8" name="COM_KUNENA_LABELS_SOLVED" b2="ok" b3="ok" fa="check" labeltype="success"/>
-        <label id="9" name="COM_KUNENA_LABELS_MERGED" b2="contract" b3="resize-small" fa="compress" labeltype="info"/>
-        <label id="10" name="COM_KUNENA_LABELS_DELETED" b2="remove" b3="remove" fa="times" labeltype="primary"/>
-        <label id="11" name="COM_KUNENA_LABELS_STICKY" b2="pin" b3="pushpin" fa="map-pin" labeltype="info"/>
-        <label id="12" name="COM_KUNENA_LABELS_LOCKED" b2="lock" b3="file" fa="lock" labeltype="info"/>
-        <label id="13" name="COM_KUNENA_LABELS_MOVED" b2="contract" b3="contract" fa="compress" labeltype="info"/>
+        <label id="0" name="COM_KUNENA_LABELS_QUESTION" b2="question-sign" b3="question-sign" fa="question-circle" svg="question-sign" labeltype="primary"/>
+        <label id="1" name="COM_KUNENA_LABELS_IMPORTANT" b2="notification-circle" b3="exclamation-sign" fa="exclamation-circle" svg="exclamation" labeltype="primary"/>
+        <label id="2" name="COM_KUNENA_LABELS_QUESTION" b2="question-sign" b3="question-sign" fa="question-circle" svg="question-sign" labeltype="primary"/>
+        <label id="3" name="COM_KUNENA_LABELS_IDEA" b2="lamp" b3="lamp" fa="lightbulb" svg="idea" labeltype="primary"/>
+        <label id="4" name="COM_KUNENA_LABELS_LOVED" b2="heart" b3="heart" fa="heart" svg="heart" labeltype="danger label-important"/>
+        <!-- <label id="5" name="Bug" b2="file" b3="file" fa="file" svg="file" labeltype="primary"/> -->
+        <!-- <label id="6" name="Bug" b2="file" b3="file" fa="file" svg="file" labeltype="primary"/> -->
+        <!-- <label id="7" name="Bug" b2="file" b3="file" fa="file" svg="file" labeltype="primary"/> -->
+        <label id="8" name="COM_KUNENA_LABELS_SOLVED" b2="ok" b3="ok" fa="check" svg="check" labeltype="success"/>
+        <label id="9" name="COM_KUNENA_LABELS_MERGED" b2="contract" b3="resize-small" fa="compress" svg="merged" labeltype="info"/>
+        <label id="10" name="COM_KUNENA_LABELS_DELETED" b2="remove" b3="remove" fa="times" svg="remove" labeltype="primary"/>
+        <label id="11" name="COM_KUNENA_LABELS_STICKY" b2="pin" b3="pushpin" fa="map-pin" svg="award" labeltype="info"/>
+        <label id="12" name="COM_KUNENA_LABELS_LOCKED" b2="lock" b3="file" fa="lock" svg="lock" labeltype="info"/>
+        <label id="13" name="COM_KUNENA_LABELS_MOVED" b2="contract" b3="contract" fa="compress" svg="merged" labeltype="info"/>
     </labels>
 </kunena-topiclabels>

--- a/src/site/template/aurelia/layouts/widget/label/default.php
+++ b/src/site/template/aurelia/layouts/widget/label/default.php
@@ -16,6 +16,7 @@ namespace Kunena\Forum\Site;
 
 use Joomla\CMS\Language\Text;
 use Kunena\Forum\Libraries\Factory\KunenaFactory;
+use Kunena\Forum\Libraries\Icons\KunenaSvgIcons;
 
 $this->ktemplate = KunenaFactory::getTemplate();
 $icon            = $this->ktemplate->getTopicLabel($this->topic);
@@ -29,6 +30,10 @@ if ($topicicontype == 'B3')
 elseif ($topicicontype == 'fa')
 {
 	$icons = '<i class="fa fa-' . $icon->fa . '" aria-hidden="true"></i>';
+}
+elseif ($topicicontype == 'svg') 
+{
+    $icons = KunenaSvgIcons::loadsvg($icon->svg);
 }
 else
 {


### PR DESCRIPTION
Pull Request for Issue #9329 . 
 
#### Summary of Changes

- topic_icons default where using svg files from media/kunena/core/svg and not the ones in media/kunena/topic_icons/default/[user|system]/[svgiconname]
- custom topic_icons where not loading svg icons
- media/kunena/core/svg is now set as fallback when svg icon configured is not found (this because all used svg icons in default topic_icons are not in hte user / system svg directory
- labels.xml now has possibility to also use svg icons (next to bs3 and fa)

 
#### Testing Instructions

- install PR and check if all icons (svg) are displaying as before
- add custom topic_icons set and check if icons are correct as configured
- load default labels.xml and check if when svg is configured, svg icons are loaded and displayed
-  create labels.xml in template config directory and configure svg icons