### PR TITLE
Fix: refactor plugin modals to dialogs to workaround J5.1 bug

### DIFF
--- a/src/admin/language/en-GB/en-GB.com_kunena.views.ini
+++ b/src/admin/language/en-GB/en-GB.com_kunena.views.ini
@@ -701,6 +701,10 @@ COM_KUNENA_CPANEL_LABEL_DONWLOAD_LANGUAGE_PACK = "Download"
 COM_KUNENA_CPANEL_LABEL_LANGUAGE = "Language"
 COM_KUNENA_CPANEL_LABEL_KUNENA_LANGUAGE = "Kunena Languages"
 
+; JROOT/administrator/components/com_kunena/views/plugins/
+
+COM_KUNENA_PLUGINS_MANAGER_PLUGIN = "Edit plugin setting: %s"
+
 ; JROOT/administrator/components/com_kunena/views/ranks/
 
 COM_KUNENA_NEW_RANK = "New Rank"

--- a/src/admin/tmpl/plugins/default.php
+++ b/src/admin/tmpl/plugins/default.php
@@ -15,17 +15,19 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Version;
 use Kunena\Forum\Libraries\Version\KunenaVersion;
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')
     ->useScript('multiselect');
-$app       = Factory::getApplication();
-$user      = $this->getCurrentUser();
-$userId    = $user->id;
-$listOrder = $this->escape($this->state->get('list.ordering'));
-$listDirn  = $this->escape($this->state->get('list.direction'));
+$app           = Factory::getApplication();
+$user          = $this->getCurrentUser();
+$userId        = $user->id;
+$listOrder     = $this->escape($this->state->get('list.ordering'));
+$listDirn      = $this->escape($this->state->get('list.direction'));
+$joomlaVersion = new Version();
 ?>
 <form action="index.php?option=com_kunena&view=plugins" method="post" name="adminForm" id="adminForm">
     <div class="row">
@@ -64,21 +66,39 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                     </thead>
                     <tbody>
                         <?php foreach ($this->items as $i => $item) :
-                            $link = Route::_('index.php?option=com_plugins&client_id=0&task=plugin.edit&extension_id=' . $item->extension_id . '&tmpl=component&layout=modal');
-                            $linkModal = HTMLHelper::_(
-                                'link',
-                                '#plugin' . $item->extension_id . 'Modal',
-                                $item->name,
-                                'data-bs-toggle="modal" id="title-' . $item->extension_id . '"'
-                            );
-
-                            if (!empty($item->note)) {
-                                $linkModal .= "<div class=\"small\">" . Text::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)) . "</div>";
-                            }
-
                             $canEdit    = $user->authorise('core.edit', 'com_plugins');
                             $canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $user->id || is_null($item->checked_out);
                             $canChange  = $user->authorise('core.edit.state', 'com_plugins') && $canCheckin;
+                            $link = Route::_('index.php?option=com_plugins&client_id=0&task=plugin.edit&extension_id=' . $item->extension_id . '&tmpl=component&layout=modal', false);
+                            if (version_compare($joomlaVersion->getShortVersion(), '5.1', '<')) {
+                                $linkModal = HTMLHelper::_(
+                                    'link',
+                                    '#plugin' . $item->extension_id . 'Modal',
+                                    $item->name,
+                                    'data-bs-toggle="modal" id="title-' . $item->extension_id . '"'
+                                );
+                            } else {
+                                $popupOptions = [
+                                    'popupType'  => 'iframe',
+                                    'textHeader' => Text::sprintf('COM_OCHSUBSCRIPTIONS_CPANEL_MANAGER_PLUGIN', $item->name),
+                                    'src'        => $link,
+                                ];
+                                $linkModal = HTMLHelper::_(
+                                    'link',
+                                    '#',
+                                    $item->name,
+                                    [
+                                        'class'                 => 'alert-link',
+                                        'data-joomla-dialog'    => $this->escape(json_encode($popupOptions, JSON_UNESCAPED_SLASHES)),
+                                        'data-checkin-url'      => Route::_('index.php?option=com_plugins&task=plugins.checkin&format=json&cid[]=' . $item->extension_id),
+                                        'data-close-on-message' => '',
+                                        'data-reload-on-close'  => '',
+                                    ],
+                                );
+                            }
+                            if (!empty($item->note)) {
+                                $linkModal .= "<div class=\"small\">" . Text::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)) . "</div>";
+                            }
                         ?>
                             <tr class="row<?php echo $i % 2; ?>" data-dragable-group="<?php echo $item->folder; ?>">
                                 <td class="text-center">
@@ -93,34 +113,35 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                     <?php endif; ?>
                                     <?php if ($canEdit) : ?>
                                         <?php echo $linkModal; ?>
-                                        <?php echo HTMLHelper::_(
-                                            'bootstrap.renderModal',
-                                            'plugin' . $item->extension_id . 'Modal',
-                                            array(
-                                                'url'         => $link,
-                                                'title'       => Text::_($item->name),
-                                                'height'      => '400px',
-                                                'width'       => '800px',
-                                                'bodyHeight'  => '70',
-                                                'modalWidth'  => '80',
-                                                'closeButton' => false,
-                                                'backdrop'    => 'static',
-                                                'keyboard'    => false,
-                                                'footer'      => '<button type="button" class="btn btn-primary"'
-                                                    . ' onclick="toggleInlineHelp({iframeSelector: \'#plugin' . $item->extension_id . 'Modal\'})">'
-                                                    . Text::_('JINLINEHELP') . '</button>'
-                                                    . '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal"'
-                                                    . ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $item->extension_id . 'Modal\', buttonSelector: \'#closeBtn\'})">'
-                                                    . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-                                                    . '<button type="button" class="btn btn-primary" data-bs-dismiss="modal"'
-                                                    . ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $item->extension_id . 'Modal\', buttonSelector: \'#saveBtn\'})">'
-                                                    . Text::_('JSAVE') . '</button>'
-                                                    . '<button type="button" class="btn btn-success"'
-                                                    . ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $item->extension_id . 'Modal\', buttonSelector: \'#applyBtn\'})">'
-                                                    . Text::_('JAPPLY') . '</button>',
-                                            )
-                                        ); ?>
-
+                                        <?php if (version_compare($joomlaVersion->getShortVersion(), '5.1', '<')) : ?>
+                                            <?php echo HTMLHelper::_(
+                                                'bootstrap.renderModal',
+                                                'plugin' . $item->extension_id . 'Modal',
+                                                array(
+                                                    'url'         => $link,
+                                                    'title'       => Text::_($item->name),
+                                                    'height'      => '400px',
+                                                    'width'       => '800px',
+                                                    'bodyHeight'  => '70',
+                                                    'modalWidth'  => '80',
+                                                    'closeButton' => false,
+                                                    'backdrop'    => 'static',
+                                                    'keyboard'    => false,
+                                                    'footer'      => '<button type="button" class="btn btn-primary"'
+                                                        . ' onclick="toggleInlineHelp({iframeSelector: \'#plugin' . $item->extension_id . 'Modal\'})">'
+                                                        . Text::_('JINLINEHELP') . '</button>'
+                                                        . '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal"'
+                                                        . ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $item->extension_id . 'Modal\', buttonSelector: \'#closeBtn\'})">'
+                                                        . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
+                                                        . '<button type="button" class="btn btn-primary" data-bs-dismiss="modal"'
+                                                        . ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $item->extension_id . 'Modal\', buttonSelector: \'#saveBtn\'})">'
+                                                        . Text::_('JSAVE') . '</button>'
+                                                        . '<button type="button" class="btn btn-success"'
+                                                        . ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $item->extension_id . 'Modal\', buttonSelector: \'#applyBtn\'})">'
+                                                        . Text::_('JAPPLY') . '</button>',
+                                                )
+                                            ); ?>
+                                        <?php endif; ?>
                                     <?php else : ?>
                                         <?php echo $item->name; ?>
                                     <?php endif; ?>
@@ -156,40 +177,42 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 <div class="mt-3 text-center small">
     <?php echo KunenaVersion::getLongVersionHTML(); ?>
 </div>
-<script>
-    Array.from(document.querySelectorAll('.modal')).forEach(modalEl => {
-        modalEl.addEventListener('hidden.bs.modal', () => {
-            setTimeout(() => {
-                window.parent.location.reload();
-            }, 1000);
-        });
-    });
-    toggleInlineHelp = options => {
-        const iframe = document.querySelector(`${options.iframeSelector} iframe`);
-        if (iframe) {
-            [].slice.call(iframe.contentWindow.document.querySelectorAll(`div.hide-aware-inline-help`)).forEach(elDiv => {
-                // Toggle the visibility of the node by toggling the 'd-none' Bootstrap class.
-                elDiv.classList.toggle('d-none'); // The ID of the description whose visibility is toggled.
-
-                const myId = elDiv.id; // The ID of the control described by this node (same ID, minus the '-desc' suffix).
-
-                const controlId = myId ? myId.substr(0, myId.length - 5) : null; // Get the control described by this node.
-
-                const elControl = controlId ? document.getElementById(controlId) : null; // Is this node hidden?
-
-                const isHidden = elDiv.classList.contains('d-none'); // If we do not have a control we will exit early
-
-                if (!controlId || !elControl) {
-                    return;
-                } // Unset the aria-describedby attribute in the control when the description is hidden and vice–versa.
-
-
-                if (isHidden && elControl.hasAttribute('aria-describedby')) {
-                    elControl.removeAttribute('aria-describedby');
-                } else if (!isHidden) {
-                    elControl.setAttribute('aria-describedby', myId);
-                }
+<?php if (version_compare($joomlaVersion->getShortVersion(), '5.1', '<')) : ?>
+    <script>
+        Array.from(document.querySelectorAll('.modal')).forEach(modalEl => {
+            modalEl.addEventListener('hidden.bs.modal', () => {
+                setTimeout(() => {
+                    window.parent.location.reload();
+                }, 1000);
             });
-        }
-    };
-</script>
+        });
+        toggleInlineHelp = options => {
+            const iframe = document.querySelector(`${options.iframeSelector} iframe`);
+            if (iframe) {
+                [].slice.call(iframe.contentWindow.document.querySelectorAll(`div.hide-aware-inline-help`)).forEach(elDiv => {
+                    // Toggle the visibility of the node by toggling the 'd-none' Bootstrap class.
+                    elDiv.classList.toggle('d-none'); // The ID of the description whose visibility is toggled.
+
+                    const myId = elDiv.id; // The ID of the control described by this node (same ID, minus the '-desc' suffix).
+
+                    const controlId = myId ? myId.substr(0, myId.length - 5) : null; // Get the control described by this node.
+
+                    const elControl = controlId ? document.getElementById(controlId) : null; // Is this node hidden?
+
+                    const isHidden = elDiv.classList.contains('d-none'); // If we do not have a control we will exit early
+
+                    if (!controlId || !elControl) {
+                        return;
+                    } // Unset the aria-describedby attribute in the control when the description is hidden and vice–versa.
+
+
+                    if (isHidden && elControl.hasAttribute('aria-describedby')) {
+                        elControl.removeAttribute('aria-describedby');
+                    } else if (!isHidden) {
+                        elControl.setAttribute('aria-describedby', myId);
+                    }
+                });
+            }
+        };
+    </script>
+<?php endif; ?>

--- a/src/admin/tmpl/plugins/default.php
+++ b/src/admin/tmpl/plugins/default.php
@@ -80,7 +80,7 @@ $joomlaVersion = new Version();
                             } else {
                                 $popupOptions = [
                                     'popupType'  => 'iframe',
-                                    'textHeader' => Text::sprintf('COM_OCHSUBSCRIPTIONS_CPANEL_MANAGER_PLUGIN', $item->name),
+                                    'textHeader' => Text::sprintf('COM_KUNENA_PLUGINS_MANAGER_PLUGIN', $item->name),
                                     'src'        => $link,
                                 ];
                                 $linkModal = HTMLHelper::_(


### PR DESCRIPTION
Pull Request for Issue #9670  . 
 
#### Summary of Changes 
added new J5.1 dialogs when Joomla version is 5.1
 
#### Testing Instructions
test on both J5.1 and < J5.1

1. in back-end goto Kunena > plugins
2. click a plugin name

on J5.1 a dialog modal should open (save / save& close / close buttons on top
on  < J5.1 a BS modal should open (buttons in the footer)

3. test if all buttons work.

The J5.1 plugin dialog modal is missing the Toggle inline help button (the BS modal has that button in the footer).
I have crated a PR for that in the Joomla repository: appreciate if you could also test that and if okay report back as positive test result on the Joomla repository: https://github.com/joomla/joomla-cms/pull/43296