### PR TITLE
message_closed not empty when 'empty'

### DIFF
--- a/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
+++ b/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
@@ -199,7 +199,7 @@ class MessageItemActionsDisplay extends KunenaControllerDisplay
 		{
 			// User is not allowed to write a post.
 			$this->message_closed = $this->topic->locked ? Text::_('COM_KUNENA_POST_LOCK_SET') :
-				($me->exists() ? Text::_('COM_KUNENA_REPLY_USER_REPLY_DISABLED') : ' ');
+				($me->exists() ? Text::_('COM_KUNENA_REPLY_USER_REPLY_DISABLED') : '');
 		}
 
 		$login = KunenaLogin::getInstance();


### PR DESCRIPTION
Pull Request for Issue #- . 

the 'message_closed" text can be set (dependendon who visits the message) to ' ' (1 space).
This will render the ./layouts/message/item/actions/default.php which checks if the value of $this->message_locks is empty useless.
As the value when set to ' ' is not empty (it contains one space), this displaying the $this->message_closed string.

This is an issue when you have a template that displays the $this->message_closed string in e.g. an alert: it will then display an empty alert instead of displaying nothing.

In aurelia, this issue is also present but there it is not visible as the text is displayed as plain text (and this only the space is displayed which you cannot see :)	
 
#### Summary of Changes 
change message_closed = ' ' to message_closed = ''
 
#### Testing Instructions
install PR and see if the locked, not allowed, etc. text on a message is still displayed as before