### PR TITLE
Fix: deprecated message / error exporting thankyou database

### DIFF
--- a/src/plugins/plg_privacy_kunena/src/Extension/Kunena.php
+++ b/src/plugins/plg_privacy_kunena/src/Extension/Kunena.php
@@ -418,7 +418,7 @@ class Kunena extends PrivacyPlugin
         foreach ($items as $item) {
             $data = KunenaHelper::processUserData($item, $excluded, $redacted);
 
-            $domain->addItem($this->createItemFromArray($data, $data['id']));
+            $domain->addItem($this->createItemFromArray($data, $data['postid']));
         }
 
         return $domain;


### PR DESCRIPTION
Pull Request for Issue # - . 
 
#### Summary of Changes 
non-existing id was used, replaced with postid
 
#### Testing Instructions
export a user who was thanked, #__kunena_thankyou should now also be part of the exported XML