### PR TITLE
[K6.0] Only fa symbols are displayed on recent and categories instead

### DIFF
--- a/src/libraries/kunena/src/User/KunenaUser.php
+++ b/src/libraries/kunena/src/User/KunenaUser.php
@@ -970,7 +970,7 @@ class KunenaUser extends CMSObject
     {
         $avatars = KunenaFactory::getAvatarIntegration();
 
-        if ($avatars) {
+        if (!$avatars) {
             $ktemplate     = KunenaFactory::getTemplate();
             $topicicontype = $ktemplate->params->get('topicicontype');
 


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 

 Only fa symbols are displayed on recent and categories instead the avatar of user when setting is enabled to show avatar in recent and categories pages

#### Testing Instructions