### PR TITLE
[K6.4] fix phing locale build error

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -38,4 +38,4 @@ cfg.adddate=true
 cfg.datefmt=yyyy-MM-dd
 
 # Date locale
-cfg.dateloc=en,UK
+cfg.dateloc=en_UK


### PR DESCRIPTION
#### Summary of Changes 
Fix build error 
[tstamp] Unable to format date (locale en,UK) [Found unconstructed IntlDateFormatter]
 
#### Testing Instructions