### PR TITLE
Fix for operations filter field (not translated) in Log view

### DIFF
--- a/src/admin/src/Field/KunenaoperationlistField.php
+++ b/src/admin/src/Field/KunenaoperationlistField.php
@@ -65,8 +65,8 @@ class KunenaoperationlistField extends ListField
         foreach ($constants as $key => $value) {
             if (strpos($key, 'LOG_') === 0) {
                 $operationOptions[] = (object) [
-                    'text'  => $key,
-                    'value' => Text::_("COM_KUNENA_{$value}"),
+                    'value'  => $key,
+                    'text' => Text::_("COM_KUNENA_{$value}"),
                 ];
             }
         }


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
operation filter field in log view not translated / not working
 
#### Testing Instructions
when selecting field, dropdown should show translated operations and filtering should work correct