### PR TITLE
fix: users view banned sorting / filtering

### DIFF
--- a/src/admin/forms/filter_users.xml
+++ b/src/admin/forms/filter_users.xml
@@ -68,8 +68,6 @@
 			<option value="email DESC">COM_KUNENA_FILTER_FIELD_EMAIL_DESC</option>
 			<option value="ip ASC">COM_KUNENA_FILTER_FIELD_IP_ASC</option>
 			<option value="ip DESC">COM_KUNENA_FILTER_FIELD_IP_DESC</option>
-			<option value="rank ASC">COM_KUNENA_FILTER_FIELD_RANK_ASC</option>
-			<option value="rank DESC">COM_KUNENA_FILTER_FIELD_RANK_DESC</option>
 			<option value="signature ASC">COM_KUNENA_FILTER_FIELD_SIGNATURE_ASC</option>
 			<option value="signature DESC">COM_KUNENA_FILTER_FIELD_SIGNATURE_DESC</option>
 			<option value="enabled ASC">COM_KUNENA_FILTER_FIELD_ENABLED_ASC</option>

--- a/src/admin/tmpl/users/default.php
+++ b/src/admin/tmpl/users/default.php
@@ -59,7 +59,7 @@ $language->load('com_users');
                                 <?php echo HTMLHelper::_('searchtools.sort', 'COM_KUNENA_GEN_IP', 'ip', $listDirn, $listOrder); ?>
                             </th>
                             <th scope="col" class="w-10 d-none d-md-table-cell">
-                                <?php echo HTMLHelper::_('searchtools.sort', 'COM_KUNENA_A_RANKS', 'rank', $listDirn, $listOrder); ?>
+                                <?php echo Text::_('COM_KUNENA_A_RANKS'); ?>
                             </th>
                             <th scope="col" class="w-5 d-none d-md-table-cell">
                                 <?php echo HTMLHelper::_('searchtools.sort', 'COM_KUNENA_GEN_SIGNATURE', 'signature', $listDirn, $listOrder); ?>


### PR DESCRIPTION
Pull Request for Issue # . 
filtering of banned users in users view
 
#### Summary of Changes 
banned status is a constructedd status after the query, so sorting and selecting will not work. This PR adds part of the construction of this field ito the query so we can use it to filter and select banned status.
Removed rand sorting as that didn't work (ranks are assigned dynamically after querying the database)
 
#### Testing Instructions
in users view, sort the banned column
filter on banned = yes