### PR TITLE
[K6.4] get rid of CMSObject::getProperties()

### DIFF
--- a/src/admin/src/Controller/CategoryController.php
+++ b/src/admin/src/Controller/CategoryController.php
@@ -165,9 +165,21 @@ class CategoryController extends KunenaController
             if (!$me->isAdmin()) {
                 $access = ['accesstype', 'access', 'pubAccess', 'pubRecurse', 'adminAccess', 'adminRecurse', 'channels', 'class_sfx', 'params'];
 
+                $data = [
+                    'accesstype' => $parent->accesstype,
+                    'access' => $parent->access, 
+                    'pubAccess' => $parent->pubAccess, 
+                    'pubRecurse' => $parent->pubRecurse, 
+                    'adminAccess' => $parent->adminAccess, 
+                    'adminRecurse' => $parent->adminRecurse, 
+                    'channels' => $parent->channels, 
+                    'class_sfx' => $parent->class_sfx, 
+                    'params' => $parent->params
+                ];
+
                 if (!$category->exists() || $parent->id != $category->parentid) {
                     // If category didn't exist or is moved, copy access and class_sfx from parent
-                    $category->bind($parent->getProperties(), $access, true);
+                    $category->bind($data, $access, true);
                 }
 
                 $ignore = array_merge($ignore, $access);

--- a/src/admin/src/Controller/ConfigController.php
+++ b/src/admin/src/Controller/ConfigController.php
@@ -93,7 +93,7 @@ class ConfigController extends FormController
             return;
         }
 
-        $properties = KunenaConfig::getInstance()->getProperties();
+        $kconfig    = KunenaConfig::getInstance();
         $postConfig = $this->input->post->getArray();
 
         foreach ($postConfig as $postsetting => $postvalue) {
@@ -119,15 +119,12 @@ class ConfigController extends FormController
                     $postvalue = preg_replace("/\s+/", "", $postvalue);
                 }
 
-                // No matter what got posted, we only store config parameters defined
-                // in the config class. Anything else posted gets ignored.
-                if (\array_key_exists($postname, $properties)) {
-                    KunenaConfig::getInstance()->set($postname, $postvalue);
-                }
+
+                $kconfig->set($postname, $postvalue);
             }
         }
 
-        KunenaConfig::getInstance()->save();
+        $kconfig->save();
 
         KunenaFactory::loadLanguage('com_kunena.controllers', 'admin');
 

--- a/src/admin/src/Model/ToolsModel.php
+++ b/src/admin/src/Model/ToolsModel.php
@@ -690,7 +690,7 @@ class ToolsModel extends AdminModel
         $config = KunenaConfig::getInstance();
 
         if ($config) {
-            $params = $config->getProperties();
+            $params = get_object_vars($config);
 
             $kconfigSettings = '[table]';
             $kconfigSettings .= '[tr][th]Kunena config settings:[/th][/tr]';

--- a/src/libraries/kunena/src/Database/KunenaDatabaseObject.php
+++ b/src/libraries/kunena/src/Database/KunenaDatabaseObject.php
@@ -218,7 +218,7 @@ abstract class KunenaDatabaseObject extends CMSObject
 
         // Initialize table object.
         $table = $this->getTable();
-        $table->bind($this->getProperties());
+        $table->bind($this->getTableProperties());
         $table->exists($this->_exists);
         $isNew = !$this->_exists;
 
@@ -310,7 +310,7 @@ abstract class KunenaDatabaseObject extends CMSObject
 
         // Initialize table object.
         $table = $this->getTable();
-        $table->bind($this->getProperties());
+        $table->bind($this->getTableProperties());
         $table->exists($this->_exists);
 
         // Include the Kunena plugins for the on save events.
@@ -357,5 +357,21 @@ abstract class KunenaDatabaseObject extends CMSObject
         }
 
         return $return;
+    }
+
+    /**
+     * Get the table relevant properties. Override for your specific Object
+     * 
+     * @return array    Assocative array with the propertie values of table
+     * 
+     * @since   Kunena 6.4
+     */
+    protected function getTableProperties() : array
+    {
+        $properties = [
+            'id' => $this->id,
+        ];
+
+        return $properties;
     }
 }

--- a/src/libraries/kunena/src/Forum/Category/KunenaCategory.php
+++ b/src/libraries/kunena/src/Forum/Category/KunenaCategory.php
@@ -54,6 +54,7 @@ use Kunena\Forum\Libraries\User\KunenaUserHelper;
  * @property int     $parentid
  * @property string  $name
  * @property string  $alias
+ * @property string  $icon
  * @property int     $icon_id
  * @property int     $locked
  * @property string  $accesstype
@@ -73,6 +74,7 @@ use Kunena\Forum\Libraries\User\KunenaUserHelper;
  * @property int     $hits
  * @property string  $description
  * @property string  $headerdesc
+ * @property string  $topictemplate
  * @property string  $class_sfx
  * @property int     $allowPolls
  * @property string  $topicOrdering
@@ -83,8 +85,6 @@ use Kunena\Forum\Libraries\User\KunenaUserHelper;
  * @property int     $last_post_id
  * @property int     $last_post_time
  * @property string  $params
- * @property string  $topictemplate
- * @property string  $sectionheaderdesc
  * @property int     $allowRatings
  *
  * @since   Kunena 6.0
@@ -227,6 +227,12 @@ class KunenaCategory extends KunenaDatabaseObject
     public $icon;
 
     /**
+     * @var     int
+     * @since   Kunena 6.0
+     */
+    public $icon_id;
+
+    /**
      * @var     string
      * @since   Kunena 6.0
      */
@@ -359,12 +365,6 @@ class KunenaCategory extends KunenaDatabaseObject
     protected $_table = 'KunenaCategories';
 
     /**
-     * @var     string
-     * @since   Kunena 6.0
-     */
-    protected $sectionheaderdesc;
-
-    /**
      * @var     integer
      * @since   Kunena 6.0
      */
@@ -403,12 +403,6 @@ class KunenaCategory extends KunenaDatabaseObject
         }
 
         $this->_alias = $this->get('alias', '');
-
-        if (!empty($this->description)) {
-            $this->sectionheaderdesc = $this->description;
-        } else {
-            $this->sectionheaderdesc = '';
-        }
     }
 
     /**
@@ -636,6 +630,57 @@ class KunenaCategory extends KunenaDatabaseObject
         KunenaProfiler::getInstance() ? KunenaProfiler::instance()->stop('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
 
         return $this->_channels[$action];
+    }
+
+    /**
+     * Get the table relevant properties. Override for your specific Object
+     * 
+     * @return array    Assocative array with the propertie values of table
+     * 
+     * @since   Kunena 6.4
+     */
+    protected function getTableProperties() : array
+    {
+        $properties = [
+            'id' => $this->id,
+            'parentid' => $this->parentid,
+            'name' => $this->name,
+            'alias' => $this->alias,
+            'icon' => $this->icon,
+            'icon_id' => $this->icon_id,
+            'locked' => $this->locked,
+            'accesstype' => $this->accesstype,
+            'access' => $this->access,
+            'pubAccess' => $this->pubAccess,
+            'pubRecurse' => $this->pubRecurse,
+            'adminAccess' => $this->adminAccess,
+            'adminRecurse' => $this->adminRecurse,
+            'ordering' => $this->ordering,
+            'published' => $this->published,
+            'channels' => $this->channels,
+            'checked_out' => $this->checked_out,
+            'checked_out_time' => $this->checked_out_time,
+            'review' => $this->review,
+            'allowAnonymous' => $this->allowAnonymous,
+            'postAnonymous' => $this->postAnonymous,
+            'hits' => $this->hits,
+            'description' => $this->description,
+            'headerdesc' => $this->headerdesc,
+            'topictemplate' => $this->topictemplate,
+            'class_sfx' => $this->class_sfx,
+            'allowPolls' => $this->allowPolls,
+            'topicOrdering' => $this->topicOrdering,
+            'iconset' => $this->iconset,
+            'numTopics' => $this->numTopics,
+            'numPosts' => $this->numPosts,
+            'last_topic_id' => $this->last_topic_id,
+            'last_post_id' => $this->last_post_id,
+            'last_post_time' => $this->last_post_time,
+            'params' => $this->params,
+            'allowRatings' => $this->allowRatings
+        ];
+
+        return $properties;
     }
 
     /**
@@ -1579,7 +1624,7 @@ class KunenaCategory extends KunenaDatabaseObject
 
         // Create the user table object
         $table = $this->getTable();
-        $table->bind($this->getProperties());
+        $table->bind($this->getTableProperties());
         $table->exists($this->_exists);
         $result = $table->checkout($who);
 
@@ -1606,7 +1651,7 @@ class KunenaCategory extends KunenaDatabaseObject
 
         // Create the user table object
         $table = $this->getTable();
-        $table->bind($this->getProperties());
+        $table->bind($this->getTableProperties());
         $table->exists($this->_exists);
         $result = $table->checkIn();
 
@@ -1639,7 +1684,7 @@ class KunenaCategory extends KunenaDatabaseObject
 
         // Create the user table object
         $table = $this->getTable();
-        $table->bind($this->getProperties());
+        $table->bind($this->getTableProperties());
         $table->exists($this->_exists);
 
         return $table->isCheckedOut($userid);
@@ -1813,7 +1858,7 @@ class KunenaCategory extends KunenaDatabaseObject
     {
         // Reorder categories
         $table = $this->getTable();
-        $table->bind($this->getProperties());
+        $table->bind($this->getTableProperties());
         $table->exists($this->_exists);
 
         // Update alias

--- a/src/libraries/kunena/src/Route/KunenaRoute.php
+++ b/src/libraries/kunena/src/Route/KunenaRoute.php
@@ -371,12 +371,6 @@ abstract class KunenaRoute
             $language     = strtolower(Factory::getApplication()->getDocument()->getLanguage());
             self::$search = false;
 
-            if (KunenaConfig::getInstance()->get('cache_mid')) {
-                // FIXME: Experimental caching.
-                $cache = Factory::getContainer()->get(CacheControllerFactoryInterface::class)->createCacheController();
-                self::$search = unserialize($cache->get('search', "com_kunena.route.v1.{$language}.{$user->userid}"));
-            }
-
             if (self::$search === false) {
                 self::$search         = [];
                 self::$search['home'] = [];


### PR DESCRIPTION
Based on #9727 and need to be merged first
 
#### Summary of Changes 
Implement alternatives for CMSObj getProperties and remove the CMSObj as parent from KunenaConfig 

#### Testing Instructions