### PR TITLE
Fix: dashboard trash button didn't work anymore

### DIFF
--- a/src/admin/tmpl/cpanel/default.php
+++ b/src/admin/tmpl/cpanel/default.php
@@ -431,7 +431,7 @@ $count = KunenaStatistics::getInstance()->loadCategoryCount();
                             <div class="row align-items-center">
                                 <div class="col">
                                     <h6 class="mb-25">
-                                        <a href="<?php echo Route::_('index.php?option=com_kunena&view=trash'); ?>" class="stretched-link">
+                                        <a href="<?php echo Route::_('index.php?option=com_kunena&view=trashs'); ?>" class="stretched-link">
                                             <?php echo Text::_('COM_KUNENA_CPANEL_LABEL_TRASH') ?>
                                         </a>
                                     </h6>


### PR DESCRIPTION
Pull Request for Issue #9655 . 
 
#### Summary of Changes
dashboard ison for trash was still pointing to old (removed) trash view
 
#### Testing Instructions
implement PR and click on the dasboard trash button, the trashs view should show without errors