### PR TITLE
Change: let category filters act on stored category data

### DIFF
--- a/src/admin/src/Model/CategoriesModel.php
+++ b/src/admin/src/Model/CategoriesModel.php
@@ -441,7 +441,7 @@ class CategoriesModel extends KunenaModel
                 'filterAllowPolls' => $this->getState('filter.allowPolls', '') === '' ? null : $this->getState('filter.allowPolls', ''),
                 'filterReview'     => $this->getState('filter.review', '') === '' ? null : $this->getState('filter.review', ''),
                 'filterAnonymous'  => $this->getState('filter.anonymous', '') === '' ? null : $this->getState('filter.anonymous', ''),
-                'action'           => 'none',
+                'action'           => 'admin',
             ];
 
             $catid      = $this->getState('filter.category', '') === '' ? $this->getState('item.id', 0) : $this->getState('filter.category', '');


### PR DESCRIPTION
Pull Request for Issue https://github.com/Kunena/Kunena-Forum/issues/9649.

### Summary of Changes

This is a small change but it impacts all filtered results in the back-end categories filters.
e.g. when selecting unpublished it will display all unpublished categories regardless of the published status of the parent of the categories (section).
Same for review, polls, locked, anonymous
### Testing Instructions

implement PR and test all back-end category view filters and combinations of these filters