### PR TITLE
Fix user filter where clause and nulldate not being nulldate for bann…

### DIFF
--- a/src/admin/forms/filter_users.xml
+++ b/src/admin/forms/filter_users.xml
@@ -27,8 +27,8 @@
 			default=""
 			validate="options">
 			<option value="">COM_KUNENA_FILTER_SELECT_ENABLED</option>
-			<option value="0">COM_KUNENA_FIELD_LABEL_ON</option>
-			<option value="1">COM_KUNENA_FIELD_LABEL_OFF</option>
+			<option value="0">COM_KUNENA_FIELD_LABEL_YES</option>
+			<option value="1">COM_KUNENA_FIELD_LABEL_NO</option>
 		</field>
 		<field
 			name="banned"
@@ -38,8 +38,8 @@
 			default=""
 			validate="options">
 			<option value="">COM_KUNENA_FILTER_SELECT_BANNED</option>
-			<option value="1">COM_KUNENA_FIELD_LABEL_ON</option>
-			<option value="0">COM_KUNENA_FIELD_LABEL_OFF</option>
+			<option value="1">COM_KUNENA_FIELD_LABEL_YES</option>
+			<option value="0">COM_KUNENA_FIELD_LABEL_NO</option>
 		</field>
 		<field
 			name="moderator"

--- a/src/admin/src/Model/UsersModel.php
+++ b/src/admin/src/Model/UsersModel.php
@@ -285,7 +285,7 @@ class UsersModel extends ListModel
                 // $query->where("(ku.banned={$nullDate} OR ku.banned={$db->quote('1000-01-01 00:00:00')} OR ku.banned>{$db->quote($now->toSql())})");
                 $query->where("ku.banned>{$nullDate}");
             } else {
-                $query->where("(ku.banned IS NULL OR (ku.banned>{$nullDate} AND ku.banned<{$db->quote($now->toSql())}))");
+                $query->where("(ku.banned IS NULL OR (ku.banned>={$nullDate} AND ku.banned<{$db->quote($now->toSql())}))");
             }
         }
 

--- a/src/admin/src/Model/UsersModel.php
+++ b/src/admin/src/Model/UsersModel.php
@@ -259,9 +259,9 @@ class UsersModel extends ListModel
 
         if ($filter !== '') {
             if ($filter) {
-                $query->where("ku.signature!={$db->quote('')} AND ku.signature IS NOT NULL");
+                $query->where("(ku.signature!={$db->quote('')} AND ku.signature IS NOT NULL)");
             } else {
-                $query->where("ku.signature={$db->quote('')} OR ku.signature IS NULL");
+                $query->where("(ku.signature={$db->quote('')} OR ku.signature IS NULL)");
             }
         }
 
@@ -277,12 +277,15 @@ class UsersModel extends ListModel
 
         if ($filter !== '') {
             $now      = new Date();
-            $nullDate = $db->getNullDate() ? $db->quote($db->getNullDate()) : 'NULL';
+            // $DB nulldate = 0000-00-00 00:00:00 but Kunena uses 1000-01-01 00:00:00 as nulldate
+            // $nullDate = $db->getNullDate() ? $db->quote($db->getNullDate()) : 'NULL';
+            $nullDate = $db->quote('1000-01-01 00:00:00');
 
             if ($filter) {
-                $query->where("ku.banned={$nullDate} OR ku.banned>{$db->quote($now->toSql())}");
+                // $query->where("(ku.banned={$nullDate} OR ku.banned={$db->quote('1000-01-01 00:00:00')} OR ku.banned>{$db->quote($now->toSql())})");
+                $query->where("ku.banned>{$nullDate}");
             } else {
-                $query->where("ku.banned IS NULL OR (ku.banned>{$nullDate} AND ku.banned<{$db->quote($now->toSql())})");
+                $query->where("(ku.banned IS NULL OR (ku.banned>{$nullDate} AND ku.banned<{$db->quote($now->toSql())}))");
             }
         }
 

--- a/src/admin/src/Model/UsersModel.php
+++ b/src/admin/src/Model/UsersModel.php
@@ -282,7 +282,6 @@ class UsersModel extends ListModel
             $nullDate = $db->quote('1000-01-01 00:00:00');
 
             if ($filter) {
-                // $query->where("(ku.banned={$nullDate} OR ku.banned={$db->quote('1000-01-01 00:00:00')} OR ku.banned>{$db->quote($now->toSql())})");
                 $query->where("ku.banned>{$nullDate}");
             } else {
                 $query->where("(ku.banned IS NULL OR (ku.banned>={$nullDate} AND ku.banned<{$db->quote($now->toSql())}))");


### PR DESCRIPTION
Pull Request for Issue # . 
https://www.kunena.org/forum/k-6-3-0-support/168362-kunena-6-3-0-beta2-dev-user-incorrect-filter-options
 
#### Summary of Changes 
changed the where clause when there as an OR (signature and banned)

Also the original banned where was filtering on $db->nullDate() which is '0000-00-00 00:00:00' but when I check my kunena users table I see that in field banned a nulldate of '1000-01-01 00:00:00' is used (so not the $db nulldate but an own one). I changed the filter to use the 1000-01-01 00:00:00 nulldate instead.

#### Testing Instructions
test filters and combinations of filters and see if they work