### PR TITLE
Wrong time stamp shown when listing topics/messages in trashbin

### DIFF
--- a/src/admin/tmpl/trashs/messages.php
+++ b/src/admin/tmpl/trashs/messages.php
@@ -15,6 +15,7 @@ defined('_JEXEC') or die();
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Kunena\Forum\Libraries\Route\KunenaRoute;
 use Kunena\Forum\Libraries\Version\KunenaVersion;
@@ -87,7 +88,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                 <td><?php echo $this->escape($row->category); ?></td>
                                 <td><?php echo $this->escape($row->author); ?></td>
                                 <td><?php echo $this->escape($row->ip); ?></td>
-                                <td><?php echo Factory::getDate($row->time)->format('Y-m-d h:m:s', $row->time); ?></td>
+                                <td><?php echo HTMLHelper::date($row->time, Text::_('DATE_FORMAT_LC6')); ?></td>
                             </tr>
                         <?php
                         endforeach; ?>

--- a/src/admin/tmpl/trashs/topics.php
+++ b/src/admin/tmpl/trashs/topics.php
@@ -15,6 +15,7 @@ defined('_JEXEC') or die();
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Kunena\Forum\Libraries\Route\KunenaRoute;
 use Kunena\Forum\Libraries\Version\KunenaVersion;
@@ -81,7 +82,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                 <td><?php echo $this->escape($row->category); ?></td>
                                 <td><?php echo $this->escape($row->author); ?></td>
                                 <td><?php echo $this->escape($row->ip); ?></td>
-                                <td><?php echo Factory::getDate($row->time)->format('Y-m-d h:m:s', $row->time); ?></td>
+                                <td><?php echo HTMLHelper::date($row->time, Text::_('DATE_FORMAT_LC6')); ?></td>
                             </tr>
                         <?php
                         endforeach; ?>


### PR DESCRIPTION
#### Summary of Changes 
When listing messages or topics in trashbin, it would show bogus timestamps because the UNIX timestamp was not converted properly. 

#### Testing Instructions
Delete  message to trashbin, Check out the original creation time, compare with time shown in trashbin.
Before this patch it was different, the message in the trashbin would show a timestamp on the same day, but a different time.
After applying the patch it shows correctly.