### PR TITLE
Ul items misplaced for thumbnail attachments

### DIFF
--- a/src/site/template/aurelia/layouts/message/item/default.php
+++ b/src/site/template/aurelia/layouts/message/item/default.php
@@ -124,11 +124,11 @@ $list = [];
 
 <?php if (!empty($attachments)) : 
     if (!$this->me->exists() && ($this->config->showImgForGuest || $this->config->showFileForGuest ) || $this->me->exists()) : ?> 	
-			<?php if ($attachs->inline != count($attachments) && $attachs->totalPrivate != count($attachments) || $this->me->isModerator($this->topic->getCategory()) && $attachs->totalPrivate == count($attachments)) : ?>
-			<div class="card pb-3 pd-3 mb-3">
+					<div class="card pb-3 pd-3 mb-3">
+                    <?php if ($attachs->inline != count($attachments) && $attachs->totalPrivate != count($attachments) || $this->me->isModerator($this->topic->getCategory()) && $attachs->totalPrivate == count($attachments)) : ?>
             	<div class="card-header"><?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?></div>
-            		<div class="card-body kattach">                		
-             <?php endif; ?>
+            	      <div class="card-body kattach">          		
+             <?php endif; ?>	
             			<ul class="thumbnails" style="list-style:none;">   		
 						<?php foreach ($attachments as $attachment) :	
 
@@ -166,11 +166,11 @@ $list = [];
                                     </div>
                                 </li>
                         <?php endif;
-
+	
 						endforeach; ?>
-						</ul>
+						</ul></div>
 						<?php if ($attachs->inline != count($attachments) && $attachs->totalPrivate != count($attachments) || $this->me->isModerator($this->topic->getCategory()) && $attachs->totalPrivate == count($attachments)) : ?>						
-            		</div>
+            	
             	</div>
 			<div class="clearfix"></div>
 			<?php endif; ?>
@@ -229,3 +229,4 @@ $list = [];
         ?>
     </div>
 <?php endif;
+

--- a/src/site/template/aurelia/layouts/topic/edit/history/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/history/default.php
@@ -68,12 +68,13 @@ use Kunena\Forum\Libraries\Icons\KunenaIcons;
 
                     if (!empty($attachments)) :
                         ?>
-                        <div class="kattach col-md-12">
-                            <h4><?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?></h4>
+                  <div class="card pb-3 pd-3 mb-3">
+                         
+            	      <div class="card-body kattach">        
                             <ul class="thumbnails">
                                 <?php foreach ($attachments as $attachment) :
                                     ?>
-                                    <li class="col-md-4">
+                                  <li class="col-md-3 text-center">
                                         <div class="thumbnail">
                                             <?php echo $attachment->getLayout()->render('thumbnail'); ?>
                                             <?php echo $attachment->getLayout()->render('textlink'); ?>
@@ -81,7 +82,7 @@ use Kunena\Forum\Libraries\Icons\KunenaIcons;
                                     </li>
                                 <?php endforeach; ?>
                             </ul>
-                        </div>
+                        </div></div>
                     <?php endif; ?>
                 </div>
             </div>


### PR DESCRIPTION
Issue #9722 
As far as I can test, this should be the final solution for this problem.

Pull Request for Issue # . 
 
#### Summary of Changes 
When attachments are inline thumbnails are now placed in a div and nicely above buttons and last edited bar. 

![2024-09-13 Screenshot 583](https://github.com/user-attachments/assets/00af6fdc-9047-4e94-8779-58745727d647)

As mentionned in my last reaction in original issue a thumbnail have always been displayed when an image has been inserted into the post.
 
#### Testing Instructions