### PR TITLE
Log date format

### DIFF
--- a/src/admin/tmpl/logs/default.php
+++ b/src/admin/tmpl/logs/default.php
@@ -147,7 +147,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                     <?php echo !$this->group ? $this->escape($item->id) : (int) $item->count; ?>
                                 </th>
                                 <td>
-                                    <?php echo $date->toSql(); ?>
+                                    <?php echo HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC6')); ?>
                                 </td>
                                 <td>
                                     <?php echo !$this->group || isset($this->group['type']) ? $this->escape($this->getType((int) $item->type)) : ''; ?>


### PR DESCRIPTION
Pull Request for Issue #9654 . 
 
#### Summary of Changes 
changed displaying of date to take into consideration the configured server setting for the timezone

#### Testing Instructions
in back-end view logs, check if the log entry date is using the timezone setting from the Joomla global config (date / time should be the same as date / time in front-end