### PR TITLE
[Fix] undefined variable $target

### DIFF
--- a/src/site/template/aurelia/layouts/bbcode/url/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/url/default.php
@@ -18,11 +18,11 @@ namespace Kunena\Forum\Site;
 // [url="www.kunena.org" target="_blank"]Kunena.org[/url]
 
 // Display URL.
+$rel = '';
+$target = '';
 if (!$this->internal) {
     $rel = 'rel="nofollow noopener noreferrer"';
     $target = ' target="' . $this->escape($this->target) . '"';
-} else {
-    $rel = '';
 }
 ?>
 <a href="<?php echo $this->escape($this->url); ?>"


### PR DESCRIPTION
When referring to an internal url, for example another post or a Joomla news item from the same domain, a warning is displayed because the variable is not initialized.

`Warning: Undefined variable $target in /var/www/html/components/com_kunena/template/aurelia/layouts/bbcode/url/default.php on line 32`

Pull Request for Issue # .
 
#### Summary of Changes 
 
#### Testing Instructions