### PR TITLE
Update config.xml

### DIFF
--- a/src/site/template/aurelia/config/config.xml
+++ b/src/site/template/aurelia/config/config.xml
@@ -106,7 +106,7 @@
             <option value="both">COM_KUNENA_TEMPLATE_WHOISONLINE_NAME_BOTH</option>
         </field>
         <field name="avatarType" type="list" default="rounded" label="COM_KUNENA_TEMPLATE_PROFILE_TYPE"
-               description="COM_KUNENA_TEMPLATE_PROFILETYPE_DESC">
+               description="COM_KUNENA_TEMPLATE_PROFILE_TYPE_DESC">
             <option value="rounded">COM_KUNENA_TEMPLATE_ROUNDED</option>
             <option value="rounded-circle">COM_KUNENA_TEMPLATE_CIRCLE</option>
             <option value="img-thumbnail">COM_KUNENA_TEMPLATE_THUMBNAIL</option>


### PR DESCRIPTION
The word PROFILETYPE should be separated by an underline. Otherwise, the corresponding text will not be displayed in Aurelia's avatar settings.