### PR TITLE
[K6.0] Remove install and update of mail_templates queries #9366

### DIFF
--- a/src/admin/install/kunena.install.upgrade.xml
+++ b/src/admin/install/kunena.install.upgrade.xml
@@ -129,13 +129,6 @@
                 KEY `user_id` (`user_id`)
                 );</query>
         </version>
-        <version version="6.0.0-RC3-DEV"
-                 versiondate="2022-05-03"
-                 versionname="Internal">
-            <query mode="silenterror">UPDATE `#__mail_templates` SET `subject` = 'COM_KUNENA_SENDMAIL_REPLY_SUBJECT', `body` = 'COM_KUNENA_SENDMAIL_BODY' WHERE template_id = 'com_kunena.reply';</query>
-            <query mode="silenterror">UPDATE `#__mail_templates` SET `subject` = 'COM_KUNENA_SENDMAIL_REPLYMODERATOR_SUBJECT', `body` = 'COM_KUNENA_SENDMAIL_BODY' WHERE template_id = 'com_kunena.replymoderator';</query>
-            <query mode="silenterror">UPDATE `#__mail_templates` SET `subject` = 'COM_KUNENA_SENDMAIL_REPORT_SUBJECT', `body` = 'COM_KUNENA_SENDMAIL_BODY_REPORTMODERATOR' WHERE template_id = 'com_kunena.report';</query>
-        </version>
         <version version="6.0.0-RC4-DEV"
                  versiondate="2022-05-29"
                  versionname="Internal">
@@ -165,13 +158,6 @@
 		(22, ':unsure:', '22.png', 'unsure-grey.png', 1),
 		(23, ':o', '23.png', 'shocked-grey.png', 1);</query>
         </version>
-        <version version="6.0.0-RC4-DEV"
-                 versiondate="2022-06-01"
-                 versionname="Internal">
-            <query mode="silenterror">UPDATE `#__mail_templates` SET `extension` = 'com_kunena' WHERE template_id = 'com_kunena.reply';</query>
-            <query mode="silenterror">UPDATE `#__mail_templates` SET `extension` = 'com_kunena' WHERE template_id = 'com_kunena.replymoderator';</query>
-            <query mode="silenterror">UPDATE `#__mail_templates` SET `extension` = 'com_kunena' WHERE template_id = 'com_kunena.report';</query>
-        </version>
         <version version="6.0.2-DEV"
                  versiondate="2022-07-30"
                  versionname="Internal">
@@ -188,6 +174,9 @@
                  versiondate="2022-11-06"
                  versionname="Internal">
             <query mode="silenterror">ALTER TABLE `#__kunena_polls` CHANGE `polltimetolive` `polltimetolive` DATETIME NULL DEFAULT '1000-01-01 00:00:00'; </query>
+            <query mode="silenterror">DELETE FROM `#__mail_templates` WHERE `template_id` = 'com_kunena.reply';</query>
+            <query mode="silenterror">DELETE FROM `#__mail_templates` WHERE `template_id` = 'com_kunena.replymoderator';</query>
+            <query mode="silenterror">DELETE FROM `#__mail_templates` WHERE `template_id` = 'com_kunena.report';</query>
         </version>
         <version version="@kunenaversion@"
                  versiondate="@kunenaversiondate@"

--- a/src/admin/sql/install/mysql/create_tables.utf8.sql
+++ b/src/admin/sql/install/mysql/create_tables.utf8.sql
@@ -554,12 +554,3 @@ CREATE TABLE IF NOT EXISTS `#__kunena_version`
     DEFAULT CHARSET = utf8mb4
     DEFAULT COLLATE = utf8mb4_unicode_ci;
 
-INSERT INTO `#__mail_templates` (`template_id`, `extension`, `language`, `subject`, `body`, `htmlbody`, `attachments`, `params`)
-VALUES ('com_kunena.reply', 'com_kunena', '', 'COM_KUNENA_SENDMAIL_REPLY_SUBJECT', 'COM_KUNENA_SENDMAIL_BODY', '', '',
-        '{"tags":["mail", "subject", "message", "messageUrl", "once"]}');
-INSERT INTO `#__mail_templates` (`template_id`, `extension`, `language`, `subject`, `body`, `htmlbody`, `attachments`, `params`)
-VALUES ('com_kunena.replymoderator', 'com_kunena', '', 'COM_KUNENA_SENDMAIL_REPLYMODERATOR_SUBJECT', 'COM_KUNENA_SENDMAIL_BODY', '', '',
-        '{"tags":["mail", "subject", "message", "messageUrl", "once"]}');
-INSERT INTO `#__mail_templates` (`template_id`, `extension`, `language`, `subject`, `body`, `htmlbody`, `attachments`, `params`)
-VALUES ('com_kunena.report', 'com_kunena', '', 'COM_KUNENA_SENDMAIL_REPORT_SUBJECT', 'COM_KUNENA_SENDMAIL_BODY_REPORTMODERATOR', '', '',
-        '{"tags":["mail", "subject", "message", "messageUrl", "once"]}');


### PR DESCRIPTION
Pull Request for Issue #9366. 
 
#### Summary of Changes 
 
Remove the queries which install the mail_templates because it's useless now, remove the part on update too and on update delete from database teh mail_templates entries for Kunena

#### Testing Instructions