### PR TITLE
[K6.0] Rendering Error in layout Category/Index: getAllowedHold()

### DIFF
--- a/src/libraries/kunena/src/Forum/Message/KunenaMessageHelper.php
+++ b/src/libraries/kunena/src/Forum/Message/KunenaMessageHelper.php
@@ -419,7 +419,10 @@ abstract class KunenaMessageHelper
         if (!$hold) {
             $me           = KunenaUserHelper::getMyself();
             $mes_instance = self::get($mesid);
-            $hold         = KunenaAccess::getInstance()->getAllowedHold($me->userid, $mes_instance->catid, false);
+
+            if ($mes_instance->exists()) {
+                $hold         = KunenaAccess::getInstance()->getAllowedHold($me->userid, $mes_instance->catid, false);
+            }
         }
 
         if (!isset(self::$_location [$mesid])) {


### PR DESCRIPTION
Pull Request for Issue # . 
 
Rendering Error in layout Category/Index: Kunena\Forum\Libraries\Access\KunenaAccess::getAllowedHold(): Argument #2 ($catid) must be of type int, null given, called in \src\libraries\kunena\src\Forum\Message\KunenaMessageHelper.php on line 423 in \src\libraries\kunena\src\Forum\Message\KunenaMessageHelper.php on line 423

#### Summary of Changes 
 
#### Testing Instructions