### PR TITLE
Fix: Category moderator becomes global moderator

### DIFF
--- a/src/admin/src/Model/UsersModel.php
+++ b/src/admin/src/Model/UsersModel.php
@@ -158,7 +158,7 @@ class UsersModel extends ListModel
             $options[] = HTMLHelper::_('select.option', 0, Text::_('COM_KUNENA_GLOBAL_MODERATOR'));
         }
 
-        return HTMLHelper::_('kunenaforum.categorylist', 'catid[]', 0, $options, ['action' => 'admin'], 'class="input-block-level w-100" multiple="multiple" size="5"', 'value', 'text', 0, 'catidmodslist');
+        return HTMLHelper::_('kunenaforum.categorylist', 'catid[]', 0, $options, ['action' => 'admin', 'preselect' => false], 'class="input-block-level w-100" multiple="multiple" size="5"', 'value', 'text', [], 'catidmodslist');
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #9843 . 
 
#### Summary of Changes
removed automatically added 'preselect' value, and set 'selected' to none (emty array instead of 0 which is actually global moderator
 
#### Testing Instructions
Only tested this in the backend as reproduced by instructions in issue.
not sure if this is also impacting other parts of kunena (@xillibit )