### PR TITLE
attachments cart is not card

### DIFF
--- a/src/site/template/aurelia/layouts/message/item/bottom/default.php
+++ b/src/site/template/aurelia/layouts/message/item/bottom/default.php
@@ -117,8 +117,8 @@ else
 		<?php endif; ?>
 	<?php endif; ?>
 	<?php if (!empty($attachments) && $attachs->readable) : ?>
-        <div class="cart pb-3 pd-3">
-            <h5 class="card-header"> <?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?> </h5>
+        <div class="card pb-3 pd-3 mb-3">
+            <div class="card-header"><?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?></div>
             <div class="card-body kattach">
                 <ul class="thumbnails" style="list-style:none;">
 					<?php foreach ($attachments as $attachment) :

--- a/src/site/template/aurelia/layouts/message/item/bottom/default.php
+++ b/src/site/template/aurelia/layouts/message/item/bottom/default.php
@@ -29,6 +29,14 @@ $attachs              = $message->getNbAttachments();
 $topicStarter         = $this->topic->first_post_userid == $this->message->userid;
 $config               = KunenaConfig::getInstance();
 $subjectlengthmessage = $this->ktemplate->params->get('SubjectLengthMessage', 20);
+$displayAttachments   = false;
+
+foreach ($attachments as $attachment) {
+    if (!$attachment->inline) {
+        $displayAttachments = true;
+        break;
+    }
+}
 
 if ($config->orderingSystem == 'mesid')
 {
@@ -116,7 +124,7 @@ else
             <div class="clearfix"></div>
 		<?php endif; ?>
 	<?php endif; ?>
-	<?php if (!empty($attachments) && $attachs->readable) : ?>
+	<?php if (!empty($attachments) && $displayAttachments && $attachs->readable) : ?>
         <div class="card pb-3 pd-3 mb-3">
             <div class="card-header"><?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?></div>
             <div class="card-body kattach">

--- a/src/site/template/aurelia/layouts/message/item/default.php
+++ b/src/site/template/aurelia/layouts/message/item/default.php
@@ -27,6 +27,14 @@ $attachments          = $message->getAttachments();
 $attachs              = $message->getNbAttachments();
 $config               = KunenaConfig::getInstance();
 $subjectlengthmessage = $this->ktemplate->params->get('SubjectLengthMessage', 20);
+$displayAttachments   = false;
+
+foreach ($attachments as $attachment) {
+    if (!$attachment->inline) {
+        $displayAttachments = true;
+        break;
+    }
+}
 
 if ($config->orderingSystem == 'mesid')
 {
@@ -101,7 +109,7 @@ $list = [];
         <div class="clearfix"></div>
 	<?php endif; ?>
 <?php endif; ?>
-<?php if (!empty($attachments)) : ?>
+<?php if (!empty($attachments) && $displayAttachments && $attachs->readable) : ?>
     <div class="card pb-3 pd-3 mb-3">
         <div class="card-header"><?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?></div>
         <div class="card-body kattach">

--- a/src/site/template/aurelia/layouts/message/item/default.php
+++ b/src/site/template/aurelia/layouts/message/item/default.php
@@ -102,8 +102,8 @@ $list = [];
 	<?php endif; ?>
 <?php endif; ?>
 <?php if (!empty($attachments)) : ?>
-    <div class="cart pb-3 pd-3">
-        <h5 class="card-header"> <?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?> </h5>
+    <div class="card pb-3 pd-3 mb-3">
+        <div class="card-header"><?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?></div>
         <div class="card-body kattach">
             <ul class="thumbnails" style="list-style:none;">
 				<?php foreach ($attachments as $attachment) :

--- a/src/site/template/aurelia/layouts/message/item/top/default.php
+++ b/src/site/template/aurelia/layouts/message/item/top/default.php
@@ -30,6 +30,14 @@ $attachs              = $message->getNbAttachments();
 $topicStarter         = $this->topic->first_post_userid == $this->message->userid;
 $config               = KunenaConfig::getInstance();
 $subjectlengthmessage = $this->ktemplate->params->get('SubjectLengthMessage', 20);
+$displayAttachments   = false;
+
+foreach ($attachments as $attachment) {
+    if (!$attachment->inline) {
+        $displayAttachments = true;
+        break;
+    }
+}
 
 if ($config->orderingSystem == 'mesid')
 {
@@ -118,7 +126,7 @@ else
         <div class="clearfix"></div>
 	<?php endif; ?>
 <?php endif; ?>
-	<?php if (!empty($attachments) && $attachs->readable) : ?>
+    <?php if (!empty($attachments) && $displayAttachments && $attachs->readable) : ?>
     <div class="card pb-3 pd-3 mb-3">
         <div class="card-header"><?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?></div>
         <div class="card-body kattach">

--- a/src/site/template/aurelia/layouts/message/item/top/default.php
+++ b/src/site/template/aurelia/layouts/message/item/top/default.php
@@ -119,8 +119,8 @@ else
 	<?php endif; ?>
 <?php endif; ?>
 	<?php if (!empty($attachments) && $attachs->readable) : ?>
-    <div class="cart pb-3 pd-3">
-        <h5 class="card-header"> <?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?> </h5>
+    <div class="card pb-3 pd-3 mb-3">
+        <div class="card-header"><?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?></div>
         <div class="card-body kattach">
             <ul class="thumbnails" style="list-style:none;">
 				<?php foreach ($attachments as $attachment) :


### PR DESCRIPTION
Pull Request for Issue #- . 
 
#### Summary of Changes 
attachments in posts are displayed in a bootstrap card, but because it has wrong class name (cart !== card) it doesn't display as BS card.
This PR changes that.
Note that this is a visual change!
 
#### Testing Instructions