### PR TITLE
Fix wrond iconset used when creating new topic with no category selected

### DIFF
--- a/src/site/src/Controller/Topic/Form/Create/TopicFormCreateDisplay.php
+++ b/src/site/src/Controller/Topic/Form/Create/TopicFormCreateDisplay.php
@@ -135,7 +135,9 @@ class TopicFormCreateDisplay extends KunenaControllerDisplay
 		$this->category = KunenaCategoryHelper::get($catid);
 		list($this->topic, $this->message) = $this->category->newTopic($saved);
 
-		$this->ktemplate->setCategoryIconset($this->topic->getCategory()->iconset);
+        // When no categoy set, use default icon set
+        $iconset = $catid ? $this->topic->getCategory()->iconset : 'default';
+		$this->ktemplate->setCategoryIconset($iconset);
 
 		// Get topic icons if they are enabled.
 		if ($this->config->topicIcons)


### PR DESCRIPTION
Pull Request for Issue #9358  . 
 
#### Summary of Changes
okay so here is the analysis:
when using the 'New Topic' from the menu, a new topic for is opened. Because no category is set (you need to select that), an empty topic is created and while doing so a category for this topic is requested. That function returns the first category where the user has create rights in. This is (in your case) the category with the special 'test' topic icons: the topic isons from the test are read from the xml file.

Now because no category is actually selected it defaults back to the topicicons set name set in the template (which is 'default'. so now it is trying to load the topicicons from the read topicicons.xml (test) but refers for the location to 'default' wher ethat icon is not present....

So in the change I have done now, it will force 'default' iconset when the requested category id = 0.

Now it should work as expected... except (and this has always been an issue):
when you have category1 with iconset default and category2 with iconset 'test' > creating a new topic will display iconset 'default' (which is correct as no category is selected). Now when you select category 2, the iconset will not change and will be default and not test.

Joomla solves this (changing a category in article edit) via javascript: selecting a different category should load and display the correct iconset dynamically on the form. This is not (and never was) implemented @xillibit 
 
#### Testing Instructions
test if different icons sets work in the different views and if all svg load errors are 'gone'