### PR TITLE
[6.1] Wrong http error code thrown when profile page may not be read by guests

### DIFF
--- a/src/libraries/kunena/src/User/KunenaUser.php
+++ b/src/libraries/kunena/src/User/KunenaUser.php
@@ -730,7 +730,7 @@ class KunenaUser extends CMSObject
         switch ($action) {
             case 'read':
                 if (!isset($this->registerDate) || (!$user->exists() && !$config->pubProfile)) {
-                    $exception = new KunenaExceptionAuthorise(Text::_('COM_KUNENA_PROFILEPAGE_NOT_ALLOWED_FOR_GUESTS'), $user->exists() ? 403 : 404);
+                    $exception = new KunenaExceptionAuthorise(Text::_('COM_KUNENA_PROFILEPAGE_NOT_ALLOWED_FOR_GUESTS'), 403 );
                 }
                 break;
             case 'edit':
@@ -757,7 +757,7 @@ class KunenaUser extends CMSObject
 
         // Throw or return the exception.
         if ($throw && $exception) {
-            throw new $exception();
+             throw $exception;
         }
 
         return $exception;


### PR DESCRIPTION
#### Summary of Changes 

This PR fixes two issues. When trying to access a profile page and guests are not allowed to view profile pages, you would see the correct login screen, but a http code 500 was thrown. This originated from the problem that $exception was thrown with keyword 'new' which reset the error code inside the exception.

After fixing that it would still throw a 404 (not found) instead of a 403 (no access).
Since  a $user would never exist in that scenario (guests don't have a user) I removed the condition and set it to 403 only.

#### Testing Instructions
Set in settings that guests may not see profile pages, then try to acess a profile page URL when not logged in. (copy the URL of a valid profile while being logged in). Check the network tab and see that  500 is thrown (before this patch is applied).
After applying the patch a proper 403 is thrown. Search engines like that much better.