### PR TITLE
Change: add title to labels on topic moderation icons

### DIFF
--- a/src/site/template/aurelia/layouts/topic/moderate/default.php
+++ b/src/site/template/aurelia/layouts/topic/moderate/default.php
@@ -43,40 +43,40 @@ $labels          = $this->ktemplate->params->get('labels');
     </div>
     <div class="card-body">
         <form action="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic') ?>" method="post"
-              name="myform" id="myform" class="form-horizontal">
-            <input type="hidden" name="task" value="move"/>
-            <input type="hidden" name="catid" value="<?php echo $this->category->id; ?>"/>
-            <input type="hidden" name="id" value="<?php echo $this->topic->id; ?>"/>
+            name="myform" id="myform" class="form-horizontal">
+            <input type="hidden" name="task" value="move" />
+            <input type="hidden" name="catid" value="<?php echo $this->category->id; ?>" />
+            <input type="hidden" name="id" value="<?php echo $this->topic->id; ?>" />
             <?php
             if (isset($this->message)) :
-                ?>
-                <input type="hidden" name="mesid" value="<?php echo $this->message->id; ?>"/>
+            ?>
+                <input type="hidden" name="mesid" value="<?php echo $this->message->id; ?>" />
             <?php endif; ?>
             <?php echo HTMLHelper::_('form.token'); ?>
             <div>
                 <ul class="nav nav-tabs" id="myTab" role="tablist">
                     <li class="nav-item">
                         <a class="nav-link active" id="tab1-tab" data-bs-toggle="tab" href="#tab1" role="tab"
-                           aria-controls="tab1"
-                           aria-selected="true"><?php echo Text::_('COM_KUNENA_TITLE_MODERATE_TAB_BASIC_INFO'); ?></a>
+                            aria-controls="tab1"
+                            aria-selected="true"><?php echo Text::_('COM_KUNENA_TITLE_MODERATE_TAB_BASIC_INFO'); ?></a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" id="tab2-tab" data-bs-toggle="tab" href="#tab2" role="tab"
-                           aria-controls="tab2"
-                           aria-selected="false"><?php echo Text::_('COM_KUNENA_TITLE_MODERATE_TAB_MOVE_OPTIONS'); ?></a>
+                            aria-controls="tab2"
+                            aria-selected="false"><?php echo Text::_('COM_KUNENA_TITLE_MODERATE_TAB_MOVE_OPTIONS'); ?></a>
                     </li>
                     <?php if (isset($this->message) && $this->message->getAuthor()->id != 0) :
-                        ?>
+                    ?>
                         <li class="nav-item">
                             <a class="nav-link" id="tab3-tab" data-bs-toggle="tab" href="#tab3" role="tab"
-                               aria-controls="tab3"
-                               aria-selected="false"><?php echo Text::_('COM_KUNENA_TITLE_MODERATE_TAB_BAN_HISTORY'); ?></a>
+                                aria-controls="tab3"
+                                aria-selected="false"><?php echo Text::_('COM_KUNENA_TITLE_MODERATE_TAB_BAN_HISTORY'); ?></a>
                         </li>
                         <!--  <li><a href="#tab4" data-bs-toggle="tab"><?php // Echo Text::_('COM_KUNENA_TITLE_MODERATE_TAB_NEW_BAN');
-                        ?></a></li> -->
+                                                                        ?></a></li> -->
                     <?php endif; ?>
                 </ul>
-                <br/>
+                <br />
                 <div class="tab-content" id="myTabContent">
                     <div class="tab-pane fade show active" id="tab1" role="tabpanel" aria-labelledby="tab1-tab">
                         <dl class="dl-horizontal">
@@ -85,88 +85,88 @@ $labels          = $this->ktemplate->params->get('labels');
                             <dt> <?php echo Text::_('COM_KUNENA_CATEGORY'); ?> </dt>
                             <dd> <?php echo $this->category->displayField('name') ?> </dd>
                             <?php if (isset($this->userLink)) :
-                                ?>
+                            ?>
                                 <dt> <?php echo Text::_('JGLOBAL_USERNAME'); ?> </dt>
                                 <dd><strong> <?php echo $this->userLink; ?></strong></dd>
                             <?php endif; ?>
                         </dl>
                         <?php if ($this->config->topicIcons) :
-                            ?>
+                        ?>
                             <div><?php echo Text::_('COM_KUNENA_MODERATION_CHANGE_TOPIC_ICON'); ?>:</div>
-                            <br/>
+                            <br />
                             <div class="kmoderate-topicIcons">
                                 <?php foreach ($this->topicIcons as $icon) :
-                                    ?>
-                                <input type="radio" id="radio<?php echo $icon->id ?>" name="topic_emoticon"
-                                       value="<?php echo $icon->id ?>" <?php echo !empty($icon->checked) ? ' checked="checked" ' : '' ?> />
+                                ?>
+                                    <input type="radio" id="radio<?php echo $icon->id ?>" name="topic_emoticon"
+                                        value="<?php echo $icon->id ?>" <?php echo !empty($icon->checked) ? ' checked="checked" ' : '' ?> />
                                     <?php if ($this->config->topicIcons && $topicicontype == 'svg') :
+                                    ?>
+                                        <label class="radio inline" for="radio<?php echo $icon->id; ?>" title="<?php echo Text::_($icon->title); ?>">
+                                            <?php
+                                            if (!$this->category->iconset) :
+                                                $this->category->iconset = 'default';
+                                            endif; ?>
+                                            <?php echo KunenaSvgIcons::loadsvg($icon->svg, 'usertopicIcons', $this->category->iconset); ?>
+                                        <?php elseif ($this->config->topicIcons && $topicicontype == 'fa') :
                                         ?>
-                                <label class="radio inline" for="radio<?php echo $icon->id; ?>">
-                                        <?php
-                                        if (!$this->category->iconset) :
-                                            $this->category->iconset = 'default';
-                                        endif; ?>
-                                        <?php echo KunenaSvgIcons::loadsvg($icon->svg, 'usertopicIcons', $this->category->iconset); ?>
-                                    <?php elseif ($this->config->topicIcons && $topicicontype == 'fa') :
-                                        ?>
-                                    <label class="radio inline" for="radio<?php echo $icon->id; ?>"><i
-                                                class="fa fa-<?php echo $icon->fa; ?> glyphicon-topic fa-2x"></i>
-                                    <?php else :
-                                        ?>
-                                        <label class="radio inline" for="radio<?php echo $icon->id; ?>"><img
-                                                    loading=lazy
-                                                    src="<?php echo $icon->relpath; ?>"
-                                                    alt="<?php echo $icon->name; ?>"
-                                                    style=border:0;/>
-                                    <?php endif; ?>
-                                        </label>
-                                <?php endforeach; ?>
+                                            <label class="radio inline" for="radio<?php echo $icon->id; ?>" title="<?php echo Text::_($icon->title); ?>"><i
+                                                    class="fa fa-<?php echo $icon->fa; ?> glyphicon-topic fa-2x"></i>
+                                            <?php else :
+                                            ?>
+                                                <label class="radio inline" for="radio<?php echo $icon->id; ?>" title="<?php echo Text::_($icon->title); ?>"><img
+                                                        loading=lazy
+                                                        src="<?php echo $icon->relpath; ?>"
+                                                        alt="<?php echo $icon->name; ?>"
+                                                        style=border:0; />
+                                                <?php endif; ?>
+                                                </label>
+                                            <?php endforeach; ?>
                             </div>
                         <?php elseif ($labels && !$this->config->topicIcons) :
-                            ?>
+                        ?>
                             <div><strong><?php echo Text::_('COM_KUNENA_MODERATION_CHANGE_LABEL'); ?>:</strong></div>
-                            <br/>
+                            <br />
                             <div class="kmoderate-topicIcons">
                                 <?php foreach ($this->topicIcons as $icon) :
-                                    ?>
-                                <input type="radio" id="radio<?php echo $icon->id ?>" name="topic_emoticon"
-                                       value="<?php echo $icon->id ?>" <?php echo !empty($icon->checked) ? ' checked="checked" ' : '' ?> />
+                                ?>
+                                    <input type="radio" id="radio<?php echo $icon->id ?>" name="topic_emoticon"
+                                        value="<?php echo $icon->id ?>" <?php echo !empty($icon->checked) ? ' checked="checked" ' : '' ?> />
                                     <?php if ($topicicontype == 'svg') :
+                                    ?>
+                                        <label class="radio inline" for="radio<?php echo $icon->id; ?>" title="<?php echo Text::_($icon->title); ?>">
+                                            <?php
+                                            if (!$this->category->iconset) :
+                                                $this->category->iconset = 'default';
+                                            endif; ?>
+                                            <?php echo KunenaSvgIcons::loadsvg($icon->svg, 'usertopicIcons', $this->category->iconset); ?>
+                                        <?php elseif ($topicicontype == 'fa') :
                                         ?>
-                                <label class="radio inline" for="radio<?php echo $icon->id; ?>">
-                                        <?php
-                                        if (!$this->category->iconset) :
-                                            $this->category->iconset = 'default';
-                                        endif; ?>
-                                        <?php echo KunenaSvgIcons::loadsvg($icon->svg, 'usertopicIcons', $this->category->iconset); ?>
-                                    <?php elseif ($topicicontype == 'fa') :
-                                        ?>
-                                    <label class="radio inline" for="radio<?php echo $icon->id; ?>"><i
-                                                class="fa fa-<?php echo $icon->fa; ?> glyphicon-topic fa-2x"></i>
-                                    <?php else :
-                                        ?>
-                                        <label class="radio inline" for="radio<?php echo $icon->id; ?>"><img
-                                                    loading=lazy
-                                                    src="<?php echo $icon->relpath; ?>"
-                                                    alt="<?php echo $icon->name; ?>"
-                                                    style="border:0;"/>
-                                    <?php endif; ?>
-                                        </label>
-                                <?php endforeach; ?>
+                                            <label class="radio inline" for="radio<?php echo $icon->id; ?>" title="<?php echo Text::_($icon->title); ?>"><i
+                                                    class="fa fa-<?php echo $icon->fa; ?> glyphicon-topic fa-2x"></i>
+                                            <?php else :
+                                            ?>
+                                                <label class="radio inline" for="radio<?php echo $icon->id; ?>" title="<?php echo Text::_($icon->title); ?>"><img
+                                                        loading=lazy
+                                                        src="<?php echo $icon->relpath; ?>"
+                                                        alt="<?php echo $icon->name; ?>"
+                                                        style="border:0;" />
+                                                <?php endif; ?>
+                                                </label>
+                                            <?php endforeach; ?>
                             </div>
-                            <br/>
+                            <br />
                         <?php endif; ?>
-                        <br/>
+                        <br />
                         <?php if (isset($this->message)) :
-                            ?>
-                            <hr/>
-                            <br/>
+                        ?>
+                            <hr />
+                            <br />
                             <h3>
                                 <div class="float-start">
                                     <?php echo $this->message->getAuthor()->getAvatarImage('img-thumbnail', 'list'); ?>
                                 </div>
                                 <?php echo $this->message->displayField('subject'); ?>
-                                <br/>
+                                <br />
                                 <small>
                                     <?php echo Text::_('COM_KUNENA_POSTED_AT') ?>
                                     <?php echo $this->message->getTime()->toSpan('config_postDateFormat', 'config_postDateFormatHover'); ?>
@@ -187,57 +187,57 @@ $labels          = $this->ktemplate->params->get('labels');
 
                         <div class="control-group">
                             <label class="control-label"
-                                   for="modcategorieslist"> <?php echo Text::_('COM_KUNENA_MODERATION_DEST_CATEGORY'); ?> </label>
+                                for="modcategorieslist"> <?php echo Text::_('COM_KUNENA_MODERATION_DEST_CATEGORY'); ?> </label>
 
                             <div class="controls" id="modcategorieslist"> <?php echo $this->getCategoryList(); ?> </div>
                         </div>
                         <div class="control-group">
                             <label class="control-label"
-                                   for="modtopicslist"> <?php echo Text::_('COM_KUNENA_MODERATION_DEST_TOPIC'); ?> </label>
+                                for="modtopicslist"> <?php echo Text::_('COM_KUNENA_MODERATION_DEST_TOPIC'); ?> </label>
 
                             <div class="controls" id="modtopicslist"> <?php echo HTMLHelper::_(
-                                'select.genericlist',
-                                $this->getTopicOptions(),
-                                'targettopic',
-                                'class="form-select"',
-                                'value',
-                                'text',
-                                0,
-                                'kmod_topics'
-                            ); ?> </div>
+                                                                            'select.genericlist',
+                                                                            $this->getTopicOptions(),
+                                                                            'targettopic',
+                                                                            'class="form-select"',
+                                                                            'value',
+                                                                            'text',
+                                                                            0,
+                                                                            'kmod_topics'
+                                                                        ); ?> </div>
                         </div>
                         <div class="control-group" id="kmod_targetid" style="display: none;">
                             <label class="control-label"
-                                   for="modtopicslist"> <?php echo Text::_('COM_KUNENA_MODERATION_TARGET_TOPIC_ID'); ?> </label>
+                                for="modtopicslist"> <?php echo Text::_('COM_KUNENA_MODERATION_TARGET_TOPIC_ID'); ?> </label>
 
                             <div class="controls">
-                                <input type="text" size="7" class="form-control" name="targetid" value=""/>
+                                <input type="text" size="7" class="form-control" name="targetid" value="" />
                             </div>
                         </div>
                         <div class="control-group" id="kmod_subject">
                             <label class="control-label"
-                                   for="kmod_subject"> <?php echo Text::_('COM_KUNENA_MODERATION_TITLE_DEST_SUBJECT'); ?> </label>
+                                for="kmod_subject"> <?php echo Text::_('COM_KUNENA_MODERATION_TITLE_DEST_SUBJECT'); ?> </label>
 
                             <div class="controls">
                                 <input type="text" class="form-control" name="subject" id="ktitle_moderate_subject"
-                                       value="<?php echo !isset($this->message)
-                                           ? $this->topic->displayField('subject')
-                                           : $this->message->displayField('subject'); ?>"
-                                       maxlength="<?php echo $this->escape($this->ktemplate->params->get('SubjectLengthMessage')); ?>"/>
+                                    value="<?php echo !isset($this->message)
+                                                ? $this->topic->displayField('subject')
+                                                : $this->message->displayField('subject'); ?>"
+                                    maxlength="<?php echo $this->escape($this->ktemplate->params->get('SubjectLengthMessage')); ?>" />
                             </div>
                         </div>
                         <?php if (!empty($this->replies)) :
-                            ?>
+                        ?>
                             <div class="control-group">
                                 <div class="controls">
                                     <label class="checkbox">
                                         <input id="kmoderate-mode-selected" type="radio" name="mode" checked="checked"
-                                               value="selected"
-                                               style="display: inline-block;"/>
+                                            value="selected"
+                                            style="display: inline-block;" />
                                         <?php echo Text::_('COM_KUNENA_MODERATION_MOVE_SELECTED'); ?> </label>
                                     <label class="checkbox">
                                         <input id="kmoderate-mode-newer" type="radio" name="mode" value="newer"
-                                               style="display: inline-block;"/>
+                                            style="display: inline-block;" />
                                         <?php echo Text::sprintf('COM_KUNENA_MODERATION_MOVE_NEWER', $this->escape($this->replies)); ?>
                                     </label>
                                 </div>
@@ -247,26 +247,26 @@ $labels          = $this->ktemplate->params->get('labels');
                         <div class="control-group">
                             <div class="controls">
                                 <label class="checkbox">
-                                    <input type="checkbox" name="changesubject" value="1"/>
+                                    <input type="checkbox" name="changesubject" value="1" />
                                     <?php echo Text::_('COM_KUNENA_MODERATION_CHANGE_SUBJECT_ON_REPLIES'); ?> </label>
                             </div>
                         </div>
                         <?php if (!isset($this->message)) :
-                            ?>
+                        ?>
                             <div class="control-group">
                                 <div class="controls">
                                     <label class="checkbox">
                                         <input type="checkbox" <?php if ($this->config->boxGhostMessage) {
-                                            echo ' checked="checked"';
-                                                               } ?>
-                                               name="shadow" value="1"/>
+                                                                    echo ' checked="checked"';
+                                                                } ?>
+                                            name="shadow" value="1" />
                                         <?php echo Text::_('COM_KUNENA_MODERATION_TOPIC_SHADOW'); ?> </label>
                                 </div>
                             </div>
                         <?php endif; ?>
                     </div>
                     <?php if (isset($this->message) && $this->message->getAuthor()->id != 0) :
-                        ?>
+                    ?>
                         <div class="tab-pane fade" id="tab3" role="tabpanel" aria-labelledby="tab3-tab">
                             <?php echo $this->subLayout('User/Ban/History')->set('profile', $this->message->getAuthor())->set('headerText', Text::_('COM_KUNENA_TITLE_MODERATE_TAB_BAN_HISTORY'))->set('banHistory', $this->banHistory)->set('me', $this->me); ?>
                         </div>
@@ -277,19 +277,19 @@ $labels          = $this->ktemplate->params->get('labels');
                         ?>
                 </div>-->
                     <?php endif; ?>
-                    <hr/>
-                    <br/>
+                    <hr />
+                    <br />
                 </div>
             </div>
-            <br/>
+            <br />
             <div class="control-group center">
                 <button name="submit" type="submit"
-                        class="btn btn-outline-success btn-md">
+                    class="btn btn-outline-success btn-md">
                     <?php echo KunenaIcons::save() . ' ' . Text::_('COM_KUNENA_POST_MODERATION_PROCEED'); ?>
                 </button>
 
                 <a href="javascript:window.history.back();"
-                   class="btn btn-outline-primary border"> <?php echo KunenaIcons::cancel() . ' ' . Text::_('COM_KUNENA_BACK'); ?> </a>
+                    class="btn btn-outline-primary border"> <?php echo KunenaIcons::cancel() . ' ' . Text::_('COM_KUNENA_BACK'); ?> </a>
             </div>
         </form>
     </div>


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
When moderating a topic, I always struggle setting the correct topic status as there are only icons (which in my case can be the same).
This change will add the 'icon title' as a HTML title attribute to the icon label. This way, hovering the icons will show the title in the browser.

![image](https://github.com/user-attachments/assets/6e80d029-aac1-48c0-ac50-f40d2865e2bb)

 
#### Testing Instructions
This needs to be tested with different kind op topic labels and topic icons (svg, fa, etc.)