### PR TITLE
Fix for announcement query bug

### DIFF
--- a/src/libraries/kunena/src/Forum/Announcement/KunenaAnnouncementHelper.php
+++ b/src/libraries/kunena/src/Forum/Announcement/KunenaAnnouncementHelper.php
@@ -58,14 +58,14 @@ abstract class KunenaAnnouncementHelper
 
         $id = \intval($identifier);
 
-        if (empty(self::$_instances [$id])) {
-            self::$_instances [$id] = new KunenaAnnouncement(['id' => $id]);
-            self::$_instances [$id]->load();
+        if (empty(self::$_instances[$id])) {
+            self::$_instances[$id] = new KunenaAnnouncement(['id' => $id]);
+            self::$_instances[$id]->load();
         } elseif ($reload) {
-            self::$_instances [$id]->load();
+            self::$_instances[$id]->load();
         }
 
-        return self::$_instances [$id];
+        return self::$_instances[$id];
     }
 
     /**
@@ -128,8 +128,8 @@ abstract class KunenaAnnouncementHelper
                 ->select('*')
                 ->from($db->quoteName('#__kunena_announcement'))
                 ->where($db->quoteName('published') . ' = 1')
-                ->Where($db->quoteName('publish_up') . ' = ' . $db->quote('1000-01-01 00:00:00') . ' OR ' . $db->quoteName('publish_up') . ' <= ' . $nowDate)
-                ->Where($db->quoteName('publish_down') . ' =' . $db->quote('1000-01-01 00:00:00') . ' OR ' . $db->quoteName('publish_down') . ' >= ' . $nowDate)
+                ->Where('(' . $db->quoteName('publish_up') . ' = ' . $db->quote('1000-01-01 00:00:00') . ' OR ' . $db->quoteName('publish_up') . ' <= ' . $nowDate . ')')
+                ->Where('(' . $db->quoteName('publish_down') . ' =' . $db->quote('1000-01-01 00:00:00') . ' OR ' . $db->quoteName('publish_down') . ' >= ' . $nowDate . ')')
                 ->order($db->quoteName('id') . ' DESC');
         } else {
             $query = $db->getQuery(true)
@@ -151,13 +151,13 @@ abstract class KunenaAnnouncementHelper
         $list             = [];
 
         foreach ($results as $announcement) {
-            if (isset(self::$_instances [$announcement['id']])) {
+            if (isset(self::$_instances[$announcement['id']])) {
                 continue;
             }
 
             $instance = new KunenaAnnouncement($announcement);
             $instance->exists(true);
-            self::$_instances [$instance->id] = $instance;
+            self::$_instances[$instance->id] = $instance;
             $list[]                           = $instance;
         }
 


### PR DESCRIPTION
Pull Request for Issue #9422 . 
 
#### Summary of Changes
Kunena 6.0.7 exposed a bug in the announcement selection logic.

due to a bug in the query, unpublished announcement where displayed when publish up / down conditions where met.
 
#### Testing Instructions
install PR, unpublished announcement should not display, publish up and publish down should be respected.

Important note:
There was a change in the default date/time for publish_up / publish_down. this changed to a default value of '1000-01-01 00:00:00'
an update script changed these values where the date/time was 'null'

But that was not only the use case: date/time can also be the default nullDate being '0000-00-00 00:00:00'
these nulldate values where not replaced resulting in wrong publish_down action.