### PR TITLE
Handle protected attachments the same as non-protected attachments

### DIFF
--- a/src/media/kunena/core/js/upload.main.js
+++ b/src/media/kunena/core/js/upload.main.js
@@ -1,158 +1,25 @@
 /**
- * Kunena Component
- * @package Kunena.Media
- *
- * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
- * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
- * @link https://www.kunena.org
- **/
 
+ * Kunena Component
+
+ * @package Kunena.Media
+
+ *
+
+ * @copyright     Copyright (C) 2008 - @currentyear@ Kunena Team. All rights reserved.
+
+ * @license https://www.gnu.org/copyleft/gpl.html GNU/GPL
+
+ * @link https://www.kunena.org
+
+ **/
 jQuery(function ($) {
     'use strict';
-
-    $.widget('blueimp.fileupload', $.blueimp.fileupload, {
-        options: {
-            // The maximum width of resized images:
-            imageMaxWidth: Joomla.getOptions('com_kunena.imageWidth'),
-            // The maximum height of resized images:
-            imageMaxHeight: Joomla.getOptions('com_kunena.imageHeight')
-        }
-    });
-
-// Modified insertInMessage function to handle both regular and protected attachments
-    function insertInMessage(attachid, filename, button) {
-        // Ensure we have a valid attachment ID
-        if (!attachid && button) {
-            const data = button.data();
-            attachid = data.file_id || data.result?.data?.id || data.id;
-        }
-
-        // Ensure we have a valid filename
-        if (!filename && button) {
-            const data = button.data();
-            filename = data.name || data.result?.data?.filename;
-        }
-
-        // Only proceed if we have both id and filename
-        if (attachid && filename) {
-            const content = ' [attachment=' + attachid + ']' + filename + '[/attachment]';
-            
-            if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-                CKEDITOR.instances.message.insertText(content);
-            } else {
-                sceditor.instance(document.getElementById('message')).insert(content);
-            }
-
-            if (button !== undefined) {
-                button.removeClass('btn-primary')
-                     .addClass('btn-success')
-                     .html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + 
-                          Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'));
-            }
-        }
-    }
-    jQuery.fn.extend({
-        insertAtCaret: function (myValue) {
-            return this.each(function (i) {
-                if (document.selection) {
-                    //For browsers like Internet Explorer
-                    this.focus();
-                    //noinspection JSUnresolvedconstiable
-                    let sel;
-                    sel = document.selection.createRange();
-                    sel.text = myValue;
-                    this.focus();
-                } else if (this.selectionStart || this.selectionStart === '0') {
-                    //For browsers like Firefox and Webkit based
-                    const startPos = this.selectionStart;
-                    const endPos = this.selectionEnd;
-                    const scrollTop = this.scrollTop;
-                    this.value = this.value.substring(0, startPos) + myValue + this.value.substring(endPos, this.value.length);
-                    this.focus();
-                    this.selectionStart = startPos + myValue.length;
-                    this.selectionEnd = startPos + myValue.length;
-                    this.scrollTop = scrollTop;
-                } else {
-                    this.value += myValue;
-                    this.focus();
-                }
-            })
-        }
-    });
-
-    var fileCount = null;
-    var filesedit = null;
-    var fileeditinline = 0;
-
-    $('#set-secure-all').on('click', function (e) {
-    e.preventDefault();
-
-    const child = $('#kattach-list').find('input');
-    const filesidtosetprivate = [];
-    const $this = $(this);
-
-    child.each(function (i, el) {
-        const elem = $(el);
-
-        if (!elem.attr('id').match("[a-z]{8}")) {
-            const fileid = elem.attr('id').match("[0-9]{1,8}");
-            filesidtosetprivate.push(fileid);
-        }
-    });
-
-    if (filesidtosetprivate.length !== 0) {
-        $.ajax({
-            url: Joomla.getOptions('com_kunena.kunena_upload_files_set_private') + '&files_id=' + JSON.stringify(filesidtosetprivate),
-            type: 'POST'
-        })
-        .done(function (data) {
-            // Update all individual private buttons
-            $('#files button').each(function() {
-                const $btn = $(this);
-                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))) {
-                    $btn.removeClass('btn-primary')
-                       .addClass('btn-success')
-                       .prop('disabled', true)
-                       .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                            Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENT_IS_SECURED'));
-                    
-                    // Hide the corresponding insert button in the same container
-                    $btn.siblings('button').each(function() {
-                        const $siblingBtn = $(this);
-                        if ($siblingBtn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT')) ||
-                            $siblingBtn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'))) {
-                            $siblingBtn.hide();
-                        }
-                    });
-                }
-            });
-
-            // Update the set-secure-all button
-            $this.removeClass('btn-primary')
-                 .addClass('btn-success')
-                 .prop('disabled', true)
-                 .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                      Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENTS_ARE_SECURED'));
-
-            // Hide both insert and insert-all buttons
-            $('button').each(function() {
-                const $btn = $(this);
-                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT')) ||
-                    $btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE')) ||
-                    $btn.attr('id') === 'insert-all') {
-                    $btn.hide();
-                }
-            });
-
-            // Explicitly hide the insert-all button
-            $('#insert-all').hide();
-        })
-        .fail(function () {
-            //TODO: handle the error of ajax request
-        });
-    }
-});
-
+    // Single declaration of global variables at the top
+    let fileCount = 0;
+    let filesedit = null;
+    let fileeditinline = 0;
+	  // Add click handler for remove-all button
   $('#remove-all').on('click', function (e) {
     e.preventDefault();
 
@@ -251,9 +118,7 @@ jQuery(function ($) {
     // Remove any alert messages
     $('#alert_max_file').remove();
 });
-
-
-   $('#insert-all').on('click', function (e) {
+  $('#insert-all').on('click', function (e) {
     e.preventDefault();
 
     const child = $('#kattach-list').find('input');
@@ -340,481 +205,468 @@ jQuery(function ($) {
 
     filesedit = null;
 });
-
-       // Modified setPrivateButton to properly handle private attachments
-    const setPrivateButton = $('<button>')
-        .addClass("btn btn-primary")
-        .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-              Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))
-        .on('click', function (e) {
-            e.preventDefault();
-            e.stopPropagation();
-
-            const $this = $(this),
-                  data = $this.data();
-
-            let file_id = data.result?.data?.id || data.id;
-            const files_id = [file_id];
-
-            $.ajax({
-                url: Joomla.getOptions('com_kunena.kunena_upload_files_set_private') + 
-                     '&files_id=' + JSON.stringify(files_id),
-                type: 'POST'
-            })
-            .done(function (data) {
-                // Update private button to show secured state
-                $this.removeClass('btn-primary')
-                     .addClass('btn-success')
-                     .prop('disabled', true)
-                     .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                          Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENT_IS_SECURED'));
-                
-                // Hide the insert button as private attachments cannot be inserted
-                $this.siblings('button').each(function() {
-                    const $btn = $(this);
-                    if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT')) ||
-                        $btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'))) {
-                        $btn.hide();
-                    }
-                });
-
-                // Check if all attachments are now private
-                let allPrivate = true;
-                $('#files button').each(function() {
-                    const $btn = $(this);
-                    if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))) {
-                        if (!$btn.prop('disabled')) {
-                            allPrivate = false;
-                            return false;
-                        }
-                    }
-                });
-
-                if (allPrivate) {
-                    $('#insert-all').hide();
-                    $('#set-secure-all')
-                        .removeClass('btn-primary')
-                        .addClass('btn-success')
-                        .prop('disabled', true)
-                        .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                             Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENTS_ARE_SECURED'));
-                }
-            })
-            .fail(function () {
-                //TODO: handle the error of ajax request
-            });
-        });
-    // Modified insertButton to properly handle protected attachments
-    const insertButton = $('<button>')
-        .addClass("btn btn-primary")
-        .html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + 
-              Joomla.Text._('COM_KUNENA_EDITOR_INSERT'))
-        .on('click', function (e) {
-            e.preventDefault();
-            e.stopPropagation();
-
-            const $this = $(this);
-            const data = $this.data();
-
-            // Check if attachment is private
-            if (data.private) {
-                return; // Don't allow insertion of private attachments
+    $.widget('blueimp.fileupload', $.blueimp.fileupload, {
+        options: {
+            // The maximum width of resized images:
+            imageMaxWidth: Joomla.getOptions('com_kunena.imageWidth'),
+            // The maximum height of resized images:
+            imageMaxHeight: Joomla.getOptions('com_kunena.imageHeight')
+        }
+    });
+    // Function to insert attachments in message
+    function insertInMessage(attachid, filename, button) {
+        // Ensure we have a valid attachment ID
+        if (!attachid && button) {
+            const data = button.data();
+            attachid = data.file_id || data.result?.data?.id || data.id;
+        }
+        // Ensure we have a valid filename
+        if (!filename && button) {
+            const data = button.data();
+            filename = data.name || data.result?.data?.filename;
+        }
+        // Only proceed if we have both id and filename
+        if (attachid && filename) {
+            const content = ' [attachment=' + attachid + ']' + filename + '[/attachment]';
+            if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+                CKEDITOR.instances.message.insertText(content);
+            } else {
+                sceditor.instance(document.getElementById('message')).insert(content);
             }
-
-            // Get file ID from various possible sources
-            const file_id = data.file_id || data.result?.data?.id || data.id;
-            
-            // Get filename - for protected attachments, use the hash/generated name
-            let filename = data.protected ? 
-                (data.hash || data.name) : // Use hash for protected files
-                (data.result?.data?.filename || data.name); // Use regular filename for non-protected
-
-            insertInMessage(file_id, filename, $this);
-
-            // Hide the private button as the attachment is now inline
-            $this.siblings('button').each(function() {
-                if ($(this).html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))) {
-                    $(this).hide();
+            if (button !== undefined) {
+                button.removeClass('btn-primary').addClass('btn-success').html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'));
+            }
+        }
+    }
+    jQuery.fn.extend({
+        insertAtCaret: function (myValue) {
+            return this.each(function (i) {
+                if (document.selection) {
+                    //For browsers like Internet Explorer
+                    this.focus();
+                    let sel = document.selection.createRange();
+                    sel.text = myValue;
+                    this.focus();
+                } else if (this.selectionStart || this.selectionStart === '0') {
+                    //For browsers like Firefox and Webkit based
+                    const startPos = this.selectionStart;
+                    const endPos = this.selectionEnd;
+                    const scrollTop = this.scrollTop;
+                    this.value = this.value.substring(0, startPos) + myValue + this.value.substring(endPos, this.value.length);
+                    this.focus();
+                    this.selectionStart = startPos + myValue.length;
+                    this.selectionEnd = startPos + myValue.length;
+                    this.scrollTop = scrollTop;
+                } else {
+                    this.value += myValue;
+                    this.focus();
                 }
             });
-
-            // Mark as inline
-            if (file_id) {
-                const files_id = [file_id];
-                $.ajax({
-                    url: Joomla.getOptions('com_kunena.kunena_upload_files_set_inline') + 
-                         '&files_id=' + JSON.stringify(files_id),
-                    type: 'POST'
-                });
-            }
-        });
-
-         const removeButton = $('<button/>')
-        .addClass('btn btn-danger')
-        .attr('type', 'button')
-        .html(Joomla.getOptions('com_kunena.icons.trash') + ' ' + Joomla.Text._('COM_KUNENA_GEN_REMOVE_FILE'))
-        .on('click', function (e) {
-            e.preventDefault();
-            e.stopPropagation();
-
-            const $this = $(this);
-            const data = $this.data();
-
-            $('#klabel_info_drop_browse').show();
-
-            let file_id = 0;
-            
-            if (data.result !== undefined) {
-                file_id = data.result.data.id;
-            } else if (data.file_id !== undefined) {
-                file_id = data.file_id;
-            } else if (data.id !== undefined) {
-                file_id = data.id;
-            }
-
-            if (file_id === 0) {
-                console.error('Could not determine file ID');
-                return;
-            }
-
-            // Remove hidden input fields
-            $('#kattachs-' + file_id).remove();
-            $('#kattach-' + file_id).remove();
-
-            fileCount = Math.max(0, fileCount - 1);
-
-            // Update visibility of global buttons
-            if (fileCount === 0) {
-                $('#insert-all').hide();
-                $('#remove-all').hide();
-                $('#set-secure-all').hide();
-            }
-
-            $('#alert_max_file').remove();
-            
-            // Get editor content
-            let editor_text = '';
-            if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-                editor_text = CKEDITOR.instances.message.getData();
-            } else {
-                editor_text = sceditor.instance(document.getElementById('message')).val();
-            }
-
-            // Find and remove the attachment BBCode
-            const attachmentRegex = /\[attachment=[0-9]+\][^[\]]+\[\/attachment\]/g;
-            const cleanedEditorText = editor_text.replace(new RegExp('\\[attachment=' + file_id + '\\][^[\\]]+\\[/attachment\\]'), '');
-
-            // Update editor content with the cleaned text
-            if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-                CKEDITOR.instances.message.setData(cleanedEditorText);
-            } else {
-                sceditor.instance(document.getElementById('message')).val(cleanedEditorText);
-            }
-
-            const file_query_id = [file_id];
-
-            // Enable submit button before AJAX call
-            $('#form_submit_button').prop('disabled', false);
-
-            // Ajax Request to delete the file
-            $.ajax({
-                url: Joomla.getOptions('com_kunena.kunena_upload_files_rem') + '&files_id_delete=' + JSON.stringify(file_query_id) + '&editor_text=' + encodeURIComponent(cleanedEditorText),
-                type: 'POST'
-            })
-            .done(function (data) {
-                // Remove the attachment container
-                $this.closest('div').remove();
-
-                // Ensure submit button is enabled after successful removal
-                setTimeout(function() {
-                    $('#form_submit_button').prop('disabled', false);
-                }, 100);
-            })
-            .fail(function () {
-                // Keep submit button enabled even on failure
-                setTimeout(function() {
-                    $('#form_submit_button').prop('disabled', false);
-                }, 100);
-            })
-            .always(function() {
-                // Final check to ensure button is enabled
-                setTimeout(function() {
-                    $('#form_submit_button').prop('disabled', false);
-                }, 200);
-            });
-        });
-
-    $('#fileupload').fileupload({
-    url: $('#kunena_upload_files_url').val(),
-    dataType: 'json',
-    autoUpload: true,
-    // Enable image resizing, except for Android and Opera,
-    // which actually support image resizing, but fail to
-    // send Blob objects via XHR requests:
-    disableImageResize: /Android(?!.*Chrome)|Opera/
-        .test(window.navigator.userAgent),
-    previewMaxWidth: 100,
-    previewMaxHeight: 100,
-    previewCrop: true
-})
-.bind('fileuploadsubmit', function (e, data) {
-    var params = {};
-    $.each(data.files, function (index, file) {
-        params = {
-            'catid': $('#kunena_upload').val(),
-            'filename': file.name,
-            'size': file.size,
-            'mime': file.type
-        };
+        }
     });
-    data.formData = params;
-})
-.bind('fileuploaddrop', function (e, data) {
-    $('#form_submit_button').prop('disabled', true);
-    $('#remove-all').show();
-    $('#insert-all').show();
-    
-    if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
-        $('#set-secure-all').show();
-    }
+       const setPrivateButton = $('<button>')
+    .addClass("btn btn-primary")
+    .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))
+    .on('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
 
-    $('#kattach_form').show();
+        const $this = $(this),
+        data = $this.data();
 
-    const fileCountTotal = Object.keys(data['files']).length + fileCount;
-
-    if (fileCountTotal > Joomla.getOptions('com_kunena.kunena_upload_files_maxfiles')) {
-        $('<div class="alert alert-danger alert-dismissible fade show" id="alert_max_file" role="alert">' + 
-          Joomla.Text._('COM_KUNENA_UPLOADED_LABEL_ERROR_REACHED_MAX_NUMBER_FILES') + 
-          '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>')
-        .insertBefore($('#files'));
-        
-        $('#form_submit_button').prop('disabled', false);
-        return false;
-    }
-    
-    fileCount = fileCountTotal;
-})
-.bind('fileuploadchange', function (e, data) {
-    $('#form_submit_button').prop('disabled', true);
-    $('#remove-all').show();
-    $('#insert-all').show();
-    
-    if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
-        $('#set-secure-all').show();
-    }
-
-    const fileCountTotal = Object.keys(data['files']).length + fileCount;
-
-    if (fileCountTotal > Joomla.getOptions('com_kunena.kunena_upload_files_maxfiles')) {
-        $('<div class="alert alert-danger alert-dismissible fade show" id="alert_max_file" role="alert">' + 
-          Joomla.Text._('COM_KUNENA_UPLOADED_LABEL_ERROR_REACHED_MAX_NUMBER_FILES') + 
-          '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>')
-        .insertBefore($('#files'));
-        
-        $('#form_submit_button').prop('disabled', false);
-        return false;
-    }
-    
-    fileCount = fileCountTotal;
-})
-.on('fileuploadadd', function (e, data) {
-    $('#progress-bar').css('width', '0%');
-    $('#progress').show();
-
-    data.context = $('<div/>').appendTo('#files');
-
-    $.each(data.files, function (index, file) {
-        const node = $('<p/>').append($('<span/>').text(file.name));
-        if (!index) {
-            node.append('<br>');
+        let file_id = 0;
+        if (data.result !== undefined) {
+            file_id = data.result.data.id;
+        } else {
+            file_id = data.id;
         }
-        node.appendTo(data.context);
-    });
-})
-.on('fileuploadprocessalways', function (e, data) {
-    const index = data.index,
-        file = data.files[index],
-        node = $(data.context.children()[index]);
 
-    if (file.preview) {
-        node.prepend('<br>').prepend(file.preview);
-    }
+        const files_id = [];
+        files_id.push(file_id);
 
-    if (file.error) {
-        node.append('<br>')
-           .append($('<span class="text-danger"/>').text(file.error));
-    }
-
-    if (index + 1 === data.files.length) {
-        data.context.find('button.btn-primary')
-            .text(Joomla.Text._('COM_KUNENA_UPLOADED_LABEL_UPLOAD_BUTTON'))
-            .prop('disabled', !!data.files.error);
-    }
-})
-.on('fileuploaddone', function (e, data) {
-    const progress = parseInt(data.loaded / data.total * 100, 10);
-    $('.progress-bar').css('width', progress + '%')
-                     .prop('aria-valuenow', progress);
-
-    const link = $('<a>').attr('target', '_blank')
-                        .prop('href', data.result.location);
-    
-    data.context.find('span').wrap(link);
-
-    if (data.result.success === true) {
-        $('#form_submit_button').prop('disabled', false);
-
-        // Add hidden inputs for attachments
-        $('#kattach-list').append(
-            '<input id="kattachs-' + data.result.data.id + 
-            '" type="hidden" name="attachments[' + data.result.data.id + ']" value="1" />' +
-            '<input id="kattach-' + data.result.data.id + 
-            '" placeholder="' + data.result.data.filename + 
-            '" type="hidden" name="attachment[' + data.result.data.id + ']" value="1" />'
-        );
-
-        data.uploaded = true;
-
-        // Add action buttons
-        if (data.context.find('button.btn-danger').length) {
-            data.context.find('button.btn-danger').remove();
-        }
-        
-        data.context.append(insertButton.clone(true).data(data));
-        
-        if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
-            data.context.append(setPrivateButton.clone(true).data(data));
-        }
-        
-        data.context.append(removeButton.clone(true).data(data));
-    } else if (data.result.message) {
-        $('#form_submit_button').prop('disabled', false);
-        data.uploaded = false;
-        
-        // Add remove button and show error message
-        data.context.append(removeButton.clone(true).data(data));
-        
-        if (data.result.message.length > 0) {
-            const error = $('<div class="alert alert-danger" role="alert">')
-                .text(data.result.message);
-            data.context.find('span')
-                .append('<br>')
-                .append(error);
-        }
-    }
-})
-.on('fileuploadfail', function (e, data) {
-    $('#form_submit_button').prop('disabled', false);
-    
-    $.each(data.files, function (index, file) {
-        const error = $('<span class="text-danger"/>').text(file.error);
-        $(data.context.children()[index])
-            .append('<br>')
-            .append(error);
-    });
-})
-.prop('disabled', !$.support.fileInput)
-.parent().addClass($.support.fileInput ? undefined : 'disabled');
-
-     // Modified file preload handler to include hash for protected attachments
-    if ($('#kmessageid').val() > 0) {
         $.ajax({
-            type: 'POST',
-            url: Joomla.getOptions('com_kunena.kunena_upload_files_preload'),
-            async: true,
-            dataType: 'json',
-            data: {mes_id: $('#kmessageid').val()}
+            url: Joomla.getOptions('com_kunena.kunena_upload_files_set_private') + '&files_id=' + JSON.stringify(files_id),
+            type: 'POST'
         })
         .done(function (data) {
-            if ($.isEmptyObject(data.files) === false) {
-                fileCount = Object.keys(data.files).length;
-                filesedit = data.files;
-                let allPrivate = true;
-                let hasInlineAttachments = false;
+            // Update private button state
+            $this.removeClass('btn-primary')
+                 .addClass('btn-success')
+                 .prop('disabled', true)
+                 .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
+                      Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENT_IS_SECURED'));
+            
+            // Find and hide the insert button in the same container
+            $this.siblings('button').each(function() {
+                const $btn = $(this);
+                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT')) ||
+                    $btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'))) {
+                    $btn.hide();
+                }
+            });
 
-                $(data.files).each(function (index, file) {
-                    let image = file.image ? 
-                        '<img alt="" src="' + file.path + '" width="100" height="100" /><br />' : 
-                        Joomla.getOptions('com_kunena.icons.attach') + ' <br />';
-
-                    const object = $('<div><p>' + image + '<span>' + file.name + '</span><br /></p></div>');
-                    
-                    const attachmentData = {
-                        file_id: file.id,
-                        uploaded: true,
-                        name: file.name,
-                        hash: file.hash, // Include hash for protected files
-                        inline: file.inline,
-                        private: file.private,
-                        protected: file.protected
-                    };
-
-                    if (!file.private) {
+            // Check if all attachments are now private
+            let allPrivate = true;
+            let anyNonPrivate = false;
+            $('#files button').each(function() {
+                const $btn = $(this);
+                if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))) {
+                    if (!$btn.prop('disabled')) {
                         allPrivate = false;
-                        // Only add insert button for non-private attachments
-                        const insertBtn = insertButton.clone(true).data(attachmentData);
-                        if (file.inline) {
-                            insertBtn.removeClass('btn-primary')
-                                   .addClass('btn-success')
-                                   .html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + 
-                                        Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'));
-                            hasInlineAttachments = true;
-                        }
-                        object.append(insertBtn);
-                    }
-
-                    // Add private button if enabled
-                    if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
-                        const privateBtn = setPrivateButton.clone(true).data(attachmentData);
-                        if (file.private) {
-                            privateBtn.removeClass('btn-primary')
-                                    .addClass('btn-success')
-                                    .prop('disabled', true)
-                                    .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                                         Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENT_IS_SECURED'));
-                        }
-                        object.append(privateBtn);
-                    }
-
-                    object.append(removeButton.clone(true).data(attachmentData));
-                    object.appendTo("#files");
-
-                   // Add form inputs with proper filename handling
-                    const displayName = file.protected ? file.hash : file.name;
-                    $('#kattach-list').append(
-                        '<input id="kattachs-' + file.id + 
-                        '" type="hidden" name="attachments[' + file.id + ']" value="1" />' +
-                        '<input id="kattach-' + file.id + 
-                        '" placeholder="' + displayName + 
-                        '" type="hidden" name="attachment[' + file.id + ']" value="1" />'
-                    );
-                });
-                // Show/hide global buttons based on state
-                if (fileCount > 0) {
-                    $('#remove-all').show();
-                    
-                    if (!hasInlineAttachments && !allPrivate) {
-                        $('#insert-all').show();
-                    }
-                    
-                    if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
-                        if (allPrivate) {
-                            $('#set-secure-all')
-                                .removeClass('btn-primary')
-                                .addClass('btn-success')
-                                .prop('disabled', true)
-                                .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
-                                     Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENTS_ARE_SECURED'))
-                                .show();
-                        } else if (!hasInlineAttachments) {
-                            $('#set-secure-all').show();
-                        }
+                        anyNonPrivate = true;
+                        return false; // Break the loop
                     }
                 }
+            });
+
+            // Update global buttons based on state
+            if (allPrivate) {
+                // If all attachments are private, hide both insert-all and set-secure-all
+                $('#insert-all').hide();
+                $('#set-secure-all')
+                    .removeClass('btn-primary')
+                    .addClass('btn-success')
+                    .prop('disabled', true)
+                    .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
+                         Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENTS_ARE_SECURED'));
+            } else if (anyNonPrivate) {
+                // If some attachments are not private, show both buttons
+                $('#insert-all').hide();
+                $('#set-secure-all').hide();
             }
         })
         .fail(function () {
             //TODO: handle the error of ajax request
         });
-    }
-});
+    });
+	
+    // Modified insertButton to properly handle button visibility
+    const insertButton = $('<button>').addClass("btn btn-primary").html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + Joomla.Text._('COM_KUNENA_EDITOR_INSERT')).on('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const $this = $(this);
+        const data = $this.data();
+        if (data.private) {
+            return;
+        }
+        const file_id = data.file_id || data.result?.data?.id || data.id;
+        const filename = data.protected ? (data.hash || data.name) : (data.result?.data?.filename || data.name);
+        insertInMessage(file_id, filename, $this);
+        // Hide private button after successful insertion
+        $this.siblings('button').each(function () {
+            const $btn = $(this);
+            if ($btn.html().includes(Joomla.Text._('COM_KUNENA_EDITOR_INSERT_PRIVATE_ATTACHMENT'))) {
+                $btn.hide();
+            }
+        });
+        if (file_id) {
+            const files_id = [file_id];
+            $.ajax({
+                url: Joomla.getOptions('com_kunena.kunena_upload_files_set_inline') + '&files_id=' + JSON.stringify(files_id),
+                type: 'POST'
+            });
+        }
+    });
+    const removeButton = $('<button/>').addClass('btn btn-danger').attr('type', 'button').html(Joomla.getOptions('com_kunena.icons.trash') + ' ' + Joomla.Text._('COM_KUNENA_GEN_REMOVE_FILE')).on('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const $this = $(this);
+        const data = $this.data();
+        $('#klabel_info_drop_browse').show();
+        let file_id = 0;
+        if (data.result !== undefined) {
+            file_id = data.result.data.id;
+        } else if (data.file_id !== undefined) {
+            file_id = data.file_id;
+        } else if (data.id !== undefined) {
+            file_id = data.id;
+        }
+        if (file_id === 0) {
+            console.error('Could not determine file ID');
+            return;
+        }
+        $('#kattachs-' + file_id).remove();
+        $('#kattach-' + file_id).remove();
+        fileCount = Math.max(0, fileCount - 1);
+        if (fileCount === 0) {
+            $('#insert-all').hide();
+            $('#remove-all').hide();
+            $('#set-secure-all').hide();
+        }
+        $('#alert_max_file').remove();
+        let editor_text = '';
+        if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+            editor_text = CKEDITOR.instances.message.getData();
+        } else {
+            editor_text = sceditor.instance(document.getElementById('message')).val();
+        }
+        const cleanedEditorText = editor_text.replace(new RegExp('\\[attachment=' + file_id + '\\][^[\\]]+\\[/attachment\\]'), '');
+        if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+            CKEDITOR.instances.message.setData(cleanedEditorText);
+        } else {
+            sceditor.instance(document.getElementById('message')).val(cleanedEditorText);
+        }
+        const file_query_id = [file_id];
+        $('#form_submit_button').prop('disabled', false);
+        $.ajax({
+            url: Joomla.getOptions('com_kunena.kunena_upload_files_rem') + '&files_id_delete=' + JSON.stringify(file_query_id) + '&editor_text=' + encodeURIComponent(cleanedEditorText),
+            type: 'POST'
+        }).done(function (data) {
+            $this.closest('div').remove();
+            setTimeout(function () {
+                $('#form_submit_button').prop('disabled', false);
+            }, 100);
+        }).fail(function () {
+            setTimeout(function () {
+                $('#form_submit_button').prop('disabled', false);
+            }, 100);
+        }).always(function () {
+            setTimeout(function () {
+                $('#form_submit_button').prop('disabled', false);
+            }, 200);
+        });
+    });
+    // Initialize fileupload
+    $('#fileupload').fileupload({
+        url: $('#kunena_upload_files_url').val(),
+        dataType: 'json',
+        autoUpload: true,
+        disableImageResize: /Android(?!.*Chrome)|Opera/.test(window.navigator.userAgent),
+        previewMaxWidth: 100,
+        previewMaxHeight: 100,
+        previewCrop: true
+    }).bind('fileuploadsubmit', function (e, data) {
+        const params = {};
+        $.each(data.files, function (index, file) {
+            Object.assign(params, {
+                'catid': $('#kunena_upload').val(),
+                'filename': file.name,
+                'size': file.size,
+                'mime': file.type
+            });
+        });
+        data.formData = params;
+    }).bind('fileuploaddrop', function (e, data) {
+        $('#form_submit_button').prop('disabled', true);
+        $('#remove-all').show();
+        $('#insert-all').show();
+        if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
+            $('#set-secure-all').show();
+        }
+        $('#kattach_form').show();
+        const fileCountTotal = Object.keys(data['files']).length + fileCount;
+        if (fileCountTotal > Joomla.getOptions('com_kunena.kunena_upload_files_maxfiles')) {
+            $('<div class="alert alert-danger alert-dismissible fade show" id="alert_max_file" role="alert">' + Joomla.Text._('COM_KUNENA_UPLOADED_LABEL_ERROR_REACHED_MAX_NUMBER_FILES') + '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>').insertBefore($('#files'));
+            $('#form_submit_button').prop('disabled', false);
+            return false;
+        }
+        fileCount = fileCountTotal;
+    }).bind('fileuploadchange', function (e, data) {
+        $('#form_submit_button').prop('disabled', true);
+        $('#remove-all').show();
+        $('#insert-all').show();
+        if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
+            $('#set-secure-all').show();
+        }
+        const fileCountTotal = Object.keys(data['files']).length + fileCount;
+        if (fileCountTotal > Joomla.getOptions('com_kunena.kunena_upload_files_maxfiles')) {
+            $('<div class="alert alert-danger alert-dismissible fade show" id="alert_max_file" role="alert">' + Joomla.Text._('COM_KUNENA_UPLOADED_LABEL_ERROR_REACHED_MAX_NUMBER_FILES') + '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>').insertBefore($('#files'));
+            $('#form_submit_button').prop('disabled', false);
+            return false;
+        }
+        fileCount = fileCountTotal;
+    }).on('fileuploadadd', function (e, data) {
+        $('#progress-bar').css('width', '0%');
+        $('#progress').show();
+        data.context = $('<div/>').appendTo('#files');
+        $.each(data.files, function (index, file) {
+            const node = $('<p/>').append($('<span/>').text(file.name));
+            if (!index) {
+                node.append('<br>');
+            }
+            node.appendTo(data.context);
+        });
+    }).on('fileuploadprocessalways', function (e, data) {
+        const index = data.index;
+        const file = data.files[index];
+        const node = $(data.context.children()[index]);
+        if (file.preview) {
+            node.prepend('<br>').prepend(file.preview);
+        }
+        if (file.error) {
+            node.append('<br>').append($('<span class="text-danger"/>').text(file.error));
+        }
+        if (index + 1 === data.files.length) {
+            data.context.find('button.btn-primary').text(Joomla.Text._('COM_KUNENA_UPLOADED_LABEL_UPLOAD_BUTTON')).prop('disabled', !!data.files.error);
+        }
+    }).on('fileuploaddone', function (e, data) {
+        const progress = parseInt(data.loaded / data.total * 100, 10);
+        $('.progress-bar').css('width', progress + '%').prop('aria-valuenow', progress);
+        if (data.result.success === true) {
+            $('#form_submit_button').prop('disabled', false);
+            const link = $('<a>').attr('target', '_blank').prop('href', data.result.location);
+            data.context.find('span').wrap(link);
+            // Add hidden inputs for attachments
+            $('#kattach-list').append('<input id="kattachs-' + data.result.data.id + '" type="hidden" name="attachments[' + data.result.data.id + ']" value="1" />' + '<input id="kattach-' + data.result.data.id + '" placeholder="' + data.result.data.filename + '" type="hidden" name="attachment[' + data.result.data.id + ']" value="1" />');
+            data.uploaded = true;
+            // Create button container
+            const buttonContainer = $('<div class="btn-group mt-2"/>');
+            // Add insert button
+            const insertBtn = insertButton.clone(true).data('result', data.result).appendTo(buttonContainer);
+            // Add private button if enabled
+            if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
+                setPrivateButton.clone(true).data('result', data.result).appendTo(buttonContainer);
+            }
+            // Add remove button
+            removeButton.clone(true).data('result', data.result).appendTo(buttonContainer);
+            data.context.append(buttonContainer);
+        } else if (data.result.message) {
+            $('#form_submit_button').prop('disabled', false);
+            if (data.result.message.length > 0) {
+                const error = $('<div class="alert alert-danger" role="alert">').text(data.result.message);
+                data.context.find('span').append('<br>').append(error);
+            }
+        }
+    }).on('fileuploadfail', function (e, data) {
+        $('#form_submit_button').prop('disabled', false);
+        $.each(data.files, function (index, file) {
+            const error = $('<span class="text-danger"/>').text(file.error || 'Upload failed');
+            $(data.context.children()[index]).append('<br>').append(error);
+        });
+    }).prop('disabled', !$.support.fileInput).parent().addClass($.support.fileInput ? undefined : 'disabled');
+
+// Modified file handling for protected status
+if ($('#kmessageid').val() > 0) {
+    $.ajax({
+        type: 'POST',
+        url: Joomla.getOptions('com_kunena.kunena_upload_files_preload'),
+        async: true,
+        dataType: 'json',
+        data: {
+            mes_id: $('#kmessageid').val()
+        }
+    }).done(function (data) {
+        if ($.isEmptyObject(data.files) === false) {
+            fileCount = Object.keys(data.files).length;
+            filesedit = data.files;
+            let allPrivate = true;
+            let hasInlineAttachments = false;
+
+            $(data.files).each(function (index, file) {
+                // Properly determine protection status
+                const isPrivate = Boolean(file.private) || (file.protected === 32);
+                const isProtected = Boolean(file.protected === 1 || file.protected === 32);
+                
+                // Create the image preview
+                let image = file.image ? '<img alt="" src="' + file.path + '" width="100" height="100" /><br />' : Joomla.getOptions('com_kunena.icons.attach') + ' <br />';
+                const object = $('<div><p>' + image + '<span>' + file.name + '</span><br /></p></div>');
+                
+                // Create button container
+                const buttonContainer = $('<div class="btn-group mt-2"/>');
+
+                // Enhanced attachment data object with corrected protected status
+                const attachmentData = {
+                    file_id: file.id,
+                    uploaded: true,
+                    name: file.name,
+                    hash: file.hash,
+                    inline: Boolean(file.inline),
+                    private: isPrivate,
+                    protected: isProtected,
+                    result: {
+                        data: {
+                            id: file.id,
+                            filename: isProtected ? file.hash : file.name
+                        }
+                    }
+                };
+
+                // Create insert button with updated visibility logic
+                const insertBtn = insertButton.clone(true).data(attachmentData);
+                
+                // Handle button visibility based on corrected status
+                if (isPrivate) {
+                    // For private attachments, hide the insert button
+                    insertBtn.hide();
+                } else if (file.inline) {
+                    // For inline attachments, show as inserted
+                    insertBtn.removeClass('btn-primary')
+                            .addClass('btn-success')
+                            .html(Joomla.getOptions('com_kunena.icons.upload') + ' ' + 
+                                 Joomla.Text._('COM_KUNENA_EDITOR_IN_MESSAGE'));
+                    hasInlineAttachments = true;
+                }
+                buttonContainer.append(insertBtn);
+
+                // Handle private button with updated protection logic
+                if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
+                    const privateBtn = setPrivateButton.clone(true).data(attachmentData);
+                    if (isPrivate) {
+                        // For private attachments, show private button as secured
+                        privateBtn.removeClass('btn-primary')
+                                .addClass('btn-success')
+                                .prop('disabled', true)
+                                .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
+                                     Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENT_IS_SECURED'));
+                    } else if (file.inline) {
+                        // For inline attachments, hide private button
+                        privateBtn.hide();
+                    }
+                    buttonContainer.append(privateBtn);
+                }
+
+                // Add remove button (always visible)
+                buttonContainer.append(removeButton.clone(true).data(attachmentData));
+
+                // Append button container and update form inputs
+                object.append(buttonContainer);
+                object.appendTo("#files");
+
+                // Use hash for protected files, original name otherwise
+                const displayName = isProtected ? file.hash : file.name;
+                $('#kattach-list').append(
+                    '<input id="kattachs-' + file.id + '" type="hidden" name="attachments[' + file.id + ']" value="1" />' +
+                    '<input id="kattach-' + file.id + '" placeholder="' + displayName + '" type="hidden" name="attachment[' + file.id + ']" value="1" />'
+                );
+
+                if (file.inline) {
+                    fileeditinline++;
+                }
+                if (!isPrivate) {
+                    allPrivate = false;
+                }
+            });
+
+            // Update global button visibility
+            if (fileCount > 0) {
+                $('#remove-all').show();
+                
+                // Show insert-all only if there are non-private and non-inline attachments
+                if (!allPrivate && !hasInlineAttachments) {
+                    $('#insert-all').show();
+                } else {
+                    $('#insert-all').hide();
+                }
+
+                if (Joomla.getOptions('com_kunena.privateMessage') == 1) {
+                    if (allPrivate) {
+                        // If all attachments are private, show secured status
+                        $('#set-secure-all')
+                            .removeClass('btn-primary')
+                            .addClass('btn-success')
+                            .prop('disabled', true)
+                            .html(Joomla.getOptions('com_kunena.icons.secure') + ' ' + 
+                                 Joomla.Text._('COM_KUNENA_EDITOR_ATTACHMENTS_ARE_SECURED'))
+                            .show();
+                    } else if (!hasInlineAttachments) {
+                        // Show set-secure-all if there are non-private attachments
+                        $('#set-secure-all').show();
+                    }
+                }
+            }
+        }
+    }).fail(function () {
+        //TODO: handle the error of ajax request
+    });
+}
+   });

--- a/src/site/template/aurelia/layouts/message/edit/quickreply.php
+++ b/src/site/template/aurelia/layouts/message/edit/quickreply.php
@@ -231,9 +231,9 @@ if ($me->canDoCaptcha() && KunenaConfig::getInstance()->quickReply) {
                                                                                                                                                                                         endif; ?> value="<?php echo $message->displayField('subject'); ?>" />
                             </div>
                             <div class="form-group">
-                                <label class="col-md-12 control-label" style="padding:0;">
+                                <div class="col-md-12 control-label" style="padding:0;">
                                     <?php echo Text::_('COM_KUNENA_MESSAGE'); ?>:
-                                </label>
+                                </div>
                                 <?php if ($editor == 1) {
                                     echo $this->subLayout('Widget/Editor')->setLayout('wysibb_quick')->set('message', $this->message)->set('config', $config);
                                 } else {

--- a/src/site/template/aurelia/layouts/topic/edit/default.php
+++ b/src/site/template/aurelia/layouts/topic/edit/default.php
@@ -255,7 +255,7 @@ Text::script('COM_KUNENA_POLL_TITLE');
         <?php if ($this->selectcatlist !== false) : ?>
             <div class="form-group row">
                 <!-- Material input -->
-                <label for="inputCatlist" class="col-sm-2 col-form-label"><?php echo Text::_('COM_KUNENA_CATEGORY') ?></label>
+                <label for="postcatid" class="col-sm-2 col-form-label"><?php echo Text::_('COM_KUNENA_CATEGORY') ?></label>
                 <div class="col-md-10">
                     <div class="md-form mt-0">
                         <div class="controls"> <?php echo $this->selectcatlist ?> </div>
@@ -308,7 +308,7 @@ Text::script('COM_KUNENA_POLL_TITLE');
         <?php if (!empty($this->topicIcons)) : ?>
             <div class="form-group row" id="kpost-topicIcons">
                 <!-- Material input -->
-                <label for="inputIcon" class="col-sm-2 col-form-label"><?php echo Text::_('COM_KUNENA_GEN_TOPIC_ICON'); ?></label>
+                <p class="col-sm-2 col-form-label"><?php echo Text::_('COM_KUNENA_GEN_TOPIC_ICON'); ?></p>
                 <div class="col-md-10">
                     <div id="iconset_inject" class="controls controls-select">
                         <div id="iconset_topicList">


### PR DESCRIPTION
Pull Request for Issue #9769  . 
 
#### Summary of Changes 
When setting Protect Attachments to Yes, protected attachments are now "behaving" like non-protected attachments
When testing discovered another bug: When saving message first and then edit and insert attachment, id was not retreived. Result: `[attachment=undefined]hash[/attachment]`
#### Testing Instructions
Please test carefully, because there ar so many variables in this file.