### PR TITLE
Refactor: remove links to posts / users in stats view

### DIFF
--- a/src/admin/tmpl/stats/default.php
+++ b/src/admin/tmpl/stats/default.php
@@ -118,7 +118,7 @@ use Kunena\Forum\Libraries\Version\KunenaVersion;
                                 <?php echo $id + 1; ?>
                             </div>
                             <div class="w-50">
-                                <?php echo $item->link; ?>:
+                                <?php echo property_exists($item, 'subject') ? $item->subject : (property_exists($item, 'username') ? $item->username : $item->link); ?>:
                             </div>
                             <div class="w-40">
                                 <div class="progress">

--- a/src/libraries/kunena/src/Forum/KunenaStatistics.php
+++ b/src/libraries/kunena/src/Forum/KunenaStatistics.php
@@ -367,21 +367,21 @@ class KunenaStatistics
             $query = $this->_db->getQuery(true);
             $query->select(
                 'SUM(' . $this->_db->quoteName('time') . ' >= ' .
-                $this->_db->quote($todaystart) . ' AND ' . $this->_db->quoteName('parent') . ' = 0) AS ' .
-                $this->_db->quote('todayTopicCount') . ',
+                    $this->_db->quote($todaystart) . ' AND ' . $this->_db->quoteName('parent') . ' = 0) AS ' .
+                    $this->_db->quote('todayTopicCount') . ',
 				SUM(' . $this->_db->quoteName('time') . ' >= ' . $this->_db->quote($todaystart) . ' AND ' .
-                $this->_db->quoteName('parent') . ' > 0) AS ' . $this->_db->quote('todayReplyCount') . ',
+                    $this->_db->quoteName('parent') . ' > 0) AS ' . $this->_db->quote('todayReplyCount') . ',
 				SUM(' . $this->_db->quoteName('time') . ' >= ' . $this->_db->quote($yesterdaystart) . ' AND ' .
-                $this->_db->quoteName('time') . ' < ' . $this->_db->quote($todaystart) . '  AND ' .
-                $this->_db->quoteName('parent') . ' = 0 ) AS ' . $this->_db->quote('yesterdayTopicCount') . ',
+                    $this->_db->quoteName('time') . ' < ' . $this->_db->quote($todaystart) . '  AND ' .
+                    $this->_db->quoteName('parent') . ' = 0 ) AS ' . $this->_db->quote('yesterdayTopicCount') . ',
 				SUM(' . $this->_db->quoteName('time') . ' >= ' . $this->_db->quote($yesterdaystart) . '  AND ' .
-                $this->_db->quoteName('time') . '< ' . $this->_db->quote($todaystart) . '  AND ' .
-                $this->_db->quoteName('parent') . ' > 0) AS ' . $this->_db->quote('yesterdayReplyCount')
+                    $this->_db->quoteName('time') . '< ' . $this->_db->quote($todaystart) . '  AND ' .
+                    $this->_db->quoteName('parent') . ' > 0) AS ' . $this->_db->quote('yesterdayReplyCount')
             )
                 ->from($this->_db->quoteName('#__kunena_messages'))
                 ->where(
                     $this->_db->quoteName('time') . ' >= ' . $this->_db->quote($yesterdaystart) . ' AND ' .
-                    $this->_db->quoteName('hold') . ' = 0'
+                        $this->_db->quoteName('hold') . ' = 0'
                 );
             $this->_db->setQuery($query);
 
@@ -432,7 +432,7 @@ class KunenaStatistics
     }
 
     /**
-* @param   int  $limit  limit
+     * @param   int  $limit  limit
      *
      * @return array
      *
@@ -488,12 +488,12 @@ class KunenaStatistics
             $query
                 ->select(
                     $this->_db->quoteName('poll.threadid', 'id') . ', SUM(' .
-                    $this->_db->quoteName('opt.votes') . ') AS ' . $this->_db->quoteName('count')
+                        $this->_db->quoteName('opt.votes') . ') AS ' . $this->_db->quoteName('count')
                 )
                 ->from($db->quoteName('#__kunena_polls_options', 'opt'))
                 ->innerJoin(
                     $db->quoteName('#__kunena_polls', 'poll') . ' ON ' .
-                    $this->_db->quoteName('poll.id') . ' = ' . $this->_db->quoteName('opt.pollid')
+                        $this->_db->quoteName('poll.id') . ' = ' . $this->_db->quoteName('opt.pollid')
                 )
                 ->group($this->_db->quoteName('pollid'))
                 ->having($this->_db->quoteName('count') . ' > 0')
@@ -593,9 +593,10 @@ class KunenaStatistics
             $top->titleCount = Text::_('COM_KUNENA_USRL_POSTS');
 
             foreach ($this->topPosters as &$item) {
-                $item          = clone $item;
-                $item->link    = KunenaUserHelper::get($item->id)->getLink(null, null, '');
-                $item->percent = round(100 * $item->count / $top->count);
+                $item           = clone $item;
+                $item->username = KunenaUserHelper::get($item->id)->getName();
+                $item->link     = KunenaUserHelper::get($item->id)->getLink(null, null, '');
+                $item->percent  = round(100 * $item->count / $top->count);
             }
         }
 
@@ -629,9 +630,10 @@ class KunenaStatistics
             $top->titleCount = Text::_('COM_KUNENA_USRL_HITS');
 
             foreach ($this->topProfiles as &$item) {
-                $item          = clone $item;
-                $item->link    = KunenaUserHelper::get($item->id)->getLink(null, null, '');
-                $item->percent = round(100 * $item->count / $top->count);
+                $item           = clone $item;
+                $item->username = KunenaUserHelper::get($item->id)->getName();
+                $item->link     = KunenaUserHelper::get($item->id)->getLink(null, null, '');
+                $item->percent  = round(100 * $item->count / $top->count);
             }
         }
 
@@ -664,7 +666,7 @@ class KunenaStatistics
                 ->from($this->_db->quoteName('#__kunena_thankyou', 't'))
                 ->innerJoin(
                     $this->_db->quoteName('#__users', 'u') . ' ON ' .
-                    $this->_db->quoteName('u.id') . ' = ' . $this->_db->quoteName('t.targetuserid')
+                        $this->_db->quoteName('u.id') . ' = ' . $this->_db->quoteName('t.targetuserid')
                 )
                 ->group($this->_db->quoteName('t.targetuserid'));
             $query->order($this->_db->quoteName('count') . ' DESC');
@@ -694,9 +696,10 @@ class KunenaStatistics
             $top->titleCount = Text::_('COM_KUNENA_STAT_THANKS_YOU_RECEIVED');
 
             foreach ($this->topThanks as &$item) {
-                $item          = clone $item;
-                $item->link    = KunenaUserHelper::get($item->id)->getLink(null, null, '');
-                $item->percent = round(100 * $item->count / $top->count);
+                $item           = clone $item;
+                $item->username = KunenaUserHelper::get($item->id)->getName();
+                $item->link     = KunenaUserHelper::get($item->id)->getLink(null, null, '');
+                $item->percent  = round(100 * $item->count / $top->count);
             }
         }
 


### PR DESCRIPTION
Pull Request for Issue #9665 . 
 
#### Summary of Changes 
replaced the linked topics and users (which resulted in 404) with non linked text (subject / username)

#### Testing Instructions
in back-end view Forum Statistics check if view is still working and that links on top topics / users / thnaks you etc. are removed