### PR TITLE
Make sure to set the canonical URL only if the URI string is not empty to avoid `/0` as the href value in the profile view

### DIFF
--- a/src/libraries/kunena/src/Controller/Application/Display.php
+++ b/src/libraries/kunena/src/Controller/Application/Display.php
@@ -282,7 +282,10 @@ class Display extends KunenaControllerDisplay
 
         if (!$limitstart) {
             $uri = trim(strtok(KunenaRoute::_(), '?'));
-            $this->document->addHeadLink($uri, 'canonical', 'rel');
+
+            if ($uri !== '') {
+                $this->document->addHeadLink($uri, 'canonical', 'rel');
+            }
         }
 
         // Initialize breadcrumb.


### PR DESCRIPTION
#### Summary of Changes 

This PR will fix the following error in the profile view:

`<link href="/0" rel="canonical">`

For instance, you can open **rich**'s profile page (https://www.kunena.org/forum/user/2198-rich) and check the source code. You will find the wrongly created canonical URL in the header section. This 404 link is made on each profile page and affects SEO.
 
#### Testing Instructions

Check any profile page in the latest release. Apply the patch, and the incorrect tag will no longer be created.