### PR TITLE
fix svg size of sub category icons when custom class is used on paren…

### DIFF
--- a/src/site/template/aurelia/assets/scss/icons.scss
+++ b/src/site/template/aurelia/assets/scss/icons.scss
@@ -195,7 +195,8 @@ svg {
 .category th svg,
 footer svg,
 .col-md-1 svg,
-.category-stickymsg a svg {
+.category-stickymsg a svg,
+[class*="category-"] th svg {
   width: 34px;
   height: 34px;
 }

--- a/src/site/template/aurelia/assets/scss/icons.scss
+++ b/src/site/template/aurelia/assets/scss/icons.scss
@@ -195,8 +195,7 @@ svg {
 .category th svg,
 footer svg,
 .col-md-1 svg,
-.category-stickymsg a svg,
-[class*="category-"] a svg {
+.category-stickymsg a svg {
   width: 34px;
   height: 34px;
 }


### PR DESCRIPTION
…t directory

Pull Request for Issue #9424 . 
 
#### Summary of Changes 
removed 'conflicting' scss

#### Testing Instructions
install PR
visit form (make sure css is regenerated).
test all views and see if icons are still correct (when used in combination with 'category-' class (e.g. category-green)