### PR TITLE
Refactor Popup Modals to be J4 compatible

### DIFF
--- a/src/admin/src/View/Categories/HtmlView.php
+++ b/src/admin/src/View/Categories/HtmlView.php
@@ -138,11 +138,7 @@ class HtmlView extends BaseHtmlView
             ->message('COM_KUNENA_CATEGORIES_CONFIRM_DELETE_BODY_MODAL')
             ->listCheck(true);
         $childBar->popupButton('batch', 'JTOOLBAR_BATCH')
-            ->popupType('inline')
-            ->textHeader(Text::_('JTOOLBAR_BATCH'))
-            ->url('#joomla-dialog-batch')
-            ->modalWidth('800px')
-            ->modalHeight('fit-content')
+            ->selector('joomla-dialog-batch')
             ->listCheck(true);
 
         $helpUrl = 'https://docs.kunena.org/en/setup/sections-categories';

--- a/src/admin/src/View/Config/HtmlView.php
+++ b/src/admin/src/View/Config/HtmlView.php
@@ -77,11 +77,7 @@ class HtmlView extends BaseHtmlView
         $toolbar->save('config.save');
 
         $toolbar->popupButton('batch', 'COM_KUNENA_RESET_CONFIG')
-            ->popupType('inline')
-            ->textHeader(Text::_('COM_KUNENA_RESET_CONFIG'))
-            ->url('#joomla-dialog-setting')
-            ->modalWidth('800px')
-            ->modalHeight('fit-content')
+            ->selector('joomla-dialog-setting')
             ->listCheck(false);
         $toolbar->cancel('config.cancel', 'JTOOLBAR_CANCEL');
 

--- a/src/admin/src/View/Logs/HtmlView.php
+++ b/src/admin/src/View/Logs/HtmlView.php
@@ -148,11 +148,14 @@ class HtmlView extends BaseHtmlView
         // Set the title bar text
         ToolbarHelper::title(Text::_('COM_KUNENA') . ': ' . Text::_('COM_KUNENA_LOG_MANAGER'), 'users');
         $toolbar->popupButton('cleanentries', 'COM_KUNENA_LOG_CLEAN_ENTRIES')
-            ->popupType('inline')
-            ->textHeader(Text::_('COM_KUNENA_LOG_CLEAN_ENTRIES'))
-            ->url('#joomla-dialog-clean')
-            ->modalWidth('800px')
-            ->modalHeight('fit-content');
+            ->selector('joomla-dialog-clean')
+            ->listCheck(false);
+        // $toolbar->popupButton('cleanentries', 'COM_KUNENA_LOG_CLEAN_ENTRIES')
+        //     ->popupType('inline')
+        //     ->textHeader(Text::_('COM_KUNENA_LOG_CLEAN_ENTRIES'))
+        //     ->url('#joomla-dialog-clean')
+        //     ->modalWidth('800px')
+        //     ->modalHeight('fit-content');
 
         $helpUrl = 'https://docs.kunena.org/en/manual/backend/users';
         ToolbarHelper::help('COM_KUNENA', false, $helpUrl);

--- a/src/admin/src/View/Users/HtmlView.php
+++ b/src/admin/src/View/Users/HtmlView.php
@@ -106,20 +106,26 @@ class HtmlView extends BaseHtmlView
             ->listCheck(true);
 
         $childBar->popupButton('batch', 'COM_KUNENA_VIEW_USERS_TOOLBAR_ASSIGN_MODERATORS')
-            ->popupType('inline')
-            ->textHeader(Text::_('COM_KUNENA_VIEW_USERS_TOOLBAR_ASSIGN_MODERATORS'))
-            ->url('#joomla-dialog-moderators')
-            ->modalWidth('800px')
-            ->modalHeight('fit-content')
+            ->selector('joomla-dialog-moderators')
             ->listCheck(true);
+        // $childBar->popupButton('batch', 'COM_KUNENA_VIEW_USERS_TOOLBAR_ASSIGN_MODERATORS')
+        //     ->popupType('inline')
+        //     ->textHeader(Text::_('COM_KUNENA_VIEW_USERS_TOOLBAR_ASSIGN_MODERATORS'))
+        //     ->url('#joomla-dialog-moderators')
+        //     ->modalWidth('800px')
+        //     ->modalHeight('fit-content')
+        //     ->listCheck(true);
 
         $childBar->popupButton('batch', 'COM_KUNENA_VIEW_USERS_TOOLBAR_SUBSCRIBE_USERS_CATEGORIES')
-            ->popupType('inline')
-            ->textHeader(Text::_('COM_KUNENA_VIEW_USERS_TOOLBAR_SUBSCRIBE_USERS_CATEGORIES'))
-            ->url('#joomla-dialog-subscribecatsusers')
-            ->modalWidth('800px')
-            ->modalHeight('fit-content')
+            ->selector('joomla-dialog-subscribecatsusers')
             ->listCheck(true);
+        //    $childBar->popupButton('batch', 'COM_KUNENA_VIEW_USERS_TOOLBAR_SUBSCRIBE_USERS_CATEGORIES')
+        //         ->popupType('inline')
+        //         ->textHeader(Text::_('COM_KUNENA_VIEW_USERS_TOOLBAR_SUBSCRIBE_USERS_CATEGORIES'))
+        //         ->url('#joomla-dialog-subscribecatsusers')
+        //         ->modalWidth('800px')
+        //         ->modalHeight('fit-content')
+        //         ->listCheck(true);
 
         $helpUrl = 'https://docs.kunena.org/en/manual/backend/users';
         ToolbarHelper::help('COM_KUNENA', false, $helpUrl);

--- a/src/admin/tmpl/categories/default.php
+++ b/src/admin/tmpl/categories/default.php
@@ -204,7 +204,14 @@ if ($saveOrder) {
                 ?>
                 <?php echo $this->pagination->getListFooter(); ?>
 
-                <template id="joomla-dialog-batch"><?php echo $this->loadTemplate('batch'); ?></template>
+                <?php echo HTMLHelper::_(
+                    'bootstrap.renderModal',
+                    'joomla-dialog-batch',
+                    [
+                        'title'  => Text::_('COM_KUNENA_BATCH_OPTIONS'),
+                    ],
+                    $this->loadTemplate('batch')
+                ); ?>
 
                 <input type="hidden" name="task" value="" />
                 <input type="hidden" name="boxchecked" value="0" />

--- a/src/admin/tmpl/categories/default_batch.php
+++ b/src/admin/tmpl/categories/default_batch.php
@@ -41,7 +41,10 @@ use Joomla\CMS\Language\Text;
     </div>
 </div>
 <div class="btn-toolbar p-3">
-    <joomla-toolbar-button task="categories.batchCategories" class="ms-auto">
-        <button type="button" class="btn btn-success"><?php echo Text::_('COM_KUNENA_BATCH_PROCESS'); ?></button>
-    </joomla-toolbar-button>
+    <button type="button" class="btn btn-danger ms-auto" data-bs-dismiss="modal">
+        <?php echo Text::_('JCANCEL'); ?>
+    </button>
+    <button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='categories.batchCategories'>
+        <?php echo Text::_('COM_KUNENA_BATCH_PROCESS'); ?>
+    </button>
 </div>

--- a/src/admin/tmpl/config/default.php
+++ b/src/admin/tmpl/config/default.php
@@ -2085,7 +2085,14 @@ use Kunena\Forum\Libraries\Version\KunenaVersion;
             </form>
             <?php // Load the setting confirmation box form. 
             ?>
-            <template id="joomla-dialog-setting"><?php echo $this->loadTemplate('setting'); ?></template>
+            <?php echo HTMLHelper::_(
+                'bootstrap.renderModal',
+                'joomla-dialog-setting',
+                [
+                    'title'  => Text::_('COM_KUNENA_CONFIG_MODAL_TITLE'),
+                ],
+                $this->loadTemplate('setting')
+            ); ?>
         </div>
     </div>
 </div>

--- a/src/admin/tmpl/config/default_setting.php
+++ b/src/admin/tmpl/config/default_setting.php
@@ -25,7 +25,10 @@ use Kunena\Forum\Libraries\Route\KunenaRoute;
         </div>
     </div>
     <div class="btn-toolbar p-3">
-        <button type="submit" class="btn btn-success ms-auto" onclick="document.getElementById('settingFormModal').submit();"><?php echo Text::_('JSUBMIT'); ?></button>
+        <button type="button" class="btn btn-danger ms-auto" data-bs-dismiss="modal">
+            <?php echo Text::_('JCANCEL'); ?>
+        </button>
+        <button type="submit" class="btn btn-success" onclick="document.getElementById('settingFormModal').submit();"><?php echo Text::_('JSUBMIT'); ?></button>
     </div>
     <input type="hidden" name="task" value="config.setDefault" />
     <?php echo HTMLHelper::_('form.token') ?>

--- a/src/admin/tmpl/logs/default.php
+++ b/src/admin/tmpl/logs/default.php
@@ -198,7 +198,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                 ?>
                 <?php echo $this->pagination->getListFooter(); ?>
 
-                <template id="joomla-dialog-clean"><?php echo $this->loadTemplate('clean'); ?></template>
+                <?php echo HTMLHelper::_(
+                    'bootstrap.renderModal',
+                    'joomla-dialog-clean',
+                    [
+                        'title'  => Text::_('COM_KUNENA_LOG_CLEAN_ENTRIES'),
+                    ],
+                    $this->loadTemplate('clean')
+                ); ?>
 
                 <input type="hidden" name="task" value="" />
                 <input type="hidden" name="boxchecked" value="1" />

--- a/src/admin/tmpl/logs/default_clean.php
+++ b/src/admin/tmpl/logs/default_clean.php
@@ -13,10 +13,7 @@
 
 defined('_JEXEC') or die();
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Kunena\Forum\Libraries\Version\KunenaVersion;
-use Kunena\Forum\Libraries\Route\KunenaRoute;
 
 ?>
 <div class="p-3">
@@ -38,7 +35,10 @@ use Kunena\Forum\Libraries\Route\KunenaRoute;
     </div>
 </div>
 <div class="btn-toolbar p-3">
-    <joomla-toolbar-button task="logs.clean" class="ms-auto">
-        <button type="button" class="btn btn-success"><?php echo Text::_('JSUBMIT'); ?></button>
-    </joomla-toolbar-button>
+    <button type="button" class="btn btn-danger ms-auto" data-bs-dismiss="modal">
+        <?php echo Text::_('JCANCEL'); ?>
+    </button>
+    <button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='logs.clean'>
+        <?php echo Text::_('JSUBMIT'); ?>
+    </button>
 </div>

--- a/src/admin/tmpl/users/default.php
+++ b/src/admin/tmpl/users/default.php
@@ -150,8 +150,22 @@ $language->load('com_users');
                 ?>
                 <?php echo $this->pagination->getListFooter(); ?>
 
-                <template id="joomla-dialog-subscribecatsusers"><?php echo $this->loadTemplate('subscribecatsusers'); ?></template>
-                <template id="joomla-dialog-moderators"><?php echo $this->loadTemplate('moderators'); ?></template>
+                <?php echo HTMLHelper::_(
+                    'bootstrap.renderModal',
+                    'joomla-dialog-subscribecatsusers',
+                    [
+                        'title'  => Text::_('COM_KUNENA_BATCH_SUBSCIRBE_USERS_CATEGORIES_MODAL_TITLE'),
+                    ],
+                    $this->loadTemplate('subscribecatsusers')
+                ); ?>
+                <?php echo HTMLHelper::_(
+                    'bootstrap.renderModal',
+                    'joomla-dialog-moderators',
+                    [
+                        'title'  => Text::_('COM_KUNENA_BATCH_USERS_OPTIONS'),
+                    ],
+                    $this->loadTemplate('moderators')
+                ); ?>
 
                 <input type="hidden" name="task" value="">
                 <input type="hidden" name="boxchecked" value="0">

--- a/src/admin/tmpl/users/default_moderators.php
+++ b/src/admin/tmpl/users/default_moderators.php
@@ -27,7 +27,10 @@ use Joomla\CMS\Language\Text;
     </div>
 </div>
 <div class="btn-toolbar p-3">
-    <joomla-toolbar-button task="users.batchmoderators" class="ms-auto">
-        <button type="button" class="btn btn-success"><?php echo Text::_('JSUBMIT'); ?></button>
-    </joomla-toolbar-button>
+    <button type="button" class="btn btn-danger ms-auto" data-bs-dismiss="modal">
+        <?php echo Text::_('JCANCEL'); ?>
+    </button>
+    <button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='users.batchmoderators'>
+        <?php echo Text::_('JSUBMIT'); ?>
+    </button>
 </div>

--- a/src/admin/tmpl/users/default_subscribecatsusers.php
+++ b/src/admin/tmpl/users/default_subscribecatsusers.php
@@ -27,7 +27,10 @@ use Joomla\CMS\Language\Text;
     </div>
 </div>
 <div class="btn-toolbar p-3">
-    <joomla-toolbar-button task="users.subscribeuserstocategories" class="ms-auto">
-        <button type="button" class="btn btn-success"><?php echo Text::_('JSUBMIT'); ?></button>
-    </joomla-toolbar-button>
+    <button type="button" class="btn btn-danger ms-auto" data-bs-dismiss="modal">
+        <?php echo Text::_('JCANCEL'); ?>
+    </button>
+    <button type="submit" id='batch-submit-button-id' class="btn btn-success" data-submit-task='users.subscribeuserstocategories'>
+        <?php echo Text::_('JSUBMIT'); ?>
+    </button>
 </div>


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
Changed J5 popup modals into J4 popup modals

#### Testing Instructions
Test if popups work in J4 and J5 (both popup and do what they are supposed to do)

- Category view > batch
- Users view > Assign moderators
- Users view > Add subscriptions to categories
- Configuration view > Restore Default
- Logs view > Clean entries