### PR TITLE
Replace Copyrightyear with replacement token

### DIFF
--- a/COPYRIGHT.php
+++ b/COPYRIGHT.php
@@ -4,7 +4,7 @@
  * Kunena Component
  * @package Kunena.Site
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/build.php
+++ b/build.php
@@ -4,7 +4,7 @@
  * Kunena Component
  * @package Kunena.Build
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/build.properties
+++ b/build.properties
@@ -1,7 +1,7 @@
 ###################################################################
 # Kunena Package Build Configuration
 #
-# @copyright	Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+# @copyright	Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 #				portions 2007 MjazTools. All rights reserved.
 # @license      GNU General Public License <https://www.gnu.org/copyleft/gpl.html>
 # @link         https://www.kunena.org

--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
 	@package	Kunena
 	@subpackage	com_kunena
 	@copyright	Copyright (C)
-2008 - 2024 Kunena Team. All rights reserved.
+2008 - @currentyear@ Kunena Team. All rights reserved.
 				portions (C) 2007 MjazTools. All rights reserved.
 @license	GNU General Public License <https://www.gnu.org/copyleft/gpl.html>
 	@link
@@ -89,6 +89,10 @@ workspace/kunena/build/tmp)
 			property="str.datefmt"
 			pattern="${cfg.datefmt}"
 			locale="${cfg.dateloc}" />
+		<format
+			property="str.currentyear"
+			pattern="yyyy"
+			locale="${cfg.dateloc}" />
 	</tstamp>
 	<condition
 		property="version.date"
@@ -132,6 +136,9 @@ workspace/kunena/build/tmp)
 			<token
 				key="kunenaversiondate"
 				value="${version.date}" />
+			<token
+				key="currentyear"
+				value="${str.currentyear}" />
 			<token
 				key="kunenaversionname"
 				value="${xml.versionname}" />

--- a/build.xml
+++ b/build.xml
@@ -388,81 +388,97 @@ workspace/kunena/build/tmp)
 		<copy
 			todir="${tmp_dir}/packages/plg_finder_kunena"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_finder_kunena" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_altauserpoints"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_altauserpoints" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_uddeim"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_uddeim" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_community"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_community" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_comprofiler"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_comprofiler" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_easyblog"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_easyblog" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_easyprofile"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_easyprofile" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_easysocial"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_easysocial" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_finder"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_finder" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_gravatar"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_gravatar" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_kunena"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_kunena" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_kunena_joomla"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_kunena_joomla" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_privacy_kunena"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_privacy_kunena" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_system_kunena"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_system_kunena" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_quickicon_kunena"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_quickicon_kunena" />
 		</copy>
 		<copy
 			todir="${tmp_dir}/packages/plg_sampledata_kunena"
 			overwrite="true">
+			<filterchain refid="filter" />
 			<fileset dir="${kunena.plugins}/plg_sampledata_kunena" />
 		</copy>
 		<copy

--- a/externaldefinitions.php
+++ b/externaldefinitions.php
@@ -3,7 +3,7 @@
  * Kunena Component
  * @package Kunena.Build
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/admin/api/api.php
+++ b/src/admin/api/api.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/admin/install/sql/updates/php/5.2.0-2020-08-20_updaterankstitle.php
+++ b/src/admin/install/sql/updates/php/5.2.0-2020-08-20_updaterankstitle.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Installer
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/admin/install/sql/updates/php/5.2.15-2021-07-24_update_configuration.php
+++ b/src/admin/install/sql/updates/php/5.2.15-2021-07-24_update_configuration.php
@@ -4,7 +4,7 @@
  *
  * @package        Kunena.Installer
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/admin/install/sql/updates/php/5.2.15-2021-08-24_configuration_default_template.php
+++ b/src/admin/install/sql/updates/php/5.2.15-2021-08-24_configuration_default_template.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Installer
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/admin/install/sql/updates/php/6.0.2-2022-07-30_rss_timelimit_configuration_change.php
+++ b/src/admin/install/sql/updates/php/6.0.2-2022-07-30_rss_timelimit_configuration_change.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Installer
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/admin/install/sql/updates/php/6.2.4-2022-01-24_change_collation_columns_on_tables.php
+++ b/src/admin/install/sql/updates/php/6.2.4-2022-01-24_change_collation_columns_on_tables.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Installer
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/admin/kunena.xml
+++ b/src/admin/kunena.xml
@@ -11,7 +11,7 @@
     <author>Kunena Team</author>
     <authorEmail>kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPLv3 or later</license>
     <description>COM_KUNENA_XML_DESCRIPTION</description>
     <namespace path="src">Kunena\Forum</namespace>

--- a/src/admin/language/all/install.script.php
+++ b/src/admin/language/all/install.script.php
@@ -5,7 +5,7 @@
  *
  * @package       Kunena.Installer
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/language/all/manifests/com_kunena_af-ZA.xml
+++ b/src/admin/language/all/manifests/com_kunena_af-ZA.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/af_ZA/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Afrikaans (South Africa) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ar-AA.xml
+++ b/src/admin/language/all/manifests/com_kunena_ar-AA.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ar/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Arabic language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_az-AZ.xml
+++ b/src/admin/language/all/manifests/com_kunena_az-AZ.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/az_AZ/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Azerbaijani (Azerbaijan) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_be-BY.xml
+++ b/src/admin/language/all/manifests/com_kunena_be-BY.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/be-BY/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Belarusian language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_bg-BG.xml
+++ b/src/admin/language/all/manifests/com_kunena_bg-BG.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/bg_BG/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Bulgarian (Bulgaria) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_bs-BA.xml
+++ b/src/admin/language/all/manifests/com_kunena_bs-BA.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/bs_BA/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Bosnian (Bosnia and Herzegovina) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ca-ES.xml
+++ b/src/admin/language/all/manifests/com_kunena_ca-ES.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ca_ES/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Catalan (Spain) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ckb-IQ.xml
+++ b/src/admin/language/all/manifests/com_kunena_ckb-IQ.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ku_IQ/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Kurdish language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_cs-CZ.xml
+++ b/src/admin/language/all/manifests/com_kunena_cs-CZ.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/cs_CZ/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Czech (Czech Republic) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_cy-GB.xml
+++ b/src/admin/language/all/manifests/com_kunena_cy-GB.xml
@@ -7,7 +7,7 @@
     <author>Kunena Team</author>
     <authorEmail>kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Welsh (United Kingdom) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_da-DK.xml
+++ b/src/admin/language/all/manifests/com_kunena_da-DK.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/da_DK/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Danish (Denmark) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_de-DE.xml
+++ b/src/admin/language/all/manifests/com_kunena_de-DE.xml
@@ -7,7 +7,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/de_DE/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>German (Germany) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_el-GR.xml
+++ b/src/admin/language/all/manifests/com_kunena_el-GR.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/el_GR/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Greek (Greece) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_en-GB.xml
+++ b/src/admin/language/all/manifests/com_kunena_en-GB.xml
@@ -7,7 +7,7 @@
     <author>Kunena Team</author>
     <authorEmail>kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>English language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_eo-XX.xml
+++ b/src/admin/language/all/manifests/com_kunena_eo-XX.xml
@@ -7,7 +7,7 @@
     <author>Kunena Team</author>
     <authorEmail>kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Esperanto language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_es-ES.xml
+++ b/src/admin/language/all/manifests/com_kunena_es-ES.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/es_ES/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Spanish (Spain) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_et-EE.xml
+++ b/src/admin/language/all/manifests/com_kunena_et-EE.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/et_EE/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Estonian (Estonia) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_eu-ES.xml
+++ b/src/admin/language/all/manifests/com_kunena_eu-ES.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/eu_ES/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Basque (Spain) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_fa-IR.xml
+++ b/src/admin/language/all/manifests/com_kunena_fa-IR.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/fa_IR/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Persian (Iran) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_fi-FI.xml
+++ b/src/admin/language/all/manifests/com_kunena_fi-FI.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/fi_FI/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Finnish (Finland) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_fr-FR.xml
+++ b/src/admin/language/all/manifests/com_kunena_fr-FR.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/fr/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>French language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ga-IE.xml
+++ b/src/admin/language/all/manifests/com_kunena_ga-IE.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ga-IE/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Irish language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_he-IL.xml
+++ b/src/admin/language/all/manifests/com_kunena_he-IL.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/he_IL/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Hebrew (Israel) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_hi-IN.xml
+++ b/src/admin/language/all/manifests/com_kunena_hi-IN.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/hi_IN/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Hindi (India) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_hr-HR.xml
+++ b/src/admin/language/all/manifests/com_kunena_hr-HR.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/hr_HR/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Croatian (Croatia) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_hu-HU.xml
+++ b/src/admin/language/all/manifests/com_kunena_hu-HU.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/hu_HU/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Hungarian (Hungary) language file for Kunena Forum Component.</description>
 

--- a/src/admin/language/all/manifests/com_kunena_id-ID.xml
+++ b/src/admin/language/all/manifests/com_kunena_id-ID.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/teams/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Indonesia language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_it-IT.xml
+++ b/src/admin/language/all/manifests/com_kunena_it-IT.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/it_IT/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Italian (Italy) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ja-JP.xml
+++ b/src/admin/language/all/manifests/com_kunena_ja-JP.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ja_JP/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Japanese (Japan) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ka-GE.xml
+++ b/src/admin/language/all/manifests/com_kunena_ka-GE.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/af_ZA/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Georgian language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_kk-KZ.xml
+++ b/src/admin/language/all/manifests/com_kunena_kk-KZ.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/kk-KZ/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Kazakh (Kazakhstan) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_km-KH.xml
+++ b/src/admin/language/all/manifests/com_kunena_km-KH.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/km_KH/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Khmer (Cambodia) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ko-KR.xml
+++ b/src/admin/language/all/manifests/com_kunena_ko-KR.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ko-KR/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Korean language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_kz-KZ.xml
+++ b/src/admin/language/all/manifests/com_kunena_kz-KZ.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/kk/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Kazakh language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_lt-LT.xml
+++ b/src/admin/language/all/manifests/com_kunena_lt-LT.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/lt_LT/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Lithuanian (Lithuania) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_lv-LV.xml
+++ b/src/admin/language/all/manifests/com_kunena_lv-LV.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/lv_LV/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Latvian (Latvia) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_mk-MK.xml
+++ b/src/admin/language/all/manifests/com_kunena_mk-MK.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/mk_MK/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Macedonian (Macedonia) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_nb-NO.xml
+++ b/src/admin/language/all/manifests/com_kunena_nb-NO.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/nb_NO/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Norwegian Bokmål (Norway) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_nl-NL.xml
+++ b/src/admin/language/all/manifests/com_kunena_nl-NL.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/nl_NL/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Dutch (Netherlands) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_pl-PL.xml
+++ b/src/admin/language/all/manifests/com_kunena_pl-PL.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/pl/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Polish language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ps-AF.xml
+++ b/src/admin/language/all/manifests/com_kunena_ps-AF.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ps-AF/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Pashto (Afghanistan) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_pt-BR.xml
+++ b/src/admin/language/all/manifests/com_kunena_pt-BR.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/pt_BR/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Portuguese (Brazil) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_pt-PT.xml
+++ b/src/admin/language/all/manifests/com_kunena_pt-PT.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/pt_PT/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Portuguese (Portugal) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ro-RO.xml
+++ b/src/admin/language/all/manifests/com_kunena_ro-RO.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ro/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Romanian language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ru-RU.xml
+++ b/src/admin/language/all/manifests/com_kunena_ru-RU.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ru_RU/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Russian (Russia) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_sk-SK.xml
+++ b/src/admin/language/all/manifests/com_kunena_sk-SK.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/sk_SK/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Slovak (Slovakia) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_sl-SI.xml
+++ b/src/admin/language/all/manifests/com_kunena_sl-SI.xml
@@ -7,7 +7,7 @@
     <author>Kunena Team</author>
     <authorEmail>kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Slovenian (Slovenia) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_sq-AL.xml
+++ b/src/admin/language/all/manifests/com_kunena_sq-AL.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/sq_AL/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Albanian (Albania) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_sr-RS.xml
+++ b/src/admin/language/all/manifests/com_kunena_sr-RS.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/sr_RS/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Serbian (Serbia) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_sr-YU.xml
+++ b/src/admin/language/all/manifests/com_kunena_sr-YU.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/sr@latin/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Serbian (Latin) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_sv-SE.xml
+++ b/src/admin/language/all/manifests/com_kunena_sv-SE.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/sv_SE/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Swedish (Sweden) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ta-IN.xml
+++ b/src/admin/language/all/manifests/com_kunena_ta-IN.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ta-IN/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Tamil (India) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_th-TH.xml
+++ b/src/admin/language/all/manifests/com_kunena_th-TH.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/th_TH/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Thai (Thailand) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_tr-TR.xml
+++ b/src/admin/language/all/manifests/com_kunena_tr-TR.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/tr_TR/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Turkish (Turkey) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ug-CN.xml
+++ b/src/admin/language/all/manifests/com_kunena_ug-CN.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ug/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Uyghur language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_uk-UA.xml
+++ b/src/admin/language/all/manifests/com_kunena_uk-UA.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/tr_TR/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Ukrainian language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_ur-PK.xml
+++ b/src/admin/language/all/manifests/com_kunena_ur-PK.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/ur_PK/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Urdu (Pakistan) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_vi-VN.xml
+++ b/src/admin/language/all/manifests/com_kunena_vi-VN.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/teams/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Vietnamese language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_zh-CN.xml
+++ b/src/admin/language/all/manifests/com_kunena_zh-CN.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/zh_CN/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Chinese (China) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/manifests/com_kunena_zh-TW.xml
+++ b/src/admin/language/all/manifests/com_kunena_zh-TW.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>translations@kunena.org</authorEmail>
     <authorUrl>https://www.transifex.com/projects/p/Kunena/team/zh_TW/</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Chinese (Taiwan) language file for Kunena Forum Component</description>
 

--- a/src/admin/language/all/pkg_kunena_languages.xml
+++ b/src/admin/language/all/pkg_kunena_languages.xml
@@ -9,7 +9,7 @@
     <author>Kunena Team</author>
     <authorEmail>kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPL</license>
     <description>Language pack for Kunena forum component.</description>
 

--- a/src/admin/media/css/admin.css
+++ b/src/admin/media/css/admin.css
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Administrator.Joomla25
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/admin/media/css/admin.rtl.css
+++ b/src/admin/media/css/admin.rtl.css
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Administrator.Joomla25
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/admin/media/css/cpanel.css
+++ b/src/admin/media/css/cpanel.css
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Administrator.Joomla25
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/admin/media/css/layout.css
+++ b/src/admin/media/css/layout.css
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Administrator
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/admin/media/css/styles.css
+++ b/src/admin/media/css/styles.css
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Administrator
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/admin/services/provider.php
+++ b/src/admin/services/provider.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Services
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/AttachmentsController.php
+++ b/src/admin/src/Controller/AttachmentsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/BadwordsController.php
+++ b/src/admin/src/Controller/BadwordsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/BlockipsController.php
+++ b/src/admin/src/Controller/BlockipsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/CategoriesController.php
+++ b/src/admin/src/Controller/CategoriesController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/CategoryController.php
+++ b/src/admin/src/Controller/CategoryController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/CloseController.php
+++ b/src/admin/src/Controller/CloseController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/ConfigController.php
+++ b/src/admin/src/Controller/ConfigController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/CpanelController.php
+++ b/src/admin/src/Controller/CpanelController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/DisplayController.php
+++ b/src/admin/src/Controller/DisplayController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/EmailController.php
+++ b/src/admin/src/Controller/EmailController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/IconsController.php
+++ b/src/admin/src/Controller/IconsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/InstallController.php
+++ b/src/admin/src/Controller/InstallController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/LabelsController.php
+++ b/src/admin/src/Controller/LabelsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/LogsController.php
+++ b/src/admin/src/Controller/LogsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/PluginsController.php
+++ b/src/admin/src/Controller/PluginsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/RankController.php
+++ b/src/admin/src/Controller/RankController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/RanksController.php
+++ b/src/admin/src/Controller/RanksController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/SmileyController.php
+++ b/src/admin/src/Controller/SmileyController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/SmiliesController.php
+++ b/src/admin/src/Controller/SmiliesController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/StatisticsController.php
+++ b/src/admin/src/Controller/StatisticsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/StatsController.php
+++ b/src/admin/src/Controller/StatsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/TemplateController.php
+++ b/src/admin/src/Controller/TemplateController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/TemplatesController.php
+++ b/src/admin/src/Controller/TemplatesController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/ToolsController.php
+++ b/src/admin/src/Controller/ToolsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/TrashsController.php
+++ b/src/admin/src/Controller/TrashsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/UserController.php
+++ b/src/admin/src/Controller/UserController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Controller/UsersController.php
+++ b/src/admin/src/Controller/UsersController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Dispatcher/Dispatcher.php
+++ b/src/admin/src/Dispatcher/Dispatcher.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Dispatcher
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Extension/ForumComponent.php
+++ b/src/admin/src/Extension/ForumComponent.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Extension
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Field/KunenacategorylistField.php
+++ b/src/admin/src/Field/KunenacategorylistField.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Field
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Field/KunenaoperationlistField.php
+++ b/src/admin/src/Field/KunenaoperationlistField.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Field
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/AttachmentsModel.php
+++ b/src/admin/src/Model/AttachmentsModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/BadwordsModel.php
+++ b/src/admin/src/Model/BadwordsModel.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Models
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/Model/BlockipsModel.php
+++ b/src/admin/src/Model/BlockipsModel.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Models
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/Model/CategoriesModel.php
+++ b/src/admin/src/Model/CategoriesModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/CategoryModel.php
+++ b/src/admin/src/Model/CategoryModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/CloseModel.php
+++ b/src/admin/src/Model/CloseModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/ConfigModel.php
+++ b/src/admin/src/Model/ConfigModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/CpanelModel.php
+++ b/src/admin/src/Model/CpanelModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/EmailModel.php
+++ b/src/admin/src/Model/EmailModel.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Models
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/Model/IconsModel.php
+++ b/src/admin/src/Model/IconsModel.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Models
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/Model/LabelsModel.php
+++ b/src/admin/src/Model/LabelsModel.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Models
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/Model/LogsModel.php
+++ b/src/admin/src/Model/LogsModel.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Models
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/Model/RankModel.php
+++ b/src/admin/src/Model/RankModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/RanksModel.php
+++ b/src/admin/src/Model/RanksModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/SmileyModel.php
+++ b/src/admin/src/Model/SmileyModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/SmiliesModel.php
+++ b/src/admin/src/Model/SmiliesModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/StatisticsModel.php
+++ b/src/admin/src/Model/StatisticsModel.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Models
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/Model/StatsModel.php
+++ b/src/admin/src/Model/StatsModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/TemplateModel.php
+++ b/src/admin/src/Model/TemplateModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/TemplatesModel.php
+++ b/src/admin/src/Model/TemplatesModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/ToolsModel.php
+++ b/src/admin/src/Model/ToolsModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/TrashsModel.php
+++ b/src/admin/src/Model/TrashsModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/UserModel.php
+++ b/src/admin/src/Model/UserModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/Model/UsersModel.php
+++ b/src/admin/src/Model/UsersModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Attachments/HtmlView.php
+++ b/src/admin/src/View/Attachments/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Badwords/HtmlView.php
+++ b/src/admin/src/View/Badwords/HtmlView.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Views
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/View/Blockips/HtmlView.php
+++ b/src/admin/src/View/Blockips/HtmlView.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Views
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/View/Categories/HtmlView.php
+++ b/src/admin/src/View/Categories/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Categories/HtmlViewRaw.php
+++ b/src/admin/src/View/Categories/HtmlViewRaw.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Category/HtmlView.php
+++ b/src/admin/src/View/Category/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Config/HtmlView.php
+++ b/src/admin/src/View/Config/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Cpanel/HtmlView.php
+++ b/src/admin/src/View/Cpanel/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Email/HtmlView.php
+++ b/src/admin/src/View/Email/HtmlView.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Views
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/View/Icons/HtmlView.php
+++ b/src/admin/src/View/Icons/HtmlView.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Views
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/View/Install/HtmlView.php
+++ b/src/admin/src/View/Install/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Labels/HtmlView.php
+++ b/src/admin/src/View/Labels/HtmlView.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Views
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/View/Logs/HtmlView.php
+++ b/src/admin/src/View/Logs/HtmlView.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Views
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/src/View/Rank/HtmlView.php
+++ b/src/admin/src/View/Rank/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Ranks/HtmlView.php
+++ b/src/admin/src/View/Ranks/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Smiley/HtmlView.php
+++ b/src/admin/src/View/Smiley/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Smilies/HtmlView.php
+++ b/src/admin/src/View/Smilies/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Statistics/HtmlView.php
+++ b/src/admin/src/View/Statistics/HtmlView.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator
  * @subpackage    Views
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  * 

--- a/src/admin/src/View/Stats/HtmlView.php
+++ b/src/admin/src/View/Stats/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Template/HtmlView.php
+++ b/src/admin/src/View/Template/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Templates/HtmlView.php
+++ b/src/admin/src/View/Templates/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Tools/HtmlView.php
+++ b/src/admin/src/View/Tools/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Trashs/HtmlView.php
+++ b/src/admin/src/View/Trashs/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/User/HtmlView.php
+++ b/src/admin/src/View/User/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/src/View/Users/HtmlView.php
+++ b/src/admin/src/View/Users/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/attachments/default.php
+++ b/src/admin/tmpl/attachments/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Attachments
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/badwords/default.php
+++ b/src/admin/tmpl/badwords/default.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Logs
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  * 

--- a/src/admin/tmpl/blockips/default.php
+++ b/src/admin/tmpl/blockips/default.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Logs
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  * 

--- a/src/admin/tmpl/categories/default.php
+++ b/src/admin/tmpl/categories/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Categories
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https: //www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https: //www.kunena.org
  **/

--- a/src/admin/tmpl/categories/default_batch.php
+++ b/src/admin/tmpl/categories/default_batch.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Categories
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/tmpl/categories/edit.js
+++ b/src/admin/tmpl/categories/edit.js
@@ -2,7 +2,7 @@
  * Kunena       Component
  * @package     Kunena.BackendTemplate
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license     https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link        https://www.kunena.org
  **/

--- a/src/admin/tmpl/category/create.php
+++ b/src/admin/tmpl/category/create.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Categories
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/category/edit.php
+++ b/src/admin/tmpl/category/edit.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Categories
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/config/default.php
+++ b/src/admin/tmpl/config/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Config
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/config/default_setting.php
+++ b/src/admin/tmpl/config/default_setting.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Config
  * @subpackage      Configuration
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/cpanel/default.php
+++ b/src/admin/tmpl/cpanel/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      CPanel
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/email/default.php
+++ b/src/admin/tmpl/email/default.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Logs
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  * 

--- a/src/admin/tmpl/icons/default.php
+++ b/src/admin/tmpl/icons/default.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Logs
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  * 

--- a/src/admin/tmpl/install/default.php
+++ b/src/admin/tmpl/install/default.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Logs
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/tmpl/labels/default.php
+++ b/src/admin/tmpl/labels/default.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Logs
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  * 

--- a/src/admin/tmpl/layouts/attachment/item/default.php
+++ b/src/admin/tmpl/layouts/attachment/item/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Layouts.Attachment
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/layouts/button/ajaxtask/default.php
+++ b/src/admin/tmpl/layouts/button/ajaxtask/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Layouts.Pagination
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/layouts/pagination/footer/default.php
+++ b/src/admin/tmpl/layouts/pagination/footer/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Layouts.Pagination
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/layouts/pagination/limitbox/default.php
+++ b/src/admin/tmpl/layouts/pagination/limitbox/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Layouts.Pagination
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/layouts/pagination/list/default.php
+++ b/src/admin/tmpl/layouts/pagination/list/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Layouts.Pagination
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/logs/default.php
+++ b/src/admin/tmpl/logs/default.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Logs
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/admin/tmpl/logs/default_clean.php
+++ b/src/admin/tmpl/logs/default_clean.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Logs
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/rank/edit.php
+++ b/src/admin/tmpl/rank/edit.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Ranks
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/ranks/default.php
+++ b/src/admin/tmpl/ranks/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Ranks
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/smiley/edit.php
+++ b/src/admin/tmpl/smiley/edit.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Smilies
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/smilies/default.php
+++ b/src/admin/tmpl/smilies/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Smilies
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/statistics/default.php
+++ b/src/admin/tmpl/statistics/default.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Logs
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  * 

--- a/src/admin/tmpl/stats/default.php
+++ b/src/admin/tmpl/stats/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Stats
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/template.php
+++ b/src/admin/tmpl/template.php
@@ -5,7 +5,7 @@
  *
  * @package         Kunena.Template
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/template/addnew.php
+++ b/src/admin/tmpl/template/addnew.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Templates
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/template/choosecss.php
+++ b/src/admin/tmpl/template/choosecss.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Templates
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/template/choosescss.php
+++ b/src/admin/tmpl/template/choosescss.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Templates
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/template/edit.php
+++ b/src/admin/tmpl/template/edit.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Templates
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/template/editcss.php
+++ b/src/admin/tmpl/template/editcss.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Templates
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/template/editscss.php
+++ b/src/admin/tmpl/template/editscss.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Templates
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/templates/default.php
+++ b/src/admin/tmpl/templates/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Templates
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/cleanupip.php
+++ b/src/admin/tmpl/tools/cleanupip.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Prune
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/default.php
+++ b/src/admin/tmpl/tools/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      CPanel
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/diagnostics.php
+++ b/src/admin/tmpl/tools/diagnostics.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      SyncUsers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/menu.php
+++ b/src/admin/tmpl/tools/menu.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      SyncUsers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/menu_trashmenuconfirmation.php
+++ b/src/admin/tmpl/tools/menu_trashmenuconfirmation.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Administrator.Tools
  * @subpackage      Tools
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/prune.php
+++ b/src/admin/tmpl/tools/prune.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Prune
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/purgerestatements.php
+++ b/src/admin/tmpl/tools/purgerestatements.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      PurgeRe
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/recount.php
+++ b/src/admin/tmpl/tools/recount.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      SyncUsers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/report.php
+++ b/src/admin/tmpl/tools/report.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Report
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/subscriptions.php
+++ b/src/admin/tmpl/tools/subscriptions.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      SyncUsers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/syncusers.php
+++ b/src/admin/tmpl/tools/syncusers.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      SyncUsers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/tools/uninstall.php
+++ b/src/admin/tmpl/tools/uninstall.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Prune
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/trashs/messages.php
+++ b/src/admin/tmpl/trashs/messages.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Trash
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/trashs/topics.php
+++ b/src/admin/tmpl/trashs/topics.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Trash
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/user/edit.php
+++ b/src/admin/tmpl/user/edit.php
@@ -6,7 +6,7 @@
  * @package           Kunena.Administrator.Template
  * @subpackage        Users
  *
- * @copyright     (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license           https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link              https://www.kunena.org
  **/

--- a/src/admin/tmpl/user/move.php
+++ b/src/admin/tmpl/user/move.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Users
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/users/default.php
+++ b/src/admin/tmpl/users/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Users
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/users/default_moderators.php
+++ b/src/admin/tmpl/users/default_moderators.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Users
  * @subpackage      Users
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/admin/tmpl/users/default_subscribecatsusers.php
+++ b/src/admin/tmpl/users/default_subscribecatsusers.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Users
  * @subpackage      Users
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/kunena.xml
+++ b/src/libraries/kunena/kunena.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>	
     <authorEmail>kunena@kunena.org</authorEmail>	
     <authorUrl>https://www.kunena.org</authorUrl>	
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPLv3 or later</license>	
     <description>Kunena Framework.</description>	
     <namespace path="src">Kunena\Forum\Libraries</namespace>	

--- a/src/libraries/kunena/src/Access/KunenaAccess.php
+++ b/src/libraries/kunena/src/Access/KunenaAccess.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Integration
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Activity/KunenaActivity.php
+++ b/src/libraries/kunena/src/Activity/KunenaActivity.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    KunenaActivity
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Attachment/KunenaAttachment.php
+++ b/src/libraries/kunena/src/Attachment/KunenaAttachment.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Forum.Message.Attachment
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Attachment/KunenaAttachmentHelper.php
+++ b/src/libraries/kunena/src/Attachment/KunenaAttachmentHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Attachment
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Attachment/KunenaFinder.php
+++ b/src/libraries/kunena/src/Attachment/KunenaFinder.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Attachment
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/BBCode/KunenaBBCode.php
+++ b/src/libraries/kunena/src/BBCode/KunenaBBCode.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/BBCode/KunenaBBCodeEditor.php
+++ b/src/libraries/kunena/src/BBCode/KunenaBBCodeEditor.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    BBCode
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Cache/KunenaCacheHelper.php
+++ b/src/libraries/kunena/src/Cache/KunenaCacheHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Cache
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Collection/KunenaCollection.php
+++ b/src/libraries/kunena/src/Collection/KunenaCollection.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Collection
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Config/KunenaConfig.php
+++ b/src/libraries/kunena/src/Config/KunenaConfig.php
@@ -6,7 +6,7 @@
  * @package        Kunena.Framework
  *
  * @copyright      Copyright (C) 2006 - 2007 Best Of Joomla All rights reserved.
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  *

--- a/src/libraries/kunena/src/Controller/Application/Display.php
+++ b/src/libraries/kunena/src/Controller/Application/Display.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Controller
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Controller/KunenaController.php
+++ b/src/libraries/kunena/src/Controller/KunenaController.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Controller/KunenaControllerApplication.php
+++ b/src/libraries/kunena/src/Controller/KunenaControllerApplication.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Controller
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Controller/KunenaControllerBase.php
+++ b/src/libraries/kunena/src/Controller/KunenaControllerBase.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Controller
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Controller/KunenaControllerDisplay.php
+++ b/src/libraries/kunena/src/Controller/KunenaControllerDisplay.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Controller
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Database/KunenaDatabaseObject.php
+++ b/src/libraries/kunena/src/Database/KunenaDatabaseObject.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Object
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Database/Object/KunenaFinder.php
+++ b/src/libraries/kunena/src/Database/Object/KunenaFinder.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Database
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Date/KunenaDate.php
+++ b/src/libraries/kunena/src/Date/KunenaDate.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Email/KunenaEmail.php
+++ b/src/libraries/kunena/src/Email/KunenaEmail.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Email
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Error/KunenaError.php
+++ b/src/libraries/kunena/src/Error/KunenaError.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Exception/KunenaException.php
+++ b/src/libraries/kunena/src/Exception/KunenaException.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Exception/KunenaExceptionAuthorise.php
+++ b/src/libraries/kunena/src/Exception/KunenaExceptionAuthorise.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Exception
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Exception/KunenaLayout.php
+++ b/src/libraries/kunena/src/Exception/KunenaLayout.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Exception
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Factory/KunenaFactory.php
+++ b/src/libraries/kunena/src/Factory/KunenaFactory.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/File/KunenaFile.php
+++ b/src/libraries/kunena/src/File/KunenaFile.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      File
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Folder/KunenaFolder.php
+++ b/src/libraries/kunena/src/Folder/KunenaFolder.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Folder
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Announcement/KunenaAnnouncement.php
+++ b/src/libraries/kunena/src/Forum/Announcement/KunenaAnnouncement.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Forum.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Announcement/KunenaAnnouncementHelper.php
+++ b/src/libraries/kunena/src/Forum/Announcement/KunenaAnnouncementHelper.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Forum.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Category/KunenaCategory.php
+++ b/src/libraries/kunena/src/Forum/Category/KunenaCategory.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Category
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Category/KunenaCategoryHelper.php
+++ b/src/libraries/kunena/src/Forum/Category/KunenaCategoryHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Category
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Category/User/KunenaCategoryUser.php
+++ b/src/libraries/kunena/src/Forum/Category/User/KunenaCategoryUser.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Category.User
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Category/User/KunenaCategoryUserHelper.php
+++ b/src/libraries/kunena/src/Forum/Category/User/KunenaCategoryUserHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Category.User
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/KunenaDiagnostics.php
+++ b/src/libraries/kunena/src/Forum/KunenaDiagnostics.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/KunenaForum.php
+++ b/src/libraries/kunena/src/Forum/KunenaForum.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/KunenaStatistics.php
+++ b/src/libraries/kunena/src/Forum/KunenaStatistics.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Message/Karma/KunenaKarma.php
+++ b/src/libraries/kunena/src/Forum/Message/Karma/KunenaKarma.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Forum.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Message/Karma/KunenaKarmaHelper.php
+++ b/src/libraries/kunena/src/Forum/Message/Karma/KunenaKarmaHelper.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Forum.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Message/KunenaMessage.php
+++ b/src/libraries/kunena/src/Forum/Message/KunenaMessage.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Message
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Message/KunenaMessageFinder.php
+++ b/src/libraries/kunena/src/Forum/Message/KunenaMessageFinder.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Message
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Message/KunenaMessageHelper.php
+++ b/src/libraries/kunena/src/Forum/Message/KunenaMessageHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Message
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Message/Thankyou/KunenaMessageThankyou.php
+++ b/src/libraries/kunena/src/Forum/Message/Thankyou/KunenaMessageThankyou.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Message.Thankyou
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Message/Thankyou/KunenaMessageThankyouHelper.php
+++ b/src/libraries/kunena/src/Forum/Message/Thankyou/KunenaMessageThankyouHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Message.Thankyou
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/KunenaTopic.php
+++ b/src/libraries/kunena/src/Forum/Topic/KunenaTopic.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Forum.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/KunenaTopicFinder.php
+++ b/src/libraries/kunena/src/Forum/Topic/KunenaTopicFinder.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Forum.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/KunenaTopicHelper.php
+++ b/src/libraries/kunena/src/Forum/Topic/KunenaTopicHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Topic
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPoll.php
+++ b/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPoll.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Topic.Poll
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPollHelper.php
+++ b/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPollHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Topic.Poll
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/Rate/KunenaRate.php
+++ b/src/libraries/kunena/src/Forum/Topic/Rate/KunenaRate.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Forum.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/Rate/KunenaRateHelper.php
+++ b/src/libraries/kunena/src/Forum/Topic/Rate/KunenaRateHelper.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Forum.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/User/KunenaTopicUser.php
+++ b/src/libraries/kunena/src/Forum/Topic/User/KunenaTopicUser.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Topic.User
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/User/KunenaTopicUserHelper.php
+++ b/src/libraries/kunena/src/Forum/Topic/User/KunenaTopicUserHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Topic.User
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/User/Read/KunenaRead.php
+++ b/src/libraries/kunena/src/Forum/Topic/User/Read/KunenaRead.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Topic.User.Read
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Forum/Topic/User/Read/KunenaTopicUserReadHelper.php
+++ b/src/libraries/kunena/src/Forum/Topic/User/Read/KunenaTopicUserReadHelper.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Topic.User.Read
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Html/KunenaParser.php
+++ b/src/libraries/kunena/src/Html/KunenaParser.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      HTML
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Icons/KunenaIcons.php
+++ b/src/libraries/kunena/src/Icons/KunenaIcons.php
@@ -6,7 +6,7 @@
  * @package    Kunena.Framework
  * @subpackage Icons
  *
- * @copyright  Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright  Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license    https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link       https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
+++ b/src/libraries/kunena/src/Icons/KunenaSvgIcons.php
@@ -6,7 +6,7 @@
  * @package    Kunena.Framework
  * @subpackage Icons
  *
- * @copyright  Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright  Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license    https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link       https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Image/KunenaImage.php
+++ b/src/libraries/kunena/src/Image/KunenaImage.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Image
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Image/KunenaImageHelper.php
+++ b/src/libraries/kunena/src/Image/KunenaImageHelper.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Image
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Install/KunenaModelInstall.php
+++ b/src/libraries/kunena/src/Install/KunenaModelInstall.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Installer
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Install/KunenaModelSchema.php
+++ b/src/libraries/kunena/src/Install/KunenaModelSchema.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Installer
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Install/KunenaSampleData.php
+++ b/src/libraries/kunena/src/Install/KunenaSampleData.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Installer
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Installer/KunenaInstaller.php
+++ b/src/libraries/kunena/src/Installer/KunenaInstaller.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Integration/KunenaActivity.php
+++ b/src/libraries/kunena/src/Integration/KunenaActivity.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Integration
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Integration/KunenaAvatar.php
+++ b/src/libraries/kunena/src/Integration/KunenaAvatar.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Integration
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Integration/KunenaPlugins.php
+++ b/src/libraries/kunena/src/Integration/KunenaPlugins.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Integration
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Integration/KunenaPrivate.php
+++ b/src/libraries/kunena/src/Integration/KunenaPrivate.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Integration
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Integration/KunenaProfile.php
+++ b/src/libraries/kunena/src/Integration/KunenaProfile.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Integration
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/KunenaPrivate/KunenaPrivateMessage.php
+++ b/src/libraries/kunena/src/KunenaPrivate/KunenaPrivateMessage.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Private
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          http://www.kunena.org
  **/

--- a/src/libraries/kunena/src/KunenaPrivate/Message/KunenaPost.php
+++ b/src/libraries/kunena/src/KunenaPrivate/Message/KunenaPost.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Private
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          http://www.kunena.org
  **/

--- a/src/libraries/kunena/src/KunenaPrivate/Message/KunenaPrivateMessageFinder.php
+++ b/src/libraries/kunena/src/KunenaPrivate/Message/KunenaPrivateMessageFinder.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Private
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          http://www.kunena.org
  **/

--- a/src/libraries/kunena/src/KunenaPrivate/Message/KunenaUser.php
+++ b/src/libraries/kunena/src/KunenaPrivate/Message/KunenaUser.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Private
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          http://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Layout/KunenaBase.php
+++ b/src/libraries/kunena/src/Layout/KunenaBase.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Categories
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Layout/KunenaLayout.php
+++ b/src/libraries/kunena/src/Layout/KunenaLayout.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Administrator.Template
  * @subpackage      Categories
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Layout/KunenaPage.php
+++ b/src/libraries/kunena/src/Layout/KunenaPage.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Categories
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Log/KunenaEntry.php
+++ b/src/libraries/kunena/src/Log/KunenaEntry.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Libraries
  * @subpackage    Log
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Log/KunenaLog.php
+++ b/src/libraries/kunena/src/Log/KunenaLog.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Libraries
  * @subpackage    Log
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Log/KunenaLogFinder.php
+++ b/src/libraries/kunena/src/Log/KunenaLogFinder.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Forum.Message
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Login/KunenaLogin.php
+++ b/src/libraries/kunena/src/Login/KunenaLogin.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Integration
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Menu/KunenaMenuFix.php
+++ b/src/libraries/kunena/src/Menu/KunenaMenuFix.php
@@ -7,7 +7,7 @@
  * @subpackage      Forum.Menu
  *
  * @copyright   (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Menu/KunenaMenuHelper.php
+++ b/src/libraries/kunena/src/Menu/KunenaMenuHelper.php
@@ -7,7 +7,7 @@
  * @subpackage    Forum.Menu
  *
  * @copyright     Copyright (C) 2005 - 2012 Open Source Matters, Inc. All rights reserved.
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Model/KunenaModel.php
+++ b/src/libraries/kunena/src/Model/KunenaModel.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Module/KunenaModule.php
+++ b/src/libraries/kunena/src/Module/KunenaModule.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Module
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Pagination/KunenaPagination.php
+++ b/src/libraries/kunena/src/Pagination/KunenaPagination.php
@@ -7,7 +7,7 @@
  * @subpackage      Pagination
  *
  * @copyright       Copyright (C) 2005 - 2013 Open Source Matters, Inc. All rights reserved.
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Path/KunenaPath.php
+++ b/src/libraries/kunena/src/Path/KunenaPath.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Path
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Profiler/KunenaProfiler.php
+++ b/src/libraries/kunena/src/Profiler/KunenaProfiler.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Request/KunenaRequest.php
+++ b/src/libraries/kunena/src/Request/KunenaRequest.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Administrator.Template
  * @subpackage    Categories
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Response/KunenaResponseJson.php
+++ b/src/libraries/kunena/src/Response/KunenaResponseJson.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Lib.Response
  * @subpackage    Json
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Route/KunenaRoute.php
+++ b/src/libraries/kunena/src/Route/KunenaRoute.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Route
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Session/KunenaSession.php
+++ b/src/libraries/kunena/src/Session/KunenaSession.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Table/KunenaTableMap.php
+++ b/src/libraries/kunena/src/Table/KunenaTableMap.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Table
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Table/KunenaTableObject.php
+++ b/src/libraries/kunena/src/Table/KunenaTableObject.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Table
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/KunenaSessions.php
+++ b/src/libraries/kunena/src/Tables/KunenaSessions.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/KunenaTable.php
+++ b/src/libraries/kunena/src/Tables/KunenaTable.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/KunenaUserBans.php
+++ b/src/libraries/kunena/src/Tables/KunenaUserBans.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/KunenaUserCategories.php
+++ b/src/libraries/kunena/src/Tables/KunenaUserCategories.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/KunenaUserRead.php
+++ b/src/libraries/kunena/src/Tables/KunenaUserRead.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/KunenaUserTopics.php
+++ b/src/libraries/kunena/src/Tables/KunenaUserTopics.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/KunenaUsers.php
+++ b/src/libraries/kunena/src/Tables/KunenaUsers.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Tables
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaAnnouncements.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaAnnouncements.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaAttachments.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaAttachments.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaCategories.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaCategories.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaKarma.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaKarma.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaKeywords.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaKeywords.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaMessages.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaMessages.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaPolls.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaPolls.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaPrivate.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaPrivate.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          http://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaPrivateAttachmentMap.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaPrivateAttachmentMap.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          http://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaPrivatePostMap.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaPrivatePostMap.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          http://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaPrivateUserMap.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaPrivateUserMap.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          http://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaRate.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaRate.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tables/TableKunenaTopics.php
+++ b/src/libraries/kunena/src/Tables/TableKunenaTopics.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    Tables
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Template/KunenaTemplate.php
+++ b/src/libraries/kunena/src/Template/KunenaTemplate.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Template
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Template/KunenaTemplateHelper.php
+++ b/src/libraries/kunena/src/Template/KunenaTemplateHelper.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Template
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Tree/KunenaTree.php
+++ b/src/libraries/kunena/src/Tree/KunenaTree.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Upload/KunenaUpload.php
+++ b/src/libraries/kunena/src/Upload/KunenaUpload.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Upload
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Upload/KunenaUploadHelper.php
+++ b/src/libraries/kunena/src/Upload/KunenaUploadHelper.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      Upload
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/User/KunenaBan.php
+++ b/src/libraries/kunena/src/User/KunenaBan.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    User
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/User/KunenaFinder.php
+++ b/src/libraries/kunena/src/User/KunenaFinder.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/User/KunenaUser.php
+++ b/src/libraries/kunena/src/User/KunenaUser.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/User/KunenaUserHelper.php
+++ b/src/libraries/kunena/src/User/KunenaUserHelper.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Framework
  * @subpackage      User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/Version/KunenaVersion.php
+++ b/src/libraries/kunena/src/Version/KunenaVersion.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Installer
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/libraries/kunena/src/View/KunenaView.php
+++ b/src/libraries/kunena/src/View/KunenaView.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Framework
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/krating.js
+++ b/src/media/kunena/core/js/krating.js
@@ -2,7 +2,7 @@
  * Kunena       Component
  * @package     Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license     https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link        https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/locales/bootstrap-datepicker.kunena.js
+++ b/src/media/kunena/core/js/locales/bootstrap-datepicker.kunena.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/code/plugin.js
+++ b/src/media/kunena/core/js/plugins/code/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/confidential/plugin.js
+++ b/src/media/kunena/core/js/plugins/confidential/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/ebay/plugin.js
+++ b/src/media/kunena/core/js/plugins/ebay/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/hidetext/plugin.js
+++ b/src/media/kunena/core/js/plugins/hidetext/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/instagram/plugin.js
+++ b/src/media/kunena/core/js/plugins/instagram/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/map/dialogs/map.js
+++ b/src/media/kunena/core/js/plugins/map/dialogs/map.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/map/plugin.js
+++ b/src/media/kunena/core/js/plugins/map/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/polls/dialogs/polls.js
+++ b/src/media/kunena/core/js/plugins/polls/dialogs/polls.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/polls/plugin.js
+++ b/src/media/kunena/core/js/plugins/polls/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/soundcloud/plugin.js
+++ b/src/media/kunena/core/js/plugins/soundcloud/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/spoiler/plugin.js
+++ b/src/media/kunena/core/js/plugins/spoiler/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/twitter/plugin.js
+++ b/src/media/kunena/core/js/plugins/twitter/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/video/dialogs/video.js
+++ b/src/media/kunena/core/js/plugins/video/dialogs/video.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/plugins/video/plugin.js
+++ b/src/media/kunena/core/js/plugins/video/plugin.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/poll.js
+++ b/src/media/kunena/core/js/poll.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/upload.avatar.js
+++ b/src/media/kunena/core/js/upload.avatar.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/core/js/upload.main.js
+++ b/src/media/kunena/core/js/upload.main.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Media
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/media/kunena/kunena_media.xml
+++ b/src/media/kunena/kunena_media.xml
@@ -8,7 +8,7 @@
     <author>Kunena Team</author>
     <authorEmail>kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPLv3 or later</license>
     <description>Kunena media files.</description>
     <changelogurl>@kunenachangelog@</changelogurl>

--- a/src/pkg_kunena.xml
+++ b/src/pkg_kunena.xml
@@ -9,7 +9,7 @@
     <author>Kunena Team</author>
     <authorEmail>kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPLv3 or later</license>
     <description>Kunena Forum Package.</description>
 

--- a/src/plugins/plg_finder_kunena/kunena.php
+++ b/src/plugins/plg_finder_kunena/kunena.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Finder
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_finder_kunena/kunena.xml
+++ b/src/plugins/plg_finder_kunena/kunena.xml
@@ -7,7 +7,7 @@
     <author>Kunena Team</author>
     <authorEmail>Kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPLv3 or later</license>
     <description>PLG_FINDER_KUNENA_DESCRIPTION</description>
     <namespace>Joomla\Plugin\Finder\Kunena</namespace>

--- a/src/plugins/plg_kunena_altauserpoints/KunenaActivityAltaUserPoints.php
+++ b/src/plugins/plg_kunena_altauserpoints/KunenaActivityAltaUserPoints.php
@@ -6,7 +6,7 @@
  * @package        Kunena.Plugins
  * @subpackag      AltaUserPoints
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_altauserpoints/KunenaAvatarAltaUserPoints.php
+++ b/src/plugins/plg_kunena_altauserpoints/KunenaAvatarAltaUserPoints.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      AltaUserPoints
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_altauserpoints/KunenaProfileAltaUserPoints.php
+++ b/src/plugins/plg_kunena_altauserpoints/KunenaProfileAltaUserPoints.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      AltaUserPoints
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_altauserpoints/altauserpoints.php
+++ b/src/plugins/plg_kunena_altauserpoints/altauserpoints.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      AltaUserPoints
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_community/KunenaAccessCommunity.php
+++ b/src/plugins/plg_kunena_community/KunenaAccessCommunity.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Community
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_community/KunenaActivityCommunity.php
+++ b/src/plugins/plg_kunena_community/KunenaActivityCommunity.php
@@ -6,7 +6,7 @@
  * @package          Kunena.Plugins
  * @subpackage       Community
  *
- * @copyright   (C)  2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C)  2008 - @currentyear@ Kunena Team. All rights reserved.
  * @copyright   (C)  2013 - 2014 iJoomla, Inc. All rights reserved.
  * @license          https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link             https://www.kunena.org

--- a/src/plugins/plg_kunena_community/KunenaAvatarCommunity.php
+++ b/src/plugins/plg_kunena_community/KunenaAvatarCommunity.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Community
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_community/KunenaLoginCommunity.php
+++ b/src/plugins/plg_kunena_community/KunenaLoginCommunity.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Community
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_community/KunenaPrivateCommunity.php
+++ b/src/plugins/plg_kunena_community/KunenaPrivateCommunity.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Community
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_community/KunenaProfileCommunity.php
+++ b/src/plugins/plg_kunena_community/KunenaProfileCommunity.php
@@ -6,7 +6,7 @@
  * @package          Kunena.Plugins
  * @subpackage       Community
  *
- * @copyright   (C)  2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C)  2008 - @currentyear@ Kunena Team. All rights reserved.
  * @copyright   (C)  2013 - 2014 iJoomla, Inc. All rights reserved.
  * @license          https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link             https://www.kunena.org

--- a/src/plugins/plg_kunena_community/community.php
+++ b/src/plugins/plg_kunena_community/community.php
@@ -6,7 +6,7 @@
  * @package          Kunena.Plugins
  * @subpackage       Community
  *
- * @copyright   (C)  2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C)  2008 - @currentyear@ Kunena Team. All rights reserved.
  * @copyright   (C)  2013 - 2014 iJoomla, Inc. All rights reserved.
  * @license          https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link             https://www.kunena.org

--- a/src/plugins/plg_kunena_comprofiler/KunenaAccessComprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/KunenaAccessComprofiler.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Comprofiler
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_comprofiler/KunenaActivityComprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/KunenaActivityComprofiler.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Comprofiler
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_comprofiler/KunenaAvatarComprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/KunenaAvatarComprofiler.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Comprofiler
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_comprofiler/KunenaIntegrationComprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/KunenaIntegrationComprofiler.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Comprofiler
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_comprofiler/KunenaLoginComprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/KunenaLoginComprofiler.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Comprofiler
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_comprofiler/KunenaPrivateComprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/KunenaPrivateComprofiler.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Comprofiler
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_comprofiler/KunenaProfileComprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/KunenaProfileComprofiler.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Comprofiler
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_comprofiler/comprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/comprofiler.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Comprofiler
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_easyblog/KunenaAvatarEasyblog.php
+++ b/src/plugins/plg_kunena_easyblog/KunenaAvatarEasyblog.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easyblog
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_easyblog/KunenaProfileEasyblog.php
+++ b/src/plugins/plg_kunena_easyblog/KunenaProfileEasyblog.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easyblog
  *
- * @copyright   (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_easyblog/easyblog.php
+++ b/src/plugins/plg_kunena_easyblog/easyblog.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easyblog
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_easyprofile/KunenaAvatarEasyprofile.php
+++ b/src/plugins/plg_kunena_easyprofile/KunenaAvatarEasyprofile.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easyprofile
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_easyprofile/KunenaProfileEasyprofile.php
+++ b/src/plugins/plg_kunena_easyprofile/KunenaProfileEasyprofile.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easyprofile
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_easyprofile/easyprofile.php
+++ b/src/plugins/plg_kunena_easyprofile/easyprofile.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easyprofile
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_easysocial/KunenaActivityEasySocial.php
+++ b/src/plugins/plg_kunena_easysocial/KunenaActivityEasySocial.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easysocial
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @copyright      Copyright (C) 2010 - 2014 Stack Ideas Sdn Bhd. All rights reserved.
  * @license        GNU/GPL, see LICENSE.php
  * EasySocial is free software. This version may have been modified pursuant

--- a/src/plugins/plg_kunena_easysocial/KunenaAvatarEasySocial.php
+++ b/src/plugins/plg_kunena_easysocial/KunenaAvatarEasySocial.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easysocial
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @copyright      Copyright (C) 2010 - 2014 Stack Ideas Sdn Bhd. All rights reserved.
  * @license        GNU/GPL, see LICENSE.php
  * EasySocial is free software. This version may have been modified pursuant

--- a/src/plugins/plg_kunena_easysocial/KunenaLoginEasySocial.php
+++ b/src/plugins/plg_kunena_easysocial/KunenaLoginEasySocial.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easysocial
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @copyright      Copyright (C) 2010 - 2014 Stack Ideas Sdn Bhd. All rights reserved.
  * @license        GNU/GPL, see LICENSE.php
  * EasySocial is free software. This version may have been modified pursuant

--- a/src/plugins/plg_kunena_easysocial/KunenaPrivateEasySocial.php
+++ b/src/plugins/plg_kunena_easysocial/KunenaPrivateEasySocial.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easysocial
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @copyright      Copyright (C) 2010 - 2016 Stack Ideas Sdn Bhd. All rights reserved.
  * @license        GNU/GPL, see LICENSE.php
  * EasySocial is free software. This version may have been modified pursuant

--- a/src/plugins/plg_kunena_easysocial/KunenaProfileEasySocial.php
+++ b/src/plugins/plg_kunena_easysocial/KunenaProfileEasySocial.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easysocial
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @copyright       Copyright (C) 2010 - 2014 Stack Ideas Sdn Bhd. All rights reserved.
  * @license         GNU/GPL, see LICENSE.php
  * EasySocial is free software. This version may have been modified pursuant

--- a/src/plugins/plg_kunena_easysocial/easysocial.php
+++ b/src/plugins/plg_kunena_easysocial/easysocial.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Easysocial
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @copyright       Copyright (C) 2010 - 2016 Stack Ideas Sdn Bhd. All rights reserved.
  * @license         GNU/GPL, see LICENSE.php
  * EasySocial is free software. This version may have been modified pursuant

--- a/src/plugins/plg_kunena_finder/finder.xml
+++ b/src/plugins/plg_kunena_finder/finder.xml
@@ -7,7 +7,7 @@
     <author>Kunena Team</author>
     <authorEmail>kunena@kunena.org</authorEmail>
     <authorUrl>https://www.kunena.org</authorUrl>
-    <copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+    <copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
     <license>GNU/GPLv3 or later</license>
     <description>PLG_KUNENA_FINDER_DESCRIPTION</description>
     <namespace>Kunena\Forum\Plugin\Kunena\Finder</namespace>

--- a/src/plugins/plg_kunena_gravatar/KunenaAvatarGravatar.php
+++ b/src/plugins/plg_kunena_gravatar/KunenaAvatarGravatar.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Gravatar
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_gravatar/gravatar.php
+++ b/src/plugins/plg_kunena_gravatar/gravatar.php
@@ -6,7 +6,7 @@
  * @package        Kunena.Plugins
  * @subpackage     Kunena
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_joomla/KunenaAccessJoomla.php
+++ b/src/plugins/plg_kunena_joomla/KunenaAccessJoomla.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Joomla
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_joomla/KunenaLoginJoomla.php
+++ b/src/plugins/plg_kunena_joomla/KunenaLoginJoomla.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Joomla
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_joomla/joomla.php
+++ b/src/plugins/plg_kunena_joomla/joomla.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Joomla
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_joomla/script.php
+++ b/src/plugins/plg_kunena_joomla/script.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_kunena/KunenaAvatarKunena.php
+++ b/src/plugins/plg_kunena_kunena/KunenaAvatarKunena.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Kunena
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_kunena/KunenaProfileKunena.php
+++ b/src/plugins/plg_kunena_kunena/KunenaProfileKunena.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Kunena
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_kunena/kunena.php
+++ b/src/plugins/plg_kunena_kunena/kunena.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Kunena
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_kunena/script.php
+++ b/src/plugins/plg_kunena_kunena/script.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_uddeim/KunenaPrivateUddeim.php
+++ b/src/plugins/plg_kunena_uddeim/KunenaPrivateUddeim.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Plugins
  * @subpackage      UddeIM
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_kunena_uddeim/uddeim.php
+++ b/src/plugins/plg_kunena_uddeim/uddeim.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Plugins
  * @subpackage      UddeIM
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_privacy_kunena/script.php
+++ b/src/plugins/plg_privacy_kunena/script.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/plugins/plg_privacy_kunena/services/provider.php
+++ b/src/plugins/plg_privacy_kunena/services/provider.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Privacy
  *
- * @copyright       Copyright (C) 2023 - 2023 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2023 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_privacy_kunena/src/Extension/Kunena.php
+++ b/src/plugins/plg_privacy_kunena/src/Extension/Kunena.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Privacy
  *
- * @copyright       Copyright (C) 2023 - 2023 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2023 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_privacy_kunena/src/Helper/KunenaHelper.php
+++ b/src/plugins/plg_privacy_kunena/src/Helper/KunenaHelper.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      Privacy
  *
- * @copyright       Copyright (C) 2023 - 2023 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2023 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_quickicon_kunena/kunena.php
+++ b/src/plugins/plg_quickicon_kunena/kunena.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      QuickIcon
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_quickicon_kunena/script.php
+++ b/src/plugins/plg_quickicon_kunena/script.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/plugins/plg_sampledata_kunena/kunena.php
+++ b/src/plugins/plg_sampledata_kunena/kunena.php
@@ -4,7 +4,7 @@
  * @package        Joomla.Plugin
  * @subpackage     Sampledata.Kunena
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  */

--- a/src/plugins/plg_sampledata_kunena/kunena.xml
+++ b/src/plugins/plg_sampledata_kunena/kunena.xml
@@ -7,7 +7,7 @@
 	<author>Kunena Team</author>
 	<authorEmail>kunena@kunena.org</authorEmail>
 	<authorUrl>https://www.kunena.org</authorUrl>
-	<copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+	<copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
 	<license>GNU/GPLv3 or later</license>
 	<description>PLG_SAMPLEDATA_KUNENA_XML_DESCRIPTION</description>
 	<namespace>Kunena\Forum\Plugin\Sampledata\Kunena</namespace>

--- a/src/plugins/plg_sampledata_kunena/script.php
+++ b/src/plugins/plg_sampledata_kunena/script.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/plugins/plg_system_kunena/kunena.php
+++ b/src/plugins/plg_system_kunena/kunena.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Plugins
  * @subpackage      System
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/plugins/plg_system_kunena/script.php
+++ b/src/plugins/plg_system_kunena/script.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/script.php
+++ b/src/script.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/site/src/Application/attachment.php
+++ b/src/site/src/Application/attachment.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Site
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/src/site/src/Controller/Announcement/Edit/AnnouncementEditDisplay.php
+++ b/src/site/src/Controller/Announcement/Edit/AnnouncementEditDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Announcement/Item/AnnouncementItemDisplay.php
+++ b/src/site/src/Controller/Announcement/Item/AnnouncementItemDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Announcement/Listing/AnnouncementListingDisplay.php
+++ b/src/site/src/Controller/Announcement/Listing/AnnouncementListingDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Ajax/Initial/AjaxDisplay.php
+++ b/src/site/src/Controller/Application/Ajax/Initial/AjaxDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Attachment/Initial/AttachmentDisplay.php
+++ b/src/site/src/Controller/Application/Attachment/Initial/AttachmentDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Category/Feed/CategoryDisplay.php
+++ b/src/site/src/Controller/Application/Category/Feed/CategoryDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Category/Raw/CategoryDisplay.php
+++ b/src/site/src/Controller/Application/Category/Raw/CategoryDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Home/Initial/HomeDisplay.php
+++ b/src/site/src/Controller/Application/Home/Initial/HomeDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Misc/Initial/MiscDisplay.php
+++ b/src/site/src/Controller/Application/Misc/Initial/MiscDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Topic/Flat/ApplicationTopicFlatDisplay.php
+++ b/src/site/src/Controller/Application/Topic/Flat/ApplicationTopicFlatDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Topic/Indented/ApplicationTopicIndentedDisplay.php
+++ b/src/site/src/Controller/Application/Topic/Indented/ApplicationTopicIndentedDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Topic/Threaded/ApplicationTopicThreadedDisplay.php
+++ b/src/site/src/Controller/Application/Topic/Threaded/ApplicationTopicThreadedDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Topic/Unread/TopicDisplay.php
+++ b/src/site/src/Controller/Application/Topic/Unread/TopicDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Application/Topics/Feed/TopicsDisplay.php
+++ b/src/site/src/Controller/Application/Topics/Feed/TopicsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Application
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Category/Description/CategoryDescriptionDisplay.php
+++ b/src/site/src/Controller/Category/Description/CategoryDescriptionDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Category/Index/Actions/CategoryIndexActionsDisplay.php
+++ b/src/site/src/Controller/Category/Index/Actions/CategoryIndexActionsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Category/Index/CategoryIndexDisplay.php
+++ b/src/site/src/Controller/Category/Index/CategoryIndexDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Category/Manage/CategoryManageDisplay.php
+++ b/src/site/src/Controller/Category/Manage/CategoryManageDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Category/Subscriptions/CategorySubscriptionsDisplay.php
+++ b/src/site/src/Controller/Category/Subscriptions/CategorySubscriptionsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Category/Topics/CategoryTopicsDisplay.php
+++ b/src/site/src/Controller/Category/Topics/CategoryTopicsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Credits/Display/CreditsDisplay.php
+++ b/src/site/src/Controller/Credits/Display/CreditsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Credits
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
+++ b/src/site/src/Controller/Message/Item/Actions/MessageItemActionsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Message/Listing/Recent/MessageListingRecentDisplay.php
+++ b/src/site/src/Controller/Message/Listing/Recent/MessageListingRecentDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Search/Form/SearchFormDisplay.php
+++ b/src/site/src/Controller/Search/Form/SearchFormDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Search/Results/SearchResultsDisplay.php
+++ b/src/site/src/Controller/Search/Results/SearchResultsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Statistics/General/StatisticsGeneralDisplay.php
+++ b/src/site/src/Controller/Statistics/General/StatisticsGeneralDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Statistics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Form/Create/TopicFormCreateDisplay.php
+++ b/src/site/src/Controller/Topic/Form/Create/TopicFormCreateDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Form/Edit/TopicFormEditDisplay.php
+++ b/src/site/src/Controller/Topic/Form/Edit/TopicFormEditDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Form/History/TopicFormHistoryDisplay.php
+++ b/src/site/src/Controller/Topic/Form/History/TopicFormHistoryDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Form/Reply/TopicFormReplyDisplay.php
+++ b/src/site/src/Controller/Topic/Form/Reply/TopicFormReplyDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Item/Actions/TopicItemActionsDisplay.php
+++ b/src/site/src/Controller/Topic/Item/Actions/TopicItemActionsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Item/Message/TopicItemMessageDisplay.php
+++ b/src/site/src/Controller/Topic/Item/Message/TopicItemMessageDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Item/Rating/TopicItemRatingDisplay.php
+++ b/src/site/src/Controller/Topic/Item/Rating/TopicItemRatingDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Item/TopicItemDisplay.php
+++ b/src/site/src/Controller/Topic/Item/TopicItemDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Json/TopicJsonDisplay.php
+++ b/src/site/src/Controller/Topic/Json/TopicJsonDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Listing/ListDisplay.php
+++ b/src/site/src/Controller/Topic/Listing/ListDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Listing/Moderator/TopicListingModeratorDisplay.php
+++ b/src/site/src/Controller/Topic/Listing/Moderator/TopicListingModeratorDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Listing/Recent/TopicListingRecentDisplay.php
+++ b/src/site/src/Controller/Topic/Listing/Recent/TopicListingRecentDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Listing/Unread/TopicListingUnreadDisplay.php
+++ b/src/site/src/Controller/Topic/Listing/Unread/TopicListingUnreadDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Listing/User/TopicListingUserDisplay.php
+++ b/src/site/src/Controller/Topic/Listing/User/TopicListingUserDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Moderate/TopicModerateDisplay.php
+++ b/src/site/src/Controller/Topic/Moderate/TopicModerateDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Poll/TopicPollDisplay.php
+++ b/src/site/src/Controller/Topic/Poll/TopicPollDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Topic/Report/TopicReportDisplay.php
+++ b/src/site/src/Controller/Topic/Report/TopicReportDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Attachments/UserAttachmentsDisplay.php
+++ b/src/site/src/Controller/User/Attachments/UserAttachmentsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Ban/Form/UserBanFormDisplay.php
+++ b/src/site/src/Controller/User/Ban/Form/UserBanFormDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Ban/History/UserBanHistoryDisplay.php
+++ b/src/site/src/Controller/User/Ban/History/UserBanHistoryDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Ban/Manager/UserBanManagerDisplay.php
+++ b/src/site/src/Controller/User/Ban/Manager/UserBanManagerDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Edit/Avatar/UserEditAvatarDisplay.php
+++ b/src/site/src/Controller/User/Edit/Avatar/UserEditAvatarDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Edit/Profile/UserEditProfileDisplay.php
+++ b/src/site/src/Controller/User/Edit/Profile/UserEditProfileDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Edit/Settings/UserEditSettingsDisplay.php
+++ b/src/site/src/Controller/User/Edit/Settings/UserEditSettingsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Edit/User/UserEditUserDisplay.php
+++ b/src/site/src/Controller/User/Edit/User/UserEditUserDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Edit/UserEditDisplay.php
+++ b/src/site/src/Controller/User/Edit/UserEditDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Item/UserItemDisplay.php
+++ b/src/site/src/Controller/User/Item/UserItemDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/User/Listing/UserListingDisplay.php
+++ b/src/site/src/Controller/User/Listing/UserListingDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Widget/Announcement/WidgetAnnouncementDisplay.php
+++ b/src/site/src/Controller/Widget/Announcement/WidgetAnnouncementDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Widget/Login/WidgetLoginDisplay.php
+++ b/src/site/src/Controller/Widget/Login/WidgetLoginDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Widget/Menu/WidgetMenuDisplay.php
+++ b/src/site/src/Controller/Widget/Menu/WidgetMenuDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Widget/Statistics/WidgetStatisticsDisplay.php
+++ b/src/site/src/Controller/Widget/Statistics/WidgetStatisticsDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controller/Widget/Whoisonline/WidgetWhoisonlineDisplay.php
+++ b/src/site/src/Controller/Widget/Whoisonline/WidgetWhoisonlineDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controller.Statistics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/AnnouncementController.php
+++ b/src/site/src/Controllers/AnnouncementController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/CategoryController.php
+++ b/src/site/src/Controllers/CategoryController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/CommonController.php
+++ b/src/site/src/Controllers/CommonController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/CreditsController.php
+++ b/src/site/src/Controllers/CreditsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/HomeController.php
+++ b/src/site/src/Controllers/HomeController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/MiscController.php
+++ b/src/site/src/Controllers/MiscController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/SearchController.php
+++ b/src/site/src/Controllers/SearchController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/StatisticsController.php
+++ b/src/site/src/Controllers/StatisticsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/TopicController.php
+++ b/src/site/src/Controllers/TopicController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/TopicsController.php
+++ b/src/site/src/Controllers/TopicsController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Controllers/UserController.php
+++ b/src/site/src/Controllers/UserController.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Dispatcher/Dispatcher.php
+++ b/src/site/src/Dispatcher/Dispatcher.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Dispatcher
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Announcement/AnnouncementEdit.php
+++ b/src/site/src/Layout/Announcement/AnnouncementEdit.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Announcement.Edit
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Announcement/AnnouncementItem.php
+++ b/src/site/src/Layout/Announcement/AnnouncementItem.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Announcement.List
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Announcement/AnnouncementListing.php
+++ b/src/site/src/Layout/Announcement/AnnouncementListing.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Announcement.List
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Announcement/Listing/AnnouncementListingRow.php
+++ b/src/site/src/Layout/Announcement/Listing/AnnouncementListingRow.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Announcement.List
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Attachment/AttachmentItem.php
+++ b/src/site/src/Layout/Attachment/AttachmentItem.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Attachment
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Bbcode/BBCodeeBay.php
+++ b/src/site/src/Layout/Bbcode/BBCodeeBay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Bbcode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Bbcode/BbcodeUrl.php
+++ b/src/site/src/Layout/Bbcode/BbcodeUrl.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Bbcode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Category/CategoryIndex.php
+++ b/src/site/src/Layout/Category/CategoryIndex.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Category.Index
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Category/CategoryItem.php
+++ b/src/site/src/Layout/Category/CategoryItem.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Category.Item
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Category/CategoryList.php
+++ b/src/site/src/Layout/Category/CategoryList.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Category.Index
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Category/CategoryManage.php
+++ b/src/site/src/Layout/Category/CategoryManage.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Category.Manage
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Category/CategoryModerators.php
+++ b/src/site/src/Layout/Category/CategoryModerators.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Credits/Credits.php
+++ b/src/site/src/Layout/Credits/Credits.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Credits
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Email/EmailReport.php
+++ b/src/site/src/Layout/Email/EmailReport.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Email.Subscription
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Email/EmailSubscription.php
+++ b/src/site/src/Layout/Email/EmailSubscription.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Email.Subscription
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Message/Item/MessageItemActions.php
+++ b/src/site/src/Layout/Message/Item/MessageItemActions.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Message.Item
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Message/MessageEdit.php
+++ b/src/site/src/Layout/Message/MessageEdit.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Message/MessageItem.php
+++ b/src/site/src/Layout/Message/MessageItem.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Message/MessageList.php
+++ b/src/site/src/Layout/Message/MessageList.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Message/MessageRow.php
+++ b/src/site/src/Layout/Message/MessageRow.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Misc/MiscDisplay.php
+++ b/src/site/src/Layout/Misc/MiscDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Controllers.Misc
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Search/Results/SearchResultsRow.php
+++ b/src/site/src/Layout/Search/Results/SearchResultsRow.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Search/SearchForm.php
+++ b/src/site/src/Layout/Search/SearchForm.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Search/SearchResults.php
+++ b/src/site/src/Layout/Search/SearchResults.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Statistics/StatisticsGeneral.php
+++ b/src/site/src/Layout/Statistics/StatisticsGeneral.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/Edit/TopicEditEditor.php
+++ b/src/site/src/Layout/Topic/Edit/TopicEditEditor.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/Edit/TopicEditHistory.php
+++ b/src/site/src/Layout/Topic/Edit/TopicEditHistory.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/Item/TopicItemActions.php
+++ b/src/site/src/Layout/Topic/Item/TopicItemActions.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/Item/TopicItemMessage.php
+++ b/src/site/src/Layout/Topic/Item/TopicItemMessage.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/Item/TopicItemRating.php
+++ b/src/site/src/Layout/Topic/Item/TopicItemRating.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic.Item
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/Poll/TopicPollResults.php
+++ b/src/site/src/Layout/Topic/Poll/TopicPollResults.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic.Item
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/Poll/TopicPollVote.php
+++ b/src/site/src/Layout/Topic/Poll/TopicPollVote.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic.Item
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/TopicEdit.php
+++ b/src/site/src/Layout/Topic/TopicEdit.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/TopicItem.php
+++ b/src/site/src/Layout/Topic/TopicItem.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/TopicList.php
+++ b/src/site/src/Layout/Topic/TopicList.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/TopicModerate.php
+++ b/src/site/src/Layout/Topic/TopicModerate.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/TopicReport.php
+++ b/src/site/src/Layout/Topic/TopicReport.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Topic/TopicRow.php
+++ b/src/site/src/Layout/Topic/TopicRow.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Ban/UserBanForm.php
+++ b/src/site/src/Layout/User/Ban/UserBanForm.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Ban/UserBanHistory.php
+++ b/src/site/src/Layout/User/Ban/UserBanHistory.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Ban/UserBanManager.php
+++ b/src/site/src/Layout/User/Ban/UserBanManager.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Edit/UserEditAvatar.php
+++ b/src/site/src/Layout/User/Edit/UserEditAvatar.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Edit/UserEditProfile.php
+++ b/src/site/src/Layout/User/Edit/UserEditProfile.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Edit/UserEditSettings.php
+++ b/src/site/src/Layout/User/Edit/UserEditSettings.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Edit/UserEditUser.php
+++ b/src/site/src/Layout/User/Edit/UserEditUser.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Item/UserItemSocial.php
+++ b/src/site/src/Layout/User/Item/UserItemSocial.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Item/UserItemStatus.php
+++ b/src/site/src/Layout/User/Item/UserItemStatus.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/Item/UserItemSummary.php
+++ b/src/site/src/Layout/User/Item/UserItemSummary.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/UserAttachments.php
+++ b/src/site/src/Layout/User/UserAttachments.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/UserEdit.php
+++ b/src/site/src/Layout/User/UserEdit.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/UserItem.php
+++ b/src/site/src/Layout/User/UserItem.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/UserList.php
+++ b/src/site/src/Layout/User/UserList.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/User/UserProfile.php
+++ b/src/site/src/Layout/User/UserProfile.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/Announcement/WidgetAnnouncementButton.php
+++ b/src/site/src/Layout/Widget/Announcement/WidgetAnnouncementButton.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/Login/WidgetLoginLogin.php
+++ b/src/site/src/Layout/Widget/Login/WidgetLoginLogin.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/Login/WidgetLoginLogout.php
+++ b/src/site/src/Layout/Widget/Login/WidgetLoginLogout.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/Pagination/WidgetPaginationItem.php
+++ b/src/site/src/Layout/Widget/Pagination/WidgetPaginationItem.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/Pagination/WidgetPaginationList.php
+++ b/src/site/src/Layout/Widget/Pagination/WidgetPaginationList.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/TopicEditEditor.php
+++ b/src/site/src/Layout/Widget/TopicEditEditor.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetAnnouncement.php
+++ b/src/site/src/Layout/Widget/WidgetAnnouncement.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetBreadcrumb.php
+++ b/src/site/src/Layout/Widget/WidgetBreadcrumb.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetButton.php
+++ b/src/site/src/Layout/Widget/WidgetButton.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetEditor.php
+++ b/src/site/src/Layout/Widget/WidgetEditor.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetFooter.php
+++ b/src/site/src/Layout/Widget/WidgetFooter.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetForumjump.php
+++ b/src/site/src/Layout/Widget/WidgetForumjump.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetKarma.php
+++ b/src/site/src/Layout/Widget/WidgetKarma.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetLabel.php
+++ b/src/site/src/Layout/Widget/WidgetLabel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetMenu.php
+++ b/src/site/src/Layout/Widget/WidgetMenu.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetMenuBar.php
+++ b/src/site/src/Layout/Widget/WidgetMenuBar.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetMenuDisplay.php
+++ b/src/site/src/Layout/Widget/WidgetMenuDisplay.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetModal.php
+++ b/src/site/src/Layout/Widget/WidgetModal.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetModule.php
+++ b/src/site/src/Layout/Widget/WidgetModule.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetRanks.php
+++ b/src/site/src/Layout/Widget/WidgetRanks.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetRating.php
+++ b/src/site/src/Layout/Widget/WidgetRating.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetSearch.php
+++ b/src/site/src/Layout/Widget/WidgetSearch.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetSocial.php
+++ b/src/site/src/Layout/Widget/WidgetSocial.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetStatistics.php
+++ b/src/site/src/Layout/Widget/WidgetStatistics.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Layout/Widget/WidgetWhoisonline.php
+++ b/src/site/src/Layout/Widget/WidgetWhoisonline.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Site
  * @subpackage      Layout.widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/AnnouncementModel.php
+++ b/src/site/src/Model/AnnouncementModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/CategoryModel.php
+++ b/src/site/src/Model/CategoryModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/CommonModel.php
+++ b/src/site/src/Model/CommonModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/CreditsModel.php
+++ b/src/site/src/Model/CreditsModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/HomeModel.php
+++ b/src/site/src/Model/HomeModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/MiscModel.php
+++ b/src/site/src/Model/MiscModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/RateModel.php
+++ b/src/site/src/Model/RateModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/SearchModel.php
+++ b/src/site/src/Model/SearchModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/StatisticsModel.php
+++ b/src/site/src/Model/StatisticsModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/TopicModel.php
+++ b/src/site/src/Model/TopicModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/TopicsModel.php
+++ b/src/site/src/Model/TopicsModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Model/UserModel.php
+++ b/src/site/src/Model/UserModel.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Models
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/Service/Html/Kunenaforum.php
+++ b/src/site/src/Service/Html/Kunenaforum.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Framework
  * @subpackage    HTML
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/site/src/Service/Html/Kunenagrid.php
+++ b/src/site/src/Service/Html/Kunenagrid.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Service
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  */

--- a/src/site/src/View/Category/HtmlView.php
+++ b/src/site/src/View/Category/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Category/HtmlViewFeed.php
+++ b/src/site/src/View/Category/HtmlViewFeed.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Category/view.raw.php
+++ b/src/site/src/View/Category/view.raw.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Common/HtmlView.php
+++ b/src/site/src/View/Common/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Credits/HtmlView.php
+++ b/src/site/src/View/Credits/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Default/HtmlView.php
+++ b/src/site/src/View/Default/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Home/HtmlView.php
+++ b/src/site/src/View/Home/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Misc/HtmlView.php
+++ b/src/site/src/View/Misc/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Search/HtmlView.php
+++ b/src/site/src/View/Search/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Statistics/HtmlView.php
+++ b/src/site/src/View/Statistics/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Topic/HtmlView.php
+++ b/src/site/src/View/Topic/HtmlView.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Site
  * @subpackage    Views
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/site/src/View/Topic/HtmlViewJson.php
+++ b/src/site/src/View/Topic/HtmlViewJson.php
@@ -5,7 +5,7 @@
  *
  * @package       Kunena.json_kunenalatest
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/site/src/View/Topic/HtmlViewRaw.php
+++ b/src/site/src/View/Topic/HtmlViewRaw.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Topic/view.json.php
+++ b/src/site/src/View/Topic/view.json.php
@@ -5,7 +5,7 @@
  *
  * @package       Kunena.json_kunenalatest
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/site/src/View/Topic/view.raw.php
+++ b/src/site/src/View/Topic/view.raw.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Topics/HtmlView.php
+++ b/src/site/src/View/Topics/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/Topics/HtmlViewJson.php
+++ b/src/site/src/View/Topics/HtmlViewJson.php
@@ -5,7 +5,7 @@
  *
  * @package       Kunena.json_kunenalatest
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/site/src/View/Topics/view.json.php
+++ b/src/site/src/View/Topics/view.json.php
@@ -5,7 +5,7 @@
  *
  * @package       Kunena.json_kunenalatest
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       http://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/site/src/View/User/HtmlView.php
+++ b/src/site/src/View/User/HtmlView.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/User/HtmlViewRaw.php
+++ b/src/site/src/View/User/HtmlViewRaw.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/src/View/User/view.raw.php
+++ b/src/site/src/View/User/view.raw.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Site
  * @subpackage      Views
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/js/edit.js
+++ b/src/site/template/aurelia/assets/js/edit.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Template.Aurelia
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/js/main.js
+++ b/src/site/template/aurelia/assets/js/main.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Template.Aurelia
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/js/offcanvas.js
+++ b/src/site/template/aurelia/assets/js/offcanvas.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Template.Aurelia
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/js/profile.js
+++ b/src/site/template/aurelia/assets/js/profile.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Template.Aurelia
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/js/quickreply.js
+++ b/src/site/template/aurelia/assets/js/quickreply.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Template.Aurelia
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/js/sceditor.js
+++ b/src/site/template/aurelia/assets/js/sceditor.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Template.Aurelia
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/js/search.js
+++ b/src/site/template/aurelia/assets/js/search.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Template.Aurelia
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/js/tooltips.js
+++ b/src/site/template/aurelia/assets/js/tooltips.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Template.Aurelia
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/js/topic.js
+++ b/src/site/template/aurelia/assets/js/topic.js
@@ -2,7 +2,7 @@
  * Kunena Component
  * @package Kunena.Template.Aurelia
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link https://www.kunena.org
  **/

--- a/src/site/template/aurelia/assets/scss/aurelia.scss
+++ b/src/site/template/aurelia/assets/scss/aurelia.scss
@@ -2,7 +2,7 @@
 * Kunena Component
 * $package Kunena.Template.Aurelia
 *
-* $copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+* $copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 * $license https://www.gnu.org/copyleft/gpl.html GNU/GPL
 * $link https://www.kunena.org
 **/

--- a/src/site/template/aurelia/assets/scss/categories.scss
+++ b/src/site/template/aurelia/assets/scss/categories.scss
@@ -2,7 +2,7 @@
 * Kunena Component
 * $package Kunena.Template.Aurelia
 *
-* $copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+* $copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 * $license https://www.gnu.org/copyleft/gpl.html GNU/GPL
 * $link https://www.kunena.org
 **/

--- a/src/site/template/aurelia/assets/scss/debug.scss
+++ b/src/site/template/aurelia/assets/scss/debug.scss
@@ -2,7 +2,7 @@
 * Kunena Component
 * $package Kunena.Template.Aurelia
 *
-* $copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+* $copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 * $license https://www.gnu.org/copyleft/gpl.html GNU/GPL
 * $link https://www.kunena.org
 **/

--- a/src/site/template/aurelia/assets/scss/editor.scss
+++ b/src/site/template/aurelia/assets/scss/editor.scss
@@ -5,7 +5,7 @@
 * markItUp! Universal MarkUp Engine, JQuery plugin
 * By Jay Salvat - http://markitup.jaysalvat.com/
 *
-* $Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+* $Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 * $license https://www.gnu.org/copyleft/gpl.html GNU/GPL
 * $link https://www.kunena.org
 **/

--- a/src/site/template/aurelia/assets/scss/general.scss
+++ b/src/site/template/aurelia/assets/scss/general.scss
@@ -2,7 +2,7 @@
 * Kunena Component
 * $package Kunena.Template.Aurelia
 *
-* $copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+* $copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 * $license https://www.gnu.org/copyleft/gpl.html GNU/GPL
 * $link https://www.kunena.org
 **/

--- a/src/site/template/aurelia/assets/scss/icons.scss
+++ b/src/site/template/aurelia/assets/scss/icons.scss
@@ -2,7 +2,7 @@
 * Kunena Component
 * $package Kunena.Template.Aurelia
 *
-* $copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+* $copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 * $license https://www.gnu.org/copyleft/gpl.html GNU/GPL
 * $link https://www.kunena.org
 **/

--- a/src/site/template/aurelia/assets/scss/mediaqueries.scss
+++ b/src/site/template/aurelia/assets/scss/mediaqueries.scss
@@ -2,7 +2,7 @@
 * Kunena Component
 * $package Kunena.Template.Aurelia
 *
-* $copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+* $copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 * $license https://www.gnu.org/copyleft/gpl.html GNU/GPL
 * $link https://www.kunena.org
 **/

--- a/src/site/template/aurelia/assets/scss/profile.scss
+++ b/src/site/template/aurelia/assets/scss/profile.scss
@@ -2,7 +2,7 @@
 * Kunena Component
 * $package Kunena.Template.Aurelia
 *
-* $copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+* $copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 * $license https://www.gnu.org/copyleft/gpl.html GNU/GPL
 * $link https://www.kunena.org
 **/

--- a/src/site/template/aurelia/assets/scss/user.scss
+++ b/src/site/template/aurelia/assets/scss/user.scss
@@ -2,7 +2,7 @@
 * Kunena Component
 * $package Kunena.Template.Aurelia
 *
-* $copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+* $copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
 * $license https://www.gnu.org/copyleft/gpl.html GNU/GPL
 * $link https://www.kunena.org
 **/

--- a/src/site/template/aurelia/layouts/announcement/edit/default.php
+++ b/src/site/template/aurelia/layouts/announcement/edit/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/announcement/item/default.php
+++ b/src/site/template/aurelia/layouts/announcement/item/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/announcement/listing/default.php
+++ b/src/site/template/aurelia/layouts/announcement/listing/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/announcement/listing/row/default.php
+++ b/src/site/template/aurelia/layouts/announcement/listing/row/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/attachment/item/audio.php
+++ b/src/site/template/aurelia/layouts/attachment/item/audio.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/attachment/item/default.php
+++ b/src/site/template/aurelia/layouts/attachment/item/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/attachment/item/general.php
+++ b/src/site/template/aurelia/layouts/attachment/item/general.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/attachment/item/image.php
+++ b/src/site/template/aurelia/layouts/attachment/item/image.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/attachment/item/textlink.php
+++ b/src/site/template/aurelia/layouts/attachment/item/textlink.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/attachment/item/thumbnail.php
+++ b/src/site/template/aurelia/layouts/attachment/item/thumbnail.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/attachment/item/video.php
+++ b/src/site/template/aurelia/layouts/attachment/item/video.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/confidential/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/confidential/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/ebay/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/ebay/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/ebay/search.php
+++ b/src/site/template/aurelia/layouts/bbcode/ebay/search.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/ebay/seller.php
+++ b/src/site/template/aurelia/layouts/bbcode/ebay/seller.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/email/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/email/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/hide/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/hide/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/image/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/image/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/image/deleted.php
+++ b/src/site/template/aurelia/layouts/bbcode/image/deleted.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/image/unauthorised.php
+++ b/src/site/template/aurelia/layouts/bbcode/image/unauthorised.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/map/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/map/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/private/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/private/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/quote/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/quote/default.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/size/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/size/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/spoiler/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/spoiler/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  */

--- a/src/site/template/aurelia/layouts/bbcode/tableau/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/tableau/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/terminal/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/terminal/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/twitter/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/twitter/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/bbcode/url/default.php
+++ b/src/site/template/aurelia/layouts/bbcode/url/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/category/index/default.php
+++ b/src/site/template/aurelia/layouts/category/index/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/category/item/default.php
+++ b/src/site/template/aurelia/layouts/category/item/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/category/list/default.php
+++ b/src/site/template/aurelia/layouts/category/list/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/category/list/row/default.php
+++ b/src/site/template/aurelia/layouts/category/list/row/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/category/manage/default.php
+++ b/src/site/template/aurelia/layouts/category/manage/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/category/moderators/default.php
+++ b/src/site/template/aurelia/layouts/category/moderators/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/credits/default.php
+++ b/src/site/template/aurelia/layouts/credits/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Credits
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/email/report/default.php
+++ b/src/site/template/aurelia/layouts/email/report/default.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Email
  *
- * @copyright   (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/email/subscription/default.php
+++ b/src/site/template/aurelia/layouts/email/subscription/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Email
  *
- * @copyright   (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/email/subscription/moderator.php
+++ b/src/site/template/aurelia/layouts/email/subscription/moderator.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Email
  *
- * @copyright   (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/empty/default.php
+++ b/src/site/template/aurelia/layouts/empty/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Empty
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/message/edit/full.php
+++ b/src/site/template/aurelia/layouts/message/edit/full.php
@@ -6,7 +6,7 @@
  * @package     Kunena.Template.Aurelia
  * @subpackage  Layout.Message
  *
- * @copyright   Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license     https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link        https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/message/edit/quickreply.php
+++ b/src/site/template/aurelia/layouts/message/edit/quickreply.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/message/item/actions/default.php
+++ b/src/site/template/aurelia/layouts/message/item/actions/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/message/item/bottom/default.php
+++ b/src/site/template/aurelia/layouts/message/item/bottom/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/message/item/default.php
+++ b/src/site/template/aurelia/layouts/message/item/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/message/item/top/default.php
+++ b/src/site/template/aurelia/layouts/message/item/top/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/message/list/default.php
+++ b/src/site/template/aurelia/layouts/message/list/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/message/row/default.php
+++ b/src/site/template/aurelia/layouts/message/row/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Message
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/page/default.php
+++ b/src/site/template/aurelia/layouts/page/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/page/offline.php
+++ b/src/site/template/aurelia/layouts/page/offline.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/page/unauthorized.php
+++ b/src/site/template/aurelia/layouts/page/unauthorized.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/search/form/default.php
+++ b/src/site/template/aurelia/layouts/search/form/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/search/results/default.php
+++ b/src/site/template/aurelia/layouts/search/results/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/search/results/row/default.php
+++ b/src/site/template/aurelia/layouts/search/results/row/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/statistics/general/default.php
+++ b/src/site/template/aurelia/layouts/statistics/general/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Statistics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/edit/attachments/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/attachments/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/edit/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/edit/history/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/history/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/item/actions/default.php
+++ b/src/site/template/aurelia/layouts/topic/item/actions/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/item/default.php
+++ b/src/site/template/aurelia/layouts/topic/item/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/item/message/actions/default.php
+++ b/src/site/template/aurelia/layouts/topic/item/message/actions/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/item/message/default.php
+++ b/src/site/template/aurelia/layouts/topic/item/message/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/item/message/row.php
+++ b/src/site/template/aurelia/layouts/topic/item/message/row.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/item/rating/default.php
+++ b/src/site/template/aurelia/layouts/topic/item/rating/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/json/default.php
+++ b/src/site/template/aurelia/layouts/topic/json/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/list/default.php
+++ b/src/site/template/aurelia/layouts/topic/list/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/moderate/default.php
+++ b/src/site/template/aurelia/layouts/topic/moderate/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/poll/results/default.php
+++ b/src/site/template/aurelia/layouts/topic/poll/results/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/poll/vote/default.php
+++ b/src/site/template/aurelia/layouts/topic/poll/vote/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/report/default.php
+++ b/src/site/template/aurelia/layouts/topic/report/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/row/category.php
+++ b/src/site/template/aurelia/layouts/topic/row/category.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/row/default.php
+++ b/src/site/template/aurelia/layouts/topic/row/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/topic/row/user.php
+++ b/src/site/template/aurelia/layouts/topic/row/user.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/attachments/default.php
+++ b/src/site/template/aurelia/layouts/user/attachments/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/ban/form/default.php
+++ b/src/site/template/aurelia/layouts/user/ban/form/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/ban/history/default.php
+++ b/src/site/template/aurelia/layouts/user/ban/history/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/ban/manager/default.php
+++ b/src/site/template/aurelia/layouts/user/ban/manager/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/edit/avatar/default.php
+++ b/src/site/template/aurelia/layouts/user/edit/avatar/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/edit/default.php
+++ b/src/site/template/aurelia/layouts/user/edit/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/edit/profile/default.php
+++ b/src/site/template/aurelia/layouts/user/edit/profile/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/edit/settings/default.php
+++ b/src/site/template/aurelia/layouts/user/edit/settings/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/edit/user/default.php
+++ b/src/site/template/aurelia/layouts/user/edit/user/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/item/default.php
+++ b/src/site/template/aurelia/layouts/user/item/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/item/social/default.php
+++ b/src/site/template/aurelia/layouts/user/item/social/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/item/status/default.php
+++ b/src/site/template/aurelia/layouts/user/item/status/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/item/summary/default.php
+++ b/src/site/template/aurelia/layouts/user/item/summary/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/list/default.php
+++ b/src/site/template/aurelia/layouts/user/list/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/profile/default.php
+++ b/src/site/template/aurelia/layouts/user/profile/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/user/profile/horizontal.php
+++ b/src/site/template/aurelia/layouts/user/profile/horizontal.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/announcement/button/default.php
+++ b/src/site/template/aurelia/layouts/widget/announcement/button/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/announcement/default.php
+++ b/src/site/template/aurelia/layouts/widget/announcement/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/badge/default.php
+++ b/src/site/template/aurelia/layouts/widget/badge/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/breadcrumb/default.php
+++ b/src/site/template/aurelia/layouts/widget/breadcrumb/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/button/default.php
+++ b/src/site/template/aurelia/layouts/widget/button/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/custom/default.php
+++ b/src/site/template/aurelia/layouts/widget/custom/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/datepicker/default.php
+++ b/src/site/template/aurelia/layouts/widget/datepicker/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/editor/ckeditor.php
+++ b/src/site/template/aurelia/layouts/widget/editor/ckeditor.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/editor/sceditor.php
+++ b/src/site/template/aurelia/layouts/widget/editor/sceditor.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/error/default.php
+++ b/src/site/template/aurelia/layouts/widget/error/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/footer/default.php
+++ b/src/site/template/aurelia/layouts/widget/footer/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/forumjump/default.php
+++ b/src/site/template/aurelia/layouts/widget/forumjump/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/karma/default.php
+++ b/src/site/template/aurelia/layouts/widget/karma/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/label/default.php
+++ b/src/site/template/aurelia/layouts/widget/label/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/label/link.php
+++ b/src/site/template/aurelia/layouts/widget/label/link.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/lightbox/default.php
+++ b/src/site/template/aurelia/layouts/widget/lightbox/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/login/login/default.php
+++ b/src/site/template/aurelia/layouts/widget/login/login/default.php
@@ -6,7 +6,7 @@
  * @package     Kunena.Template.Aurelia
  * @subpackage  Layout.Widget
  *
- * @copyright   Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license     https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link        https://www.kunena.org
 **/

--- a/src/site/template/aurelia/layouts/widget/login/login/desktop.php
+++ b/src/site/template/aurelia/layouts/widget/login/login/desktop.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/login/login/mobile.php
+++ b/src/site/template/aurelia/layouts/widget/login/login/mobile.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/login/logout/default.php
+++ b/src/site/template/aurelia/layouts/widget/login/logout/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/menu/default.php
+++ b/src/site/template/aurelia/layouts/widget/menu/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/menubar/default.php
+++ b/src/site/template/aurelia/layouts/widget/menubar/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/modal/default.php
+++ b/src/site/template/aurelia/layouts/widget/modal/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/module/default.php
+++ b/src/site/template/aurelia/layouts/widget/module/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/module/table_row.php
+++ b/src/site/template/aurelia/layouts/widget/module/table_row.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/pagination/item/default.php
+++ b/src/site/template/aurelia/layouts/widget/pagination/item/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Pagination
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/pagination/list/default.php
+++ b/src/site/template/aurelia/layouts/widget/pagination/list/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Pagination
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/pagination/list/simple.php
+++ b/src/site/template/aurelia/layouts/widget/pagination/list/simple.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Pagination
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/ranks/default.php
+++ b/src/site/template/aurelia/layouts/widget/ranks/default.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/rating/default.php
+++ b/src/site/template/aurelia/layouts/widget/rating/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Rating
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/search/topic.php
+++ b/src/site/template/aurelia/layouts/widget/search/topic.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/search/user.php
+++ b/src/site/template/aurelia/layouts/widget/search/user.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/social/default.php
+++ b/src/site/template/aurelia/layouts/widget/social/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/socialcustomtag/default.php
+++ b/src/site/template/aurelia/layouts/widget/socialcustomtag/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/statistics/default.php
+++ b/src/site/template/aurelia/layouts/widget/statistics/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/whoisonline/avatar.php
+++ b/src/site/template/aurelia/layouts/widget/whoisonline/avatar.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Statistics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/whoisonline/both.php
+++ b/src/site/template/aurelia/layouts/widget/whoisonline/both.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Statistics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/whoisonline/default.php
+++ b/src/site/template/aurelia/layouts/widget/whoisonline/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Statistics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/whoisonline/name.php
+++ b/src/site/template/aurelia/layouts/widget/whoisonline/name.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Statistics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/layouts/widget/writeaccess/default.php
+++ b/src/site/template/aurelia/layouts/widget/writeaccess/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/announcement/create/default.php
+++ b/src/site/template/aurelia/pages/announcement/create/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/announcement/default/default.php
+++ b/src/site/template/aurelia/pages/announcement/default/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/announcement/edit/default.php
+++ b/src/site/template/aurelia/pages/announcement/edit/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/announcement/listing/default.php
+++ b/src/site/template/aurelia/pages/announcement/listing/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Announcement
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/category/default/default.php
+++ b/src/site/template/aurelia/pages/category/default/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/category/list/default.php
+++ b/src/site/template/aurelia/pages/category/list/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/category/manage/default.php
+++ b/src/site/template/aurelia/pages/category/manage/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/category/user/default.php
+++ b/src/site/template/aurelia/pages/category/user/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Category
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/credits/default/default.php
+++ b/src/site/template/aurelia/pages/credits/default/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Credits
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/misc/default/default.php
+++ b/src/site/template/aurelia/pages/misc/default/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Misc
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/search/default/default.php
+++ b/src/site/template/aurelia/pages/search/default/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Search
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/statistics/default/default.php
+++ b/src/site/template/aurelia/pages/statistics/default/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Statistics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/statistics/whoisonline/default.php
+++ b/src/site/template/aurelia/pages/statistics/whoisonline/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Statistics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topic/create/default.php
+++ b/src/site/template/aurelia/pages/topic/create/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topic/default/default.php
+++ b/src/site/template/aurelia/pages/topic/default/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topic/edit/default.php
+++ b/src/site/template/aurelia/pages/topic/edit/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topic/moderate/default.php
+++ b/src/site/template/aurelia/pages/topic/moderate/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topic/poll/default.php
+++ b/src/site/template/aurelia/pages/topic/poll/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topic/reply/default.php
+++ b/src/site/template/aurelia/pages/topic/reply/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topic/report/default.php
+++ b/src/site/template/aurelia/pages/topic/report/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topic/vote/default.php
+++ b/src/site/template/aurelia/pages/topic/vote/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topics/default/default.php
+++ b/src/site/template/aurelia/pages/topics/default/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topics/moderator/default.php
+++ b/src/site/template/aurelia/pages/topics/moderator/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topics/posts/default.php
+++ b/src/site/template/aurelia/pages/topics/posts/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topics/unread/default.php
+++ b/src/site/template/aurelia/pages/topics/unread/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/topics/user/default.php
+++ b/src/site/template/aurelia/pages/topics/user/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.Topics
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/user/attachments/default.php
+++ b/src/site/template/aurelia/pages/user/attachments/default.php
@@ -6,7 +6,7 @@
  * @package       Kunena.Template.Aurelia
  * @subpackage    Pages.User
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/user/banmanager/default.php
+++ b/src/site/template/aurelia/pages/user/banmanager/default.php
@@ -5,7 +5,7 @@
  * @package       Kunena.Template.Aurelia
  * @subpackage    Pages.User
  *
- * @copyright     Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/user/default/default.php
+++ b/src/site/template/aurelia/pages/user/default/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/user/edit/default.php
+++ b/src/site/template/aurelia/pages/user/edit/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/user/list/default.php
+++ b/src/site/template/aurelia/pages/user/list/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/pages/user/moderate/default.php
+++ b/src/site/template/aurelia/pages/user/moderate/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Pages.User
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/aurelia/template.php
+++ b/src/site/template/aurelia/template.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Template
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/attachment/item/audio.php
+++ b/src/site/template/system/layouts/attachment/item/audio.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/attachment/item/default.php
+++ b/src/site/template/system/layouts/attachment/item/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/attachment/item/general.php
+++ b/src/site/template/system/layouts/attachment/item/general.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/attachment/item/image.php
+++ b/src/site/template/system/layouts/attachment/item/image.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/attachment/item/textlink.php
+++ b/src/site/template/system/layouts/attachment/item/textlink.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/attachment/item/thumbnail.php
+++ b/src/site/template/system/layouts/attachment/item/thumbnail.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/attachment/item/video.php
+++ b/src/site/template/system/layouts/attachment/item/video.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/attachment/audio.php
+++ b/src/site/template/system/layouts/bbcode/attachment/audio.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/attachment/default.php
+++ b/src/site/template/system/layouts/bbcode/attachment/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/attachment/deleted.php
+++ b/src/site/template/system/layouts/bbcode/attachment/deleted.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/attachment/file.php
+++ b/src/site/template/system/layouts/bbcode/attachment/file.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/attachment/image.php
+++ b/src/site/template/system/layouts/bbcode/attachment/image.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/attachment/pdf.php
+++ b/src/site/template/system/layouts/bbcode/attachment/pdf.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/attachment/unauthorised.php
+++ b/src/site/template/system/layouts/bbcode/attachment/unauthorised.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/attachment/video.php
+++ b/src/site/template/system/layouts/bbcode/attachment/video.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/ebay/default.php
+++ b/src/site/template/system/layouts/bbcode/ebay/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/ebay/search.php
+++ b/src/site/template/system/layouts/bbcode/ebay/search.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/ebay/seller.php
+++ b/src/site/template/system/layouts/bbcode/ebay/seller.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/file/default.php
+++ b/src/site/template/system/layouts/bbcode/file/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/file/deleted.php
+++ b/src/site/template/system/layouts/bbcode/file/deleted.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/file/unauthorised.php
+++ b/src/site/template/system/layouts/bbcode/file/unauthorised.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/image/default.php
+++ b/src/site/template/system/layouts/bbcode/image/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/image/deleted.php
+++ b/src/site/template/system/layouts/bbcode/image/deleted.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/image/unauthorised.php
+++ b/src/site/template/system/layouts/bbcode/image/unauthorised.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/bbcode/twitter/default.php
+++ b/src/site/template/system/layouts/bbcode/twitter/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      Layout.BBCode
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/email/report/default.php
+++ b/src/site/template/system/layouts/email/report/default.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Template.System
  * @subpackage      Layout.Email
  *
- * @copyright   (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/email/subscription/default.php
+++ b/src/site/template/system/layouts/email/subscription/default.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      Layout.Email
  *
- * @copyright   (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/email/subscription/moderator.php
+++ b/src/site/template/system/layouts/email/subscription/moderator.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      Layout.Email
  *
- * @copyright   (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright   (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/template/system/layouts/widget/login/login/login.php
+++ b/src/site/template/system/layouts/widget/login/login/login.php
@@ -6,7 +6,7 @@
  * @package         Kunena.Template.System
  * @subpackage      Layout.Widget
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/

--- a/src/site/tmpl/Credits/default.php
+++ b/src/site/tmpl/Credits/default.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Site
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/tests/acceptance/administrator/categories/CategoryKunenaCest.php
+++ b/tests/acceptance/administrator/categories/CategoryKunenaCest.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/tests/acceptance/administrator/categories/CategoryKunenaPublishCest.php
+++ b/tests/acceptance/administrator/categories/CategoryKunenaPublishCest.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/tests/acceptance/administrator/configuration/ConfigurationKunenaCest.php
+++ b/tests/acceptance/administrator/configuration/ConfigurationKunenaCest.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/tests/acceptance/administrator/install/InstallKunenaCest.php
+++ b/tests/acceptance/administrator/install/InstallKunenaCest.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/tests/acceptance/frontend/actions/KunenaPostingTestCest.php
+++ b/tests/acceptance/frontend/actions/KunenaPostingTestCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.UnitTest
  * @subpackage    Utilities
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/install/kunenaCest.php
+++ b/tests/acceptance/install/kunenaCest.php
@@ -5,7 +5,7 @@
  *
  * @package        Kunena.Package
  *
- * @copyright      Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright      Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license        https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link           https://www.kunena.org
  **/

--- a/tests/acceptance/libraries/KunenaFactoryCest.php
+++ b/tests/acceptance/libraries/KunenaFactoryCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.UnitTest
  * @subpackage    Utilities
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/libraries/forum/category/KunenaForumCategoryCest.php
+++ b/tests/acceptance/libraries/forum/category/KunenaForumCategoryCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.UnitTest
  * @subpackage    Utilities
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/libraries/forum/category/KunenaForumCategoryHelperCest.php
+++ b/tests/acceptance/libraries/forum/category/KunenaForumCategoryHelperCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.UnitTest
  * @subpackage    Utilities
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/libraries/forum/category/KunenaForumCategoryUserCest.php
+++ b/tests/acceptance/libraries/forum/category/KunenaForumCategoryUserCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.UnitTest
  * @subpackage    Utilities
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/libraries/forum/category/KunenaForumCategoryUserHelperCest.php
+++ b/tests/acceptance/libraries/forum/category/KunenaForumCategoryUserHelperCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.UnitTest
  * @subpackage    Utilities
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/libraries/forum/topic/KunenaForumTopicCest.php
+++ b/tests/acceptance/libraries/forum/topic/KunenaForumTopicCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.UnitTest
  * @subpackage    Utilities
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/libraries/forum/topic/KunenaForumTopicUserCest.php
+++ b/tests/acceptance/libraries/forum/topic/KunenaForumTopicUserCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.UnitTest
  * @subpackage    Utilities
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/libraries/forum/topic/KunenaForumTopicUserHelperCest.php
+++ b/tests/acceptance/libraries/forum/topic/KunenaForumTopicUserHelperCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.UnitTest
  * @subpackage    Utilities
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/plugins/kunena/example/exampleCest.php
+++ b/tests/acceptance/plugins/kunena/example/exampleCest.php
@@ -5,7 +5,7 @@
  * @package       Kunena.Plugin
  * @subpackage    Example
  *
- * @Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license       https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link          https://www.kunena.org
  **/

--- a/tests/acceptance/plugins/kunena/example/exampleCest.xml
+++ b/tests/acceptance/plugins/kunena/example/exampleCest.xml
@@ -7,7 +7,7 @@
 	<author>Kunena Team</author>
 	<authorEmail>kunena@kunena.org</authorEmail>
 	<authorUrl>https://www.kunena.org</authorUrl>
-	<copyright>(C) 2008 - 2024 Kunena Team. All rights reserved.</copyright>
+	<copyright>(C) 2008 - @currentyear@ Kunena Team. All rights reserved.</copyright>
 	<license>GNU/GPL</license>
 	<description>PLG_KUNENA_EXAMPLE_XML_DESCRIPTION</description>
 


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes
I have done a search and replace for "- 2024 Kunena" with "- @currentyear@ Kunena" (also for 2023 hardcoded in the privacy plugin.
I have altered the build script to replace token @currentyear@ with the actual year at the time of executing the build script.
Should same you some hassle when 2025 arrives :)
 
#### Testing Instructions
No code changes, all files have changed that have the copyright in it

Feel free to decline as you do not feel confident at the moment to make such a 'big' change