### PR TITLE
Proposal: replace Joomla user filters with custom user filter in logs view

### DIFF
--- a/src/admin/forms/filter_logs.xml
+++ b/src/admin/forms/filter_logs.xml
@@ -42,11 +42,19 @@
 			class="js-select-submit-on-change" />
 		<field
 			name="user"
-			type="user"
-			label="COM_KUNENA_LOG_USER_SORT_LABEL"
-			hint="COM_KUNENA_FILTER_SELECT_USER"
-			class="js-select-submit-on-change"
-			default="" />
+			type="sql"
+			sql_select="a.user_id, u.id, u.name"
+			sql_from="#__kunena_logs AS a"
+			sql_join="#__users AS u ON a.user_id = u.id"
+			sql_where="u.name != ''"
+			sql_group="a.user_id"
+			sql_order="u.name ASC"
+			key_field="id"
+			value_field="name"
+			default=""
+			class="js-select-submit-on-change">
+			<option value="">COM_KUNENA_FILTER_SELECT_USER</option>
+		</field>
 		<field
 			name="category"
 			type="sql"
@@ -79,11 +87,17 @@
 		</field>
 		<field
 			name="target_user"
-			type="user"
-			label="COM_KUNENA_LOG_TARGET_USER_SORT_LABEL"
-			class="js-select-submit-on-change"
+			type="sql"
+			sql_select="a.target_user, u.id, u.name"
+			sql_from="#__kunena_logs AS a"
+			sql_join="#__users AS u ON a.target_user = u.id"
+			sql_where="u.name != ''"
+			sql_group="a.target_user"
+			sql_order="u.name ASC"
+			key_field="id"
+			value_field="name"
 			default=""
-			validate="options">
+			class="js-select-submit-on-change">
 			<option value="">COM_KUNENA_FILTER_SELECT_TARGETUSER</option>
 		</field>
 	</fields>


### PR DESCRIPTION

Pull Request for Issue https://www.kunena.org/forum/k-6-3-0-support/168364-help-needed-logs-backend-view?start=0#230977 . 
 
#### Summary of Changes 
This PR replaces the two user filters (users / target users) in the logs view.
Currently the filters are based on the Joomla core users field, this PR changes these fields to a customized dropdown filter where only users are listed that have an entry in the logs table.
 
#### Testing Instructions

This is a proposal, I like the Joomla core users field, but the added value here is very limited and it doesn't allow us to overwrite the label (select user > select target user)

Let me know what you think so @xillibit can either decline or merge (after testing)

cc @rich20 