### PR TITLE
Hide private attachments from history

### DIFF
--- a/src/media/kunena/core/js/upload.main.js
+++ b/src/media/kunena/core/js/upload.main.js
@@ -68,51 +68,73 @@ jQuery(function ($) {
     var fileeditinline = 0;
 
     $('#set-secure-all').on('click', function (e) {
-        e.preventDefault();
+    e.preventDefault();
 
-        const child = $('#kattach-list').find('input');
-        const filesidtosetprivate = [];
-        const $this = $(this);
+    const child = $('#kattach-list').find('input');
+    const filesidtosetprivate = [];
+    const $this = $(this);
 
-        child.each(function (i, el) {
-            const elem = $(el);
+    child.each(function (i, el) {
+        const elem = $(el);
 
-            if (!elem.attr('id').match("[a-z]{8}")) {
-                const fileid = elem.attr('id').match("[0-9]{1,8}");
-                filesidtosetprivate.push(fileid);
-            }
-        });
-
-        if (filesidtosetprivate.length !== 0) {
-            $.ajax({
-                url: Joomla.getOptions('com_kunena.kunena_upload_files_set_private') + '&files_id=' + JSON.stringify(filesidtosetprivate),
-                type: 'POST'
-            })
-            .done(function (data) {
-                // Update all individual private buttons
-                $('#files button').each(function() {
-                    const $btn = $(this);
-                    if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))) {
-                        $btn.removeClass('btn-primary')
-                           .addClass('btn-success')
-                           .prop('disabled', true)
-                           .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                                Joomla.Text._('COM_KUNENA_ATTACHMENT_IS_PRIVATE'));
-                    }
-                });
-
-                // Update the set-secure-all button
-                $this.removeClass('btn-primary')
-                     .addClass('btn-success')
-                     .prop('disabled', true)
-                     .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                          Joomla.Text._('COM_KUNENA_ALL_ATTACHMENTS_ARE_PRIVATE'));
-            })
-            .fail(function () {
-                //TODO: handle the error of ajax request
-            });
+        if (!elem.attr('id').match("[a-z]{8}")) {
+            const fileid = elem.attr('id').match("[0-9]{1,8}");
+            filesidtosetprivate.push(fileid);
         }
     });
+
+    if (filesidtosetprivate.length !== 0) {
+        $.ajax({
+            url: Joomla.getOptions('com_kunena.kunena_upload_files_set_private') + '&files_id=' + JSON.stringify(filesidtosetprivate),
+            type: 'POST'
+        })
+        .done(function (data) {
+            // Update all individual private buttons
+            $('#files button').each(function() {
+                const $btn = $(this);
+                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))) {
+                    $btn.removeClass('btn-primary')
+                       .addClass('btn-success')
+                       .prop('disabled', true)
+                       .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
+                            Joomla.Text._('COM_KUNENA_ATTACHMENT_IS_PRIVATE'));
+                    
+                    // Hide the corresponding insert button in the same container
+                    $btn.siblings('button').each(function() {
+                        const $siblingBtn = $(this);
+                        if ($siblingBtn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT')) ||
+                            $siblingBtn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'))) {
+                            $siblingBtn.hide();
+                        }
+                    });
+                }
+            });
+
+            // Update the set-secure-all button
+            $this.removeClass('btn-primary')
+                 .addClass('btn-success')
+                 .prop('disabled', true)
+                 .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
+                      Joomla.Text._('COM_KUNENA_ALL_ATTACHMENTS_ARE_PRIVATE'));
+
+            // Hide both insert and insert-all buttons
+            $('button').each(function() {
+                const $btn = $(this);
+                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT')) ||
+                    $btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE')) ||
+                    $btn.attr('id') === 'insert-all') {
+                    $btn.hide();
+                }
+            });
+
+            // Explicitly hide the insert-all button
+            $('#insert-all').hide();
+        })
+        .fail(function () {
+            //TODO: handle the error of ajax request
+        });
+    }
+});
 
   $('#remove-all').on('click', function (e) {
     e.preventDefault();
@@ -120,7 +142,7 @@ jQuery(function ($) {
     $('#progress').hide();
 
     // Reset insert-all button state
-    $('#insert-all').removeClass('btn-success').addClass('btn-primary');
+    $('#insert-all').removeClass('btn-success').addClass('btn-outline-primary');
     $('#insert-all').html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + Joomla.Text._('COM_KUNENA_UPLOADED_LABEL_INSERT_ALL_BUTTON'));
 
     // Hide action buttons
@@ -214,7 +236,7 @@ jQuery(function ($) {
 });
 
 
-    $('#insert-all').on('click', function (e) {
+   $('#insert-all').on('click', function (e) {
     e.preventDefault();
 
     const child = $('#kattach-list').find('input');
@@ -267,9 +289,7 @@ jQuery(function ($) {
                         Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'));
 
     // Hide the "Set all attachments private" button since they're now inline
-    if ($('#set-secure-all').length > 0) {
-        $('#set-secure-all').hide();
-    }
+    $('#set-secure-all').hide();
 
     // Inserting items in message from edit if they aren't already present
     if ($.isEmptyObject(filesedit) === false) {
@@ -304,79 +324,114 @@ jQuery(function ($) {
     filesedit = null;
 });
 
-      const setPrivateButton = $('<button>')
-        .addClass("btn btn-primary")
-        .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))
-        .on('click', function (e) {
-            e.preventDefault();
-            e.stopPropagation();
+     const setPrivateButton = $('<button>')
+    .addClass("btn btn-primary")
+    .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))
+    .on('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
 
-            const $this = $(this),
+        const $this = $(this),
+        data = $this.data();
+
+        let file_id = 0;
+        if (data.result !== undefined) {
+            file_id = data.result.data.id;
+        } else {
+            file_id = data.id;
+        }
+
+        const files_id = [];
+        files_id.push(file_id);
+
+        $.ajax({
+            url: Joomla.getOptions('com_kunena.kunena_upload_files_set_private') + '&files_id=' + JSON.stringify(files_id),
+            type: 'POST'
+        })
+        .done(function (data) {
+            // Update private button state
+            $this.removeClass('btn-primary')
+                 .addClass('btn-success')
+                 .prop('disabled', true)
+                 .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
+                      Joomla.Text._('COM_KUNENA_ATTACHMENT_IS_PRIVATE'));
+            
+            // Find and hide the insert button in the same container
+            $this.siblings('button').each(function() {
+                const $btn = $(this);
+                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT')) ||
+                    $btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'))) {
+                    $btn.hide();
+                }
+            });
+
+            // Check if all attachments are now private
+            let allPrivate = true;
+            $('#files button').each(function() {
+                const $btn = $(this);
+                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT')) &&
+                    !$btn.prop('disabled')) {
+                    allPrivate = false;
+                    return false; // Break the loop
+                }
+            });
+
+            // If all attachments are private, update the insert-all button
+            if (allPrivate) {
+                $('#insert-all').hide();
+            }
+        })
+        .fail(function () {
+            //TODO: handle the error of ajax request
+        });
+    });
+    const insertButton = $('<button>')
+    .addClass("btn btn-primary")
+    .html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_INSERT'))
+    .on('click', function (e) {
+        // Make sure the button click doesn't submit the form:
+        e.preventDefault();
+        e.stopPropagation();
+
+        const $this = $(this),
             data = $this.data();
 
-            let file_id = 0;
-            if (data.result !== undefined) {
-                file_id = data.result.data.id;
-            } else {
-                file_id = data.id;
+        let file_id = 0;
+        let filename = null;
+        if (data.result !== undefined) {
+            file_id = data.result.data.id;
+            filename = data.result.data.filename;
+        } else {
+            file_id = data.id;
+            filename = data.name;
+        }
+
+        insertInMessage(file_id, filename, $this);
+
+        const files_id = [];
+        files_id.push(file_id);
+
+        // Hide the private button for this attachment
+        $this.siblings('button').each(function() {
+            if ($(this).html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))) {
+                $(this).hide();
             }
+        });
 
-            const files_id = [];
-            files_id.push(file_id);
+        // Hide the set-secure-all button since we're inserting an attachment
+        $('#set-secure-all').hide();
 
-            $.ajax({
-                url: Joomla.getOptions('com_kunena.kunena_upload_files_set_private') + '&files_id=' + JSON.stringify(files_id),
-                type: 'POST'
-            })
+        $.ajax({
+            url: Joomla.getOptions('com_kunena.kunena_upload_files_set_inline') + '&files_id=' + JSON.stringify(files_id),
+            type: 'POST'
+        })
             .done(function (data) {
-                $this.removeClass('btn-primary')
-                     .addClass('btn-success')
-                     .prop('disabled', true)
-                     .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                          Joomla.Text._('COM_KUNENA_ATTACHMENT_IS_PRIVATE'));
+                // Success handler if needed
             })
             .fail(function () {
                 //TODO: handle the error of ajax request
             });
-        });
-
-    const insertButton = $('<button>')
-        .addClass("btn btn-primary")
-        .html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_INSERT'))
-        .on('click', function (e) {
-            // Make sure the button click doesn't submit the form:
-            e.preventDefault();
-            e.stopPropagation();
-
-            const $this = $(this),
-                data = $this.data();
-
-            let file_id = 0;
-            let filename = null;
-            if (data.result !== undefined) {
-                file_id = data.result.data.id;
-                filename = data.result.data.filename;
-            } else {
-                file_id = data.id;
-                filename = data.name;
-            }
-
-            insertInMessage(file_id, filename, $this);
-
-            const files_id = [];
-            files_id.push(file_id);
-
-            $.ajax({
-                url: Joomla.getOptions('com_kunena.kunena_upload_files_set_inline') + '&files_id=' + JSON.stringify(files_id),
-                type: 'POST'
-            })
-                .done(function (data) {
-
-                })
-                .fail(function () {
-                    //TODO: handle the error of ajax request
-                });
-        });
+    });
 
    const removeButton = $('<button/>')
         .addClass('btn btn-danger')

--- a/src/media/kunena/core/js/upload.main.js
+++ b/src/media/kunena/core/js/upload.main.js
@@ -240,42 +240,7 @@ jQuery(function ($) {
         filesedit = null;
     });
 
-    const setPrivateButton = $('<button>')
-        .addClass("btn btn-primary")
-        .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))
-        .on('click', function (e) {
-            // Make sure the button click doesn't submit the form:
-            e.preventDefault();
-            e.stopPropagation();
-
-        const $this = $(this),
-        data = $this.data();
-
-        let file_id = 0;
-        let filename = null;
-        if (data.result !== undefined) {
-            file_id = data.result.data.id;
-            filename = data.result.data.filename;
-        } else {
-            file_id = data.id;
-            filename = data.name;
-        }
-
-        const files_id = [];
-        files_id.push(file_id);
-
-        $.ajax({
-            url: Joomla.getOptions('com_kunena.kunena_upload_files_set_private') + '&files_id=' + JSON.stringify(files_id),
-            type: 'POST'
-        })
-        .done(function (data) {
-
-        })
-        .fail(function () {
-            //TODO: handle the error of ajax request
-        });
-    });
-
+ 
     const insertButton = $('<button>')
         .addClass("btn btn-primary")
         .html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_INSERT'))

--- a/src/media/kunena/core/js/upload.main.js
+++ b/src/media/kunena/core/js/upload.main.js
@@ -391,8 +391,8 @@ jQuery(function ($) {
                          Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENTS_ARE_SECURED'));
             } else if (anyNonPrivate) {
                 // If some attachments are not private, show both buttons
-                $('#insert-all').show();
-                $('#set-secure-all').show();
+                $('#insert-all').hide();
+                $('#set-secure-all').hide();
             }
         })
         .fail(function () {

--- a/src/media/kunena/core/js/upload.main.js
+++ b/src/media/kunena/core/js/upload.main.js
@@ -97,7 +97,7 @@ jQuery(function ($) {
                        .addClass('btn-success')
                        .prop('disabled', true)
                        .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                            Joomla.Text._('COM_KUNENA_ATTACHMENT_IS_PRIVATE'));
+                            Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENT_IS_SECURED'));
                     
                     // Hide the corresponding insert button in the same container
                     $btn.siblings('button').each(function() {
@@ -115,7 +115,7 @@ jQuery(function ($) {
                  .addClass('btn-success')
                  .prop('disabled', true)
                  .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                      Joomla.Text._('COM_KUNENA_ALL_ATTACHMENTS_ARE_PRIVATE'));
+                      Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENTS_ARE_SECURED'));
 
             // Hide both insert and insert-all buttons
             $('button').each(function() {
@@ -324,7 +324,7 @@ jQuery(function ($) {
     filesedit = null;
 });
 
-     const setPrivateButton = $('<button>')
+      const setPrivateButton = $('<button>')
     .addClass("btn btn-primary")
     .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))
     .on('click', function (e) {
@@ -354,7 +354,7 @@ jQuery(function ($) {
                  .addClass('btn-success')
                  .prop('disabled', true)
                  .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                      Joomla.Text._('COM_KUNENA_ATTACHMENT_IS_PRIVATE'));
+                      Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENT_IS_SECURED'));
             
             // Find and hide the insert button in the same container
             $this.siblings('button').each(function() {
@@ -367,18 +367,32 @@ jQuery(function ($) {
 
             // Check if all attachments are now private
             let allPrivate = true;
+            let anyNonPrivate = false;
             $('#files button').each(function() {
                 const $btn = $(this);
-                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT')) &&
-                    !$btn.prop('disabled')) {
-                    allPrivate = false;
-                    return false; // Break the loop
+                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))) {
+                    if (!$btn.prop('disabled')) {
+                        allPrivate = false;
+                        anyNonPrivate = true;
+                        return false; // Break the loop
+                    }
                 }
             });
 
-            // If all attachments are private, update the insert-all button
+            // Update global buttons based on state
             if (allPrivate) {
+                // If all attachments are private, hide both insert-all and set-secure-all
                 $('#insert-all').hide();
+                $('#set-secure-all')
+                    .removeClass('btn-primary')
+                    .addClass('btn-success')
+                    .prop('disabled', true)
+                    .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
+                         Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENTS_ARE_SECURED'));
+            } else if (anyNonPrivate) {
+                // If some attachments are not private, show both buttons
+                $('#insert-all').show();
+                $('#set-secure-all').show();
             }
         })
         .fail(function () {
@@ -730,7 +744,7 @@ jQuery(function ($) {
                                     .addClass('btn-success')
                                     .prop('disabled', true)
                                     .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                                         Joomla.Text._('COM_KUNENA_ATTACHMENT_IS_PRIVATE'));
+                                         Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENT_IS_SECURED'));
                         }
                         
                         object.append(privateBtn);

--- a/src/media/kunena/core/js/upload.main.js
+++ b/src/media/kunena/core/js/upload.main.js
@@ -345,7 +345,7 @@ jQuery(function ($) {
                 });
         });
 
-    const removeButton = $('<button/>')
+   const removeButton = $('<button/>')
         .addClass('btn btn-danger')
         .attr('type', 'button')
         .html(Joomla.getOptions('com_kunena.icons.trash') + ' ' + Joomla.Text._('COM_KUNENA_GEN_REMOVE_FILE'))
@@ -384,10 +384,14 @@ jQuery(function ($) {
             }
 
             $('#alert_max_file').remove();
-            var editor_text = null;
+            
+            // Get editor content while preserving line breaks
+            let editor_text = '';
             if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+                // For CKEditor, getData() already preserves formatting
                 editor_text = CKEDITOR.instances.message.getData();
             } else {
+                // For SCEditor, get raw content with preserved line breaks
                 editor_text = sceditor.instance(document.getElementById('message')).val();
             }
 
@@ -397,24 +401,26 @@ jQuery(function ($) {
 
                 // Ajax Request to delete the file from filesystem
                 $.ajax({
-	                url: Joomla.getOptions('com_kunena.kunena_upload_files_rem') + '&files_id_delete=' + JSON.stringify(file_query_id) + '&editor_text=' + editor_text,
-                type: 'POST'
+                    url: Joomla.getOptions('com_kunena.kunena_upload_files_rem') + '&files_id_delete=' + JSON.stringify(file_query_id) + '&editor_text=' + encodeURIComponent(editor_text),
+                    type: 'POST'
                 })
-	              .done(function (data) {
-	                    $this.parent().remove();
+                .done(function (data) {
+                    $this.parent().remove();
 
-	                    if (data.text_prepared !== false) {
- 	                          if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-							        CKEDITOR.instances.message.setData(data.text_prepared);
-							  } else {
-							        sceditor.instance(document.getElementById('message')).insert(data.text_prepared);
-							  }
-	                    }
-	                })
-	                .fail(function () {
-	                    //TODO: handle the error of ajax request
-	                });
-	            }
+                    if (data.text_prepared !== false) {
+                        if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+                            // Set content while preserving line breaks for CKEditor
+                            CKEDITOR.instances.message.setData(data.text_prepared);
+                        } else {
+                            // Set content while preserving line breaks for SCEditor
+                            sceditor.instance(document.getElementById('message')).val(data.text_prepared);
+                        }
+                    }
+                })
+                .fail(function () {
+                    //TODO: handle the error of ajax request
+                });
+            }
         });
 
     $('#fileupload').fileupload({

--- a/src/site/template/aurelia/layouts/topic/edit/history/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/history/default.php
@@ -1,25 +1,20 @@
 <?php
-
 /**
  * Kunena Component
  *
  * @package         Kunena.Template.Aurelia
  * @subpackage      Topic
  *
- * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/
-
 namespace Kunena\Forum\Site;
-
 \defined('_JEXEC') or die();
-
 use Joomla\CMS\Language\Text;
 use Kunena\Forum\Libraries\Factory\KunenaFactory;
 use Kunena\Forum\Libraries\Html\KunenaParser;
 use Kunena\Forum\Libraries\Icons\KunenaIcons;
-
 ?>
 <div class="float-end">
     <div class="btn btn-outline-primary border btn-small" data-bs-toggle="collapse" data-bs-target="#history">X</div>
@@ -28,14 +23,11 @@ use Kunena\Forum\Libraries\Icons\KunenaIcons;
     <?php echo Text::_('COM_KUNENA_POST_TOPIC_HISTORY') ?>:
     <?php echo $this->escape($this->topic->subject) ?>
 </h3>
-
 <div id="history" class="collapse show">
     <p>
         <?php echo Text::_('COM_KUNENA_POST_TOPIC_HISTORY_MAX') . ' ' . $this->escape($this->config->historyLimit) . ' ' . Text::_('COM_KUNENA_POST_TOPIC_HISTORY_LAST') ?>
     </p>
-    <?php foreach ($this->history as $this->message) :
-        ?>
-
+    <?php foreach ($this->history as $this->message) : ?>
         <div class="row">
             <div class="col-md-2 center">
                 <ul class="unstyled center profilebox">
@@ -46,7 +38,6 @@ use Kunena\Forum\Libraries\Icons\KunenaIcons;
                         <?php
                         $profile    = KunenaFactory::getUser(\intval($this->message->userid));
                         $useravatar = $profile->getAvatarImage(KunenaFactory::getTemplate()->params->get('avatarType'), 'profile');
-
                         if ($useravatar) :
                             echo $this->message->getAuthor()->getLink($useravatar, null, '', '', null, $this->topic->getcategory()->id);
                         endif;
@@ -65,24 +56,42 @@ use Kunena\Forum\Libraries\Icons\KunenaIcons;
                     </div>
                     <?php
                     $attachments = $this->message->getAttachments();
+                    $hasVisibleAttachments = false;
+                    
+                    // Filter out private attachments
+                    $visibleAttachments = array_filter($attachments, function($attachment) {
+                        return $attachment->protected != 32; // Exclude private attachments
+                    });
+                    
+                    if (!empty($visibleAttachments)) :
+                        foreach ($visibleAttachments as $attachment) {
+                            if (!$attachment->inline) {
+                                $hasVisibleAttachments = true;
+                                break;
+                            }
+                        }
+                    endif;
 
-                    if (!empty($attachments)) :
-                        ?>
-                  <div class="card pb-3 pd-3 mb-3">
-                         
-            	      <div class="card-body kattach">        
-                            <ul class="thumbnails">
-                                <?php foreach ($attachments as $attachment) :
-                                    ?>
-                                  <li class="col-md-3 text-center">
-                                        <div class="thumbnail">
-                                            <?php echo $attachment->getLayout()->render('thumbnail'); ?>
-                                            <?php echo $attachment->getLayout()->render('textlink'); ?>
-                                        </div>
-                                    </li>
-                                <?php endforeach; ?>
-                            </ul>
-                        </div></div>
+                    if ($hasVisibleAttachments) : ?>
+                        <div class="card pb-3 pd-3 mb-3">
+                            <div class="card-header">
+                                <?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?>
+                            </div>
+                            <div class="card-body kattach">
+                                <ul class="thumbnails">
+                                    <?php foreach ($visibleAttachments as $attachment) :
+                                        if (!$attachment->inline) : ?>
+                                            <li class="col-md-3 text-center">
+                                                <div class="thumbnail">
+                                                    <?php echo $attachment->getLayout()->render('thumbnail'); ?>
+                                                    <?php echo $attachment->getLayout()->render('textlink'); ?>
+                                                </div>
+                                            </li>
+                                        <?php endif;
+                                    endforeach; ?>
+                                </ul>
+                            </div>
+                        </div>
                     <?php endif; ?>
                 </div>
             </div>

--- a/src/site/template/aurelia/layouts/topic/edit/history/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/history/default.php
@@ -5,7 +5,7 @@
  * @package         Kunena.Template.Aurelia
  * @subpackage      Topic
  *
- * @copyright       Copyright (C) 2008 - 2024 Kunena Team. All rights reserved.
+ * @copyright       Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
  * @license         https://www.gnu.org/copyleft/gpl.html GNU/GPL
  * @link            https://www.kunena.org
  **/


### PR DESCRIPTION
Pull Request for Issue #9766  . 
 
#### Summary of Changes 
Added code to hide private attachments from history
 
#### Testing Instructions
Create topic with at least one private attachment. Logout and login as another user. Private attachment shouldn't be visible anymore in topic history