### PR TITLE
Fix Menu error : You must specify a non-empty path to clean #9571

### DIFF
--- a/src/site/tmpl/search/default.xml
+++ b/src/site/tmpl/search/default.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE metadata>
+<metadata>
+    <layout title="COM_KUNENA_MENU_SEARCH_DEFAULT">
+        <message>COM_KUNENA_MENU_SEARCH_DEFAULT_DESC</message>
+    </layout>
+</metadata>

--- a/src/site/tmpl/statistics/default.xml
+++ b/src/site/tmpl/statistics/default.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE metadata>
+<metadata>
+    <layout title="COM_KUNENA_MENU_STATISTICS_DEFAULT">
+        <message>COM_KUNENA_MENU_STATISTICS_DEFAULT_DESC</message>
+    </layout>
+</metadata>

--- a/src/site/tmpl/topics/moderator.xml
+++ b/src/site/tmpl/topics/moderator.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE metadata>
+<metadata>
+    <layout title="COM_KUNENA_MENU_TOPICS_MODERATOR">
+        <message>COM_KUNENA_MENU_TOPICS_MODERATOR_DESC</message>
+    </layout>
+
+    <fields name="params">
+        <fieldset name="basic"
+                  label="COM_KUNENA_ATTRIBS_MAIN_SETTINGS_LABEL">
+            <field name="topics_catselection"
+                   type="radio"
+                   default="0"
+                   label="COM_KUNENA_COM_A_LATESTCATEGORY_IN"
+                   description="COM_KUNENA_COM_A_LATESTCATEGORY_IN_DESC">
+                <option value="1">COM_KUNENA_COM_A_LATESTCATEGORY_IN_SHOW</option>
+                <option value="0">COM_KUNENA_COM_A_LATESTCATEGORY_IN_HIDE</option>
+            </field>
+            <field name="topics_categories"
+                   type="kunenacategorylist"
+                   default=""
+                   label="COM_KUNENA_COM_A_LATESTCATEGORY"
+                   description="COM_KUNENA_COM_A_LATESTCATEGORY_DESC"
+                   multiple="true"
+                   size="10">
+            </field>
+        </fieldset>
+    </fields>
+</metadata>

--- a/src/site/tmpl/topics/unread.xml
+++ b/src/site/tmpl/topics/unread.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE metadata>
+<metadata>
+    <layout
+            title="COM_KUNENA_MENU_UNREAD">
+        <message>COM_KUNENA_MENU_UNREAD_DESC</message>
+    </layout>
+</metadata>

--- a/src/site/tmpl/user/default.xml
+++ b/src/site/tmpl/user/default.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE metadata>
+<metadata>
+    <layout title="COM_KUNENA_MENU_USER_DEFAULT">
+        <message>COM_KUNENA_MENU_USER_DEFAULT_DESC</message>
+    </layout>
+
+    <!-- Add fields to the parameters object for the layout. -->
+    <fields name="params">
+        <!-- Basic options. -->
+        <fieldset name="basic"
+                  label="COM_KUNENA_ATTRIBS_MAIN_SETTINGS_LABEL">
+            <field name="integration"
+                   type="radio"
+                   label="COM_KUNENA_MENU_INTEGRATION"
+                   description="COM_KUNENA_MENU_INTEGRATION_DESC"
+                   default="1">
+                <option value="1">JYES</option>
+                <option value="0">JNO</option>
+            </field>
+        </fieldset>
+    </fields>
+</metadata>

--- a/src/site/tmpl/user/edit.xml
+++ b/src/site/tmpl/user/edit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE metadata>
+<metadata>
+    <layout title="COM_KUNENA_MENU_USER_EDIT">
+        <message>COM_KUNENA_MENU_USER_EDIT_DESC</message>
+    </layout>
+</metadata>

--- a/src/site/tmpl/user/list.xml
+++ b/src/site/tmpl/user/list.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE metadata>
+<metadata>
+    <layout title="COM_KUNENA_MENU_USER_LIST">
+        <message>COM_KUNENA_MENU_USER_LIST_DESC</message>
+    </layout>
+
+    <!-- Add fields to the parameters object for the layout. -->
+    <fields name="params">
+        <!-- Basic options. -->
+        <fieldset name="basic"
+                  label="COM_KUNENA_ATTRIBS_MAIN_SETTINGS_LABEL">
+            <field name="integration"
+                   type="radio"
+                   default="1"
+                   label="COM_KUNENA_MENU_INTEGRATION"
+                   description="COM_KUNENA_MENU_INTEGRATION_DESC">
+                <option value="1">JYES</option>
+                <option value="0">JNO</option>
+            </field>
+        </fieldset>
+    </fields>
+</metadata>


### PR DESCRIPTION
Pull Request for Issue #9571 
 
#### Summary of Changes 
 XML files of the affected items copied from tmpl folder up one directory.

This pull request fix the issue stated at [#9571](https://github.com/Kunena/Kunena-Forum/issues/9571) and [https://www.kunena.org/forum/k-6-2-0-support/168159-view-kunena-menu-items-on-joomla-5-give-3-items-a-error](https://www.kunena.org/forum/k-6-2-0-support/168159-view-kunena-menu-items-on-joomla-5-give-3-items-a-error)

Joomla couldn't find the template file which fails at line 1130 in /administrator/components/com_menus/src/Model/ItemModel.php

#### Testing Instructions
Go in the backend to Kunena Menu
Try to edit/create new :
Moderator Topics
Edit User
General Statistic
Search
Unread
User list
Profile