### PR TITLE
Fix: element (form) ID's must be unique on a page

### DIFF
--- a/src/site/template/aurelia/layouts/message/edit/quickreply.php
+++ b/src/site/template/aurelia/layouts/message/edit/quickreply.php
@@ -62,10 +62,10 @@ if ($me->canDoCaptcha() && KunenaConfig::getInstance()->quickReply) {
 }
 ?>
 
-    <?php if ($quick == 1) :
-        ?>
+<?php if ($quick == 1) :
+?>
     <div class="modal fade" id="kreply<?php echo $message->displayField('id'); ?>_form" data-bs-backdrop="false" aria-hidden="true">
-         <div class="modal-dialog">
+        <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
                     <h3 class="modal-title">
@@ -75,61 +75,48 @@ if ($me->canDoCaptcha() && KunenaConfig::getInstance()->quickReply) {
                 </div>
 
                 <div class="card-body">
-                    <form action="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic'); ?>"
-                          method="post"
-                          enctype="multipart/form-data" name="postform" id="postform" class="form-horizontal">
-                        <input type="hidden" name="task" value="post"/>
-                        <input type="hidden" name="parentid" value="<?php echo $message->displayField('id'); ?>"/>
-                        <input type="hidden" name="catid" value="<?php echo $category->displayField('id'); ?>"/>
+                    <form action="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic'); ?>" method="post" enctype="multipart/form-data" name="postform" id="postform-<?php echo $message->id; ?>" class="form-horizontal">
+                        <input type="hidden" name="task" value="post" />
+                        <input type="hidden" name="parentid" value="<?php echo $message->displayField('id'); ?>" />
+                        <input type="hidden" name="catid" value="<?php echo $category->displayField('id'); ?>" />
                         <?php
                         if (!$config->allowChangeSubject || $me->isModerator()) :
-                            ?>
-                            <input type="hidden" name="subject"
-                                   value="<?php echo $this->escape($this->message->subject); ?>"/>
+                        ?>
+                            <input type="hidden" name="subject" value="<?php echo $this->escape($this->message->subject); ?>" />
                         <?php endif; ?>
                         <?php
                         if ($me->exists()) :
-                            ?>
-                            <input type="hidden" id="kurl_users" name="kurl_users"
-                                   value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=user&layout=listmention&format=raw') ?>"/>
+                        ?>
+                            <input type="hidden" id="kurl_users" name="kurl_users" value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=user&layout=listmention&format=raw') ?>" />
                         <?php endif; ?>
                         <?php echo HTMLHelper::_('form.token'); ?>
 
                         <?php if (!$me->exists()) :
-                            ?>
+                        ?>
                             <div class="form-group">
                                 <label class="col-md-12 control-label" style="padding:0;">
                                     <?php echo Text::_('COM_KUNENA_GEN_NAME'); ?>:
                                 </label>
-                                <input type="text" name="authorname" class="form-control" maxlength="35"
-                                       placeholder="<?php echo Text::_('COM_KUNENA_GEN_NAME'); ?>" value=""
-                                       required/>
+                                <input type="text" name="authorname" class="form-control" maxlength="35" placeholder="<?php echo Text::_('COM_KUNENA_GEN_NAME'); ?>" value="" required />
                             </div>
                         <?php endif; ?>
 
                         <?php if ($config->askEmail && !$me->exists()) :
-                            ?>
+                        ?>
                             <div class="form-group">
                                 <?php echo $config->showEmail == '0' ? Text::_('COM_KUNENA_POST_EMAIL_NEVER') : Text::_('COM_KUNENA_POST_EMAIL_REGISTERED'); ?>
-                                <input type="text" id="email" name="email"
-                                       placeholder="<?php echo Text::_('COM_KUNENA_TOPIC_EDIT_PLACEHOLDER_EMAIL') ?>"
-                                       class="inputbox col-md-12 form-control" maxlength="45" value=""
-                                       required/>
+                                <input type="text" id="email" name="email" placeholder="<?php echo Text::_('COM_KUNENA_TOPIC_EDIT_PLACEHOLDER_EMAIL') ?>" class="inputbox col-md-12 form-control" maxlength="45" value="" required />
                             </div>
                         <?php endif; ?>
 
                         <div class="form-group">
-                            <label for="kanonymous<?php echo \intval($message->id); ?>"
-                                   class="col-md-12 control-label" style="padding:0;">
+                            <label for="kanonymous<?php echo \intval($message->id); ?>" class="col-md-12 control-label" style="padding:0;">
                                 <?php echo Text::_('COM_KUNENA_GEN_SUBJECT'); ?>:
                             </label>
-                            <input type="text" id="subject" name="subject" class="form-control"
-                                   maxlength="<?php echo $template->params->get('SubjectLengthMessage'); ?>"
-                                   <?php
-                                    if (!$config->allowChangeSubject && !$me->isModerator()) :
-                                        ?>disabled<?php
-                                    endif; ?>
-                                   value="<?php echo $message->displayField('subject'); ?>"/>
+                            <input type="text" id="subject" name="subject" class="form-control" maxlength="<?php echo $template->params->get('SubjectLengthMessage'); ?>" <?php
+                                                                                                                                                                            if (!$config->allowChangeSubject && !$me->isModerator()) :
+                                                                                                                                                                            ?>disabled<?php
+                                                                                                                                                                                    endif; ?> value="<?php echo $message->displayField('subject'); ?>" />
                         </div>
 
                         <div class="form-group">
@@ -144,46 +131,36 @@ if ($me->canDoCaptcha() && KunenaConfig::getInstance()->quickReply) {
                         </div>
 
                         <?php if ($topic->isAuthorised('subscribe')) :
-                            ?>
+                        ?>
                             <div class="clearfix"></div>
                             <div class="control-group">
                                 <div id="mesubscribe">
-                                    <input style="float: left; margin-right: 10px;" type="checkbox"
-                                           name="subscribeMe" id="subscribeMe"
-                                           value="1" <?php if ($config->subscriptionsChecked == 1 && $me->canSubscribe != 0 || $config->subscriptionsChecked == 0 && $me->canSubscribe == 1) {
-                                                echo 'checked="checked"';
-                                                     } ?> />
-                                    <label class="string optional col-md-12 control-label" style="padding:0;"
-                                           for="subscribeMe"><?php echo Text::_('COM_KUNENA_POST_NOTIFIED'); ?></label>
+                                    <input style="float: left; margin-right: 10px;" type="checkbox" name="subscribeMe" id="subscribeMe" value="1" <?php if ($config->subscriptionsChecked == 1 && $me->canSubscribe != 0 || $config->subscriptionsChecked == 0 && $me->canSubscribe == 1) {
+                                                                                                                                                        echo 'checked="checked"';
+                                                                                                                                                    } ?> />
+                                    <label class="string optional col-md-12 control-label" style="padding:0;" for="subscribeMe"><?php echo Text::_('COM_KUNENA_POST_NOTIFIED'); ?></label>
                                 </div>
                             </div>
                         <?php endif; ?>
 
                         <?php if ($me->exists() && $category->allowAnonymous) :
-                            ?>
+                        ?>
                             <div class="control-group">
                                 <div class="controls">
-                                    <input style="float: left; margin-right: 10px;" type="checkbox"
-                                           id="kanonymous<?php echo $message->displayField('id'); ?>"
-                                           name="anonymous"
-                                           value="1"
-                                           <?php if ($category->postAnonymous) {
-                                                echo 'checked="checked"';
-                                           } ?> />
+                                    <input style="float: left; margin-right: 10px;" type="checkbox" id="kanonymous<?php echo $message->displayField('id'); ?>" name="anonymous" value="1" <?php if ($category->postAnonymous) {
+                                                                                                                                                                                                echo 'checked="checked"';
+                                                                                                                                                                                            } ?> />
                                     <label for="kanonymous<?php echo \intval($message->id); ?>">
                                         <?php echo Text::_('COM_KUNENA_POST_AS_ANONYMOUS_DESC'); ?>
                                     </label>
                                 </div>
                             </div>
                         <?php endif; ?>
-                        <a id="qrlocalstorage<?php echo $message->displayField('id'); ?>"
-                           href="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=reply&catid=' . $message->catid . '&id=' . $message->thread . '&mesid=' . $message->id . '&Itemid=' . KunenaRoute::getItemID()) ?>"
-                           role="button" class="btn btn-outline-primary border btn-small btn-link float-end gotoeditor"
-                           rel="nofollow"><?php echo Text::_('COM_KUNENA_GO_TO_EDITOR'); ?></a>
-                        <br/>
+                        <a id="qrlocalstorage<?php echo $message->displayField('id'); ?>" href="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=reply&catid=' . $message->catid . '&id=' . $message->thread . '&mesid=' . $message->id . '&Itemid=' . KunenaRoute::getItemID()) ?>" role="button" class="btn btn-outline-primary border btn-small btn-link float-end gotoeditor" rel="nofollow"><?php echo Text::_('COM_KUNENA_GO_TO_EDITOR'); ?></a>
+                        <br />
 
                         <?php if (!empty($this->captchaEnabled)) :
-                            ?>
+                        ?>
                             <div class="control-group">
                                 <?php echo $this->captchaDisplay; ?>
                             </div>
@@ -191,29 +168,22 @@ if ($me->canDoCaptcha() && KunenaConfig::getInstance()->quickReply) {
 
                         <div class="k-footer">
                             <small><?php echo Text::_('COM_KUNENA_QMESSAGE_NOTE'); ?></small>
-                            <input type="submit" class="btn btn-outline-primary border kreply-submit" name="submit"
-                                   value="<?php echo Text::_('COM_KUNENA_SUBMIT'); ?>"
-                                   data-bs-toggle="tooltip" title="<?php echo Text::_('COM_KUNENA_EDITOR_HELPLINE_SUBMIT');
-                                    ?>"/>
+                            <input type="submit" class="btn btn-outline-primary border kreply-submit" name="submit" value="<?php echo Text::_('COM_KUNENA_SUBMIT'); ?>" data-bs-toggle="tooltip" title="<?php echo Text::_('COM_KUNENA_EDITOR_HELPLINE_SUBMIT');
+                                                                                                                                                                                                        ?>" />
                             <?php // TODO: remove data on cancel.
                             ?>
-                            <input type="reset" name="reset" class="btn btn-outline-primary border kreply-cancel"
-                                   value="<?php echo ' ' . Text::_('COM_KUNENA_CANCEL') . ' '; ?>"
-                                   data-bs-toggle="tooltip" title="<?php echo Text::_('COM_KUNENA_EDITOR_HELPLINE_CANCEL'); ?>"
-                                   data-bs-dismiss="modal" aria-hidden="true"/>
+                            <input type="reset" name="reset" class="btn btn-outline-primary border kreply-cancel" value="<?php echo ' ' . Text::_('COM_KUNENA_CANCEL') . ' '; ?>" data-bs-toggle="tooltip" title="<?php echo Text::_('COM_KUNENA_EDITOR_HELPLINE_CANCEL'); ?>" data-bs-dismiss="modal" aria-hidden="true" />
                         </div>
-                        <input type="hidden" id="kurl_emojis" name="kurl_emojis"
-                               value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=listemoji&format=raw') ?>"/>
-                        <input type="hidden" id="kemojis_allowed" name="kemojis_allowed"
-                               value="<?php echo $config->disableEmoticons ?>"/>
+                        <input type="hidden" id="kurl_emojis" name="kurl_emojis" value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=listemoji&format=raw') ?>" />
+                        <input type="hidden" id="kemojis_allowed" name="kemojis_allowed" value="<?php echo $config->disableEmoticons ?>" />
                     </form>
                 </div>
             </div>
         </div>
     </div>
-    <?php elseif ($quick == 0) :
-        ?>
-    <div class="modal fade" style="position: relative; top: 10px; right: -10px; z-index: 1; width: 100%;display: none;" id="kreply<?php echo $message->displayField('id'); ?>_form" data-bs-backdrop="false"  tabindex="-1"  aria-hidden="true">
+<?php elseif ($quick == 0) :
+?>
+    <div class="modal fade" style="position: relative; top: 10px; right: -10px; z-index: 1; width: 100%;display: none;" id="kreply<?php echo $message->displayField('id'); ?>_form" data-bs-backdrop="false" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
@@ -221,139 +191,109 @@ if ($me->canDoCaptcha() && KunenaConfig::getInstance()->quickReply) {
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <form action="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic'); ?>"
-                      method="post"
-                      enctype="multipart/form-data" name="postform" id="postform" class="form-horizontal">
-                    <input type="hidden" name="task" value="post"/>
-                    <input type="hidden" name="parentid" value="<?php echo $message->displayField('id'); ?>"/>
-                    <input type="hidden" name="catid" value="<?php echo $category->displayField('id'); ?>"/>
-                    <?php
-                    if (!$config->allowChangeSubject || $me->isModerator()) :
+                    <form action="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic'); ?>" method="post" enctype="multipart/form-data" name="postform" id="postform-<?php echo $message->id; ?>" class="form-horizontal">
+                        <input type="hidden" name="task" value="post" />
+                        <input type="hidden" name="parentid" value="<?php echo $message->displayField('id'); ?>" />
+                        <input type="hidden" name="catid" value="<?php echo $category->displayField('id'); ?>" />
+                        <?php
+                        if (!$config->allowChangeSubject || $me->isModerator()) :
                         ?>
-                        <input type="hidden" name="subject"
-                               value="<?php echo $this->escape($this->message->subject); ?>"/>
-                    <?php endif; ?>
-                    <?php
-                    if ($me->exists()) :
-                        ?>
-                        <input type="hidden" id="kurl_users" name="kurl_users"
-                               value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=user&layout=listmention&format=raw') ?>"/>
-                    <?php endif; ?>
-                    <?php echo HTMLHelper::_('form.token'); ?>
-
-                    <div class="card-body">
-                        <?php if (!$me->exists()) :
-                            ?>
-                            <div class="form-group">
-                                <label class="col-md-12 control-label" style="padding:0;">
-                                    <?php echo Text::_('COM_KUNENA_GEN_NAME'); ?>:
-                                </label>
-                                <input type="text" name="authorname" class="form-control" maxlength="35"
-                                       placeholder="<?php echo Text::_('COM_KUNENA_GEN_NAME'); ?>" value=""
-                                       required/>
-                            </div>
-                        <?php endif; ?>
-
-                        <?php if ($config->askEmail && !$me->exists()) :
-                            ?>
-                            <div class="form-group">
-                                <?php echo $config->showEmail == '0' ? Text::_('COM_KUNENA_POST_EMAIL_NEVER') : Text::_('COM_KUNENA_POST_EMAIL_REGISTERED'); ?>
-                                <input type="text" id="email" name="email"
-                                       placeholder="<?php echo Text::_('COM_KUNENA_TOPIC_EDIT_PLACEHOLDER_EMAIL') ?>"
-                                       class="inputbox col-md-12 form-control" maxlength="45" value=""
-                                       required/>
-                            </div>
-                        <?php endif; ?>
-
-                        <div class="form-group">
-                            <label for="kanonymous<?php echo \intval($message->id); ?>"
-                                   class="col-md-12 control-label" style="padding:0;">
-                                <?php echo Text::_('COM_KUNENA_GEN_SUBJECT'); ?>:
-                            </label>
-                            <input type="text" id="subject" name="subject" class="form-control"
-                                   maxlength="<?php echo $template->params->get('SubjectLengthMessage'); ?>"
-                                   <?php
-                                    if (!$config->allowChangeSubject && !$me->isModerator()) :
-                                        ?>disabled<?php
-                                    endif; ?>
-                                   value="<?php echo $message->displayField('subject'); ?>"/>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-md-12 control-label" style="padding:0;">
-                                <?php echo Text::_('COM_KUNENA_MESSAGE'); ?>:
-                            </label>
-                            <?php if ($editor == 1) {
-                                echo $this->subLayout('Widget/Editor')->setLayout('wysibb_quick')->set('message', $this->message)->set('config', $config);
-                            } else {
-                                echo '<textarea class="qreply form-control qrlocalstorage' . $message->displayField("id") . '" id="editor" name="message" rows="6" cols="60" placeholder="' . Text::_('COM_KUNENA_ENTER_MESSAGE') . '"></textarea>';
-                            } ?>
-                        </div>
-
-                        <?php if ($topic->isAuthorised('subscribe')) :
-                            ?>
-                            <div class="clearfix"></div>
-                            <div class="control-group">
-                                <div id="mesubscribe">
-                                    <input style="float: left; margin-right: 10px;" type="checkbox"
-                                           name="subscribeMe" id="subscribeMe"
-                                           value="1" <?php if ($config->subscriptionsChecked == 1 && $me->canSubscribe != 0 || $config->subscriptionsChecked == 0 && $me->canSubscribe == 1 || $category->getSubscribed($me->userid)) {
-                                                echo 'checked="checked"';
-                                                     } ?> />
-                                    <label class="string optional col-md-12 control-label" style="padding:0;"
-                                           for="subscribeMe"><?php echo Text::_('COM_KUNENA_POST_NOTIFIED'); ?></label>
-                                </div>
-                            </div>
+                            <input type="hidden" name="subject" value="<?php echo $this->escape($this->message->subject); ?>" />
                         <?php endif; ?>
                         <?php
-                        if ($me->exists() && $category->allowAnonymous) :
+                        if ($me->exists()) :
+                        ?>
+                            <input type="hidden" id="kurl_users" name="kurl_users" value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=user&layout=listmention&format=raw') ?>" />
+                        <?php endif; ?>
+                        <?php echo HTMLHelper::_('form.token'); ?>
+
+                        <div class="card-body">
+                            <?php if (!$me->exists()) :
                             ?>
-                            <div class="control-group">
-                                <div class="controls">
-                                    <input style="float: left; margin-right: 10px;" type="checkbox"
-                                           id="kanonymous<?php echo $message->displayField('id'); ?>"
-                                           name="anonymous"
-                                           value="1"
-                                           <?php if ($category->postAnonymous) {
-                                                echo 'checked="checked"';
-                                           } ?> />
-                                    <label for="kanonymous<?php echo \intval($message->id); ?>">
-                                        <?php echo Text::_('COM_KUNENA_POST_AS_ANONYMOUS_DESC'); ?>
+                                <div class="form-group">
+                                    <label class="col-md-12 control-label" style="padding:0;">
+                                        <?php echo Text::_('COM_KUNENA_GEN_NAME'); ?>:
                                     </label>
+                                    <input type="text" name="authorname" class="form-control" maxlength="35" placeholder="<?php echo Text::_('COM_KUNENA_GEN_NAME'); ?>" value="" required />
                                 </div>
+                            <?php endif; ?>
+
+                            <?php if ($config->askEmail && !$me->exists()) :
+                            ?>
+                                <div class="form-group">
+                                    <?php echo $config->showEmail == '0' ? Text::_('COM_KUNENA_POST_EMAIL_NEVER') : Text::_('COM_KUNENA_POST_EMAIL_REGISTERED'); ?>
+                                    <input type="text" id="email" name="email" placeholder="<?php echo Text::_('COM_KUNENA_TOPIC_EDIT_PLACEHOLDER_EMAIL') ?>" class="inputbox col-md-12 form-control" maxlength="45" value="" required />
+                                </div>
+                            <?php endif; ?>
+
+                            <div class="form-group">
+                                <label for="kanonymous<?php echo \intval($message->id); ?>" class="col-md-12 control-label" style="padding:0;">
+                                    <?php echo Text::_('COM_KUNENA_GEN_SUBJECT'); ?>:
+                                </label>
+                                <input type="text" id="subject" name="subject" class="form-control" maxlength="<?php echo $template->params->get('SubjectLengthMessage'); ?>" <?php
+                                                                                                                                                                                if (!$config->allowChangeSubject && !$me->isModerator()) :
+                                                                                                                                                                                ?>disabled<?php
+                                                                                                                                                                                        endif; ?> value="<?php echo $message->displayField('subject'); ?>" />
+                            </div>
+                            <div class="form-group">
+                                <label class="col-md-12 control-label" style="padding:0;">
+                                    <?php echo Text::_('COM_KUNENA_MESSAGE'); ?>:
+                                </label>
+                                <?php if ($editor == 1) {
+                                    echo $this->subLayout('Widget/Editor')->setLayout('wysibb_quick')->set('message', $this->message)->set('config', $config);
+                                } else {
+                                    echo '<textarea class="qreply form-control qrlocalstorage' . $message->displayField("id") . '" id="editor" name="message" rows="6" cols="60" placeholder="' . Text::_('COM_KUNENA_ENTER_MESSAGE') . '"></textarea>';
+                                } ?>
+                            </div>
+
+                            <?php if ($topic->isAuthorised('subscribe')) :
+                            ?>
+                                <div class="clearfix"></div>
+                                <div class="control-group">
+                                    <div id="mesubscribe">
+                                        <input style="float: left; margin-right: 10px;" type="checkbox" name="subscribeMe" id="subscribeMe" value="1" <?php if ($config->subscriptionsChecked == 1 && $me->canSubscribe != 0 || $config->subscriptionsChecked == 0 && $me->canSubscribe == 1 || $category->getSubscribed($me->userid)) {
+                                                                                                                                                            echo 'checked="checked"';
+                                                                                                                                                        } ?> />
+                                        <label class="string optional col-md-12 control-label" style="padding:0;" for="subscribeMe"><?php echo Text::_('COM_KUNENA_POST_NOTIFIED'); ?></label>
+                                    </div>
+                                </div>
+                            <?php endif; ?>
+                            <?php
+                            if ($me->exists() && $category->allowAnonymous) :
+                            ?>
+                                <div class="control-group">
+                                    <div class="controls">
+                                        <input style="float: left; margin-right: 10px;" type="checkbox" id="kanonymous<?php echo $message->displayField('id'); ?>" name="anonymous" value="1" <?php if ($category->postAnonymous) {
+                                                                                                                                                                                                    echo 'checked="checked"';
+                                                                                                                                                                                                } ?> />
+                                        <label for="kanonymous<?php echo \intval($message->id); ?>">
+                                            <?php echo Text::_('COM_KUNENA_POST_AS_ANONYMOUS_DESC'); ?>
+                                        </label>
+                                    </div>
+                                </div>
+                            <?php endif; ?>
+                            <a id="qrlocalstorage<?php echo $message->displayField('id'); ?>" href="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=reply&catid=' . $message->catid . '&id=' . $message->thread . '&mesid=' . $message->id . '&Itemid=' . KunenaRoute::getItemID()) ?>" role="button" class="btn btn-outline-primary border btn-small btn-link float-end gotoeditor" rel="nofollow"><?php echo Text::_('COM_KUNENA_GO_TO_EDITOR'); ?></a>
+                            <br />
+                        </div>
+                        <?php if (!empty($this->captchaEnabled)) :
+                        ?>
+                            <div class="control-group">
+                                <?php echo $this->captchaDisplay; ?>
                             </div>
                         <?php endif; ?>
-                        <a id="qrlocalstorage<?php echo $message->displayField('id'); ?>"
-                           href="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=reply&catid=' . $message->catid . '&id=' . $message->thread . '&mesid=' . $message->id . '&Itemid=' . KunenaRoute::getItemID()) ?>"
-                           role="button" class="btn btn-outline-primary border btn-small btn-link float-end gotoeditor"
-                           rel="nofollow"><?php echo Text::_('COM_KUNENA_GO_TO_EDITOR'); ?></a>
-                        <br/>
-                    </div>
-                    <?php if (!empty($this->captchaEnabled)) :
-                        ?>
-                        <div class="control-group">
-                            <?php echo $this->captchaDisplay; ?>
+                        <div class="card-footer">
+                            <small><?php echo Text::_('COM_KUNENA_QMESSAGE_NOTE'); ?></small>
+                            <input type="submit" class="btn btn-outline-primary border kreply-submit" name="submit" value="<?php echo Text::_('COM_KUNENA_SUBMIT'); ?>" data-bs-toggle="tooltip" title="<?php echo Text::_('COM_KUNENA_EDITOR_HELPLINE_SUBMIT');
+                                                                                                                                                                                                        ?>" />
+                            <?php // TODO: remove data on cancel.
+                            ?>
+                            <input type="reset" name="reset" class="btn btn-outline-primary border kreply-cancel" value="<?php echo ' ' . Text::_('COM_KUNENA_CANCEL') . ' '; ?>" data-bs-toggle="tooltip" title="<?php echo Text::_('COM_KUNENA_EDITOR_HELPLINE_CANCEL'); ?>" data-bs-dismiss="modal" aria-hidden="true" />
                         </div>
-                    <?php endif; ?>
-                    <div class="card-footer">
-                        <small><?php echo Text::_('COM_KUNENA_QMESSAGE_NOTE'); ?></small>
-                        <input type="submit" class="btn btn-outline-primary border kreply-submit" name="submit"
-                               value="<?php echo Text::_('COM_KUNENA_SUBMIT'); ?>"
-                               data-bs-toggle="tooltip" title="<?php echo Text::_('COM_KUNENA_EDITOR_HELPLINE_SUBMIT');
-                                ?>"/>
-                        <?php // TODO: remove data on cancel.
-                        ?>
-                        <input type="reset" name="reset" class="btn btn-outline-primary border kreply-cancel"
-                               value="<?php echo ' ' . Text::_('COM_KUNENA_CANCEL') . ' '; ?>"
-                               data-bs-toggle="tooltip" title="<?php echo Text::_('COM_KUNENA_EDITOR_HELPLINE_CANCEL'); ?>"
-                               data-bs-dismiss="modal" aria-hidden="true"/>
-                    </div>
-                    <input type="hidden" id="kurl_emojis" name="kurl_emojis"
-                           value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=listemoji&format=raw') ?>"/>
-                    <input type="hidden" id="kemojis_allowed" name="kemojis_allowed"
-                           value="<?php echo $config->disableEmoticons ?>"/>
-                        </form>
-                    </div>
+                        <input type="hidden" id="kurl_emojis" name="kurl_emojis" value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&layout=listemoji&format=raw') ?>" />
+                        <input type="hidden" id="kemojis_allowed" name="kemojis_allowed" value="<?php echo $config->disableEmoticons ?>" />
+                    </form>
                 </div>
             </div>
         </div>
-    <?php endif;
+    </div>
+<?php endif;


### PR DESCRIPTION
Pull Request for Potential Issue 
 
#### Summary of Changes 
elements on a page should have a unique ID, currently the quick reply forms all have the same form ID. This can cause errors / conflicts when trying to do CSS / JS functions on these forms
 
#### Testing Instructions
install PR, test if everything is still working.
Take special attantion when you have JS or CSS using the form ID "postform" as this ID now has been made unique with the message ID the postform is linked to.