### PR TITLE
Fix: template count dashboard + cleanup template upload file

### DIFF
--- a/src/admin/src/Controller/TemplatesController.php
+++ b/src/admin/src/Controller/TemplatesController.php
@@ -109,6 +109,8 @@ class TemplatesController extends KunenaController
 					);
 					$result = false;
 				}
+
+                File::delete($dest . $file ['name']);
 			}
 
 			if ($result)

--- a/src/admin/tmpl/cpanel/default.php
+++ b/src/admin/tmpl/cpanel/default.php
@@ -373,7 +373,7 @@ $count = KunenaStatistics::getInstance()->loadCategoryCount();
 											<?php echo Text::_('COM_KUNENA_CPANEL_LABEL_TEMPLATES') ?>
                                         </a>
                                     </h6>
-                                    <h3 class="fw-700 text-cyan"><?php echo count(KunenaTemplate::getInstance()->getTemplatePaths()); ?></h3>
+                                    <h3 class="fw-700 text-cyan"><?php echo round(count(KunenaTemplate::getInstance()->getTemplatePaths()) / 2) - 1; ?></h3>
                                     <p class="mb-0"><?php echo Text::_('COM_KUNENA_CPANEL_LABEL_TEMPLATES_INSTALLED'); ?></p>
                                 </div>
                                 <div class="col-auto">


### PR DESCRIPTION
Pull Request for Issue #- . 
 
#### Summary of Changes 
Fix for Kunena Dashoard showing wrong number of templates installed as 'system' template is counted and all templates are double in count function (site + admin template paths).

Fix for uploading template not removing uploaded file after successful extraction of the zip file

#### Testing Instructions
After this PR the number of templates should be correct
after this PR the template file uploaded to ./components/com_kunena/templates should be deleted after installation of the template