### PR TITLE
Updates Community Builder integration for CB 2.10 API compatibility

### DIFF
--- a/src/plugins/plg_kunena_comprofiler/KunenaPrivateComprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/KunenaPrivateComprofiler.php
@@ -15,9 +15,11 @@ namespace Kunena\Forum\Plugin\Kunena\Comprofiler;
 
 \defined('_JEXEC') or die();
 
+use CB\Plugin\PMS\PMSHelper;
+use CB\Plugin\PMS\UddeIM;
 use CBLib\Application\Application;
-use CBLib\Language\CBTxt;
 use Joomla\CMS\Language\Text;
+use Kunena\Forum\Libraries\Factory\KunenaFactory;
 use Kunena\Forum\Libraries\Integration\KunenaPrivate;
 
 /**
@@ -46,75 +48,21 @@ class KunenaPrivateComprofiler extends KunenaPrivate
     }
 
     /**
-     * @param   int  $userid  userid
+     * @param   integer  $userid  userid
      *
-     * @return  string
-     *
-     * @since   Kunena 6.0
-     */
-    public function showIcon(int $userid): string
-    {
-        global $_CB_framework, $_CB_PMS;
-
-        $myid = Application::MyUser()->getUserId();
-
-        // Don't send messages from/to anonymous and to yourself
-        if ($myid == 0 || $userid == 0 || $userid == $myid) {
-            return '';
-        }
-
-        outputCbTemplate(Application::Cms()->getClientId());
-        $resultArray = $_CB_PMS->getPMSlinks($userid, $myid, '', '', 1);
-        $url         = $_CB_framework->userProfileUrl($userid);
-        $html        = '<a href="' . $url . '" title="' .
-            Text::_('COM_KUNENA_VIEW_PMS') . '"><span class="kicon-profile kicon-profile-pm" title="' . Text::_('COM_KUNENA_VIEW_PMS') . '"></span></a>';
-
-        if ($resultArray > 0) {
-            $linkItem = '<span class="pm" alt="' . Text::_('COM_KUNENA_VIEW_PMS') . '" />';
-
-            foreach ($resultArray as $res) {
-                if (\is_array($res)) {
-                    $html .= '<a href="' . cbSef($res["url"]) . '" title="' . CBTxt::T($res["tooltip"]) . '">' . $linkItem . '</a> ';
-                }
-            }
-        }
-
-        return $html;
-    }
-
-    /**
-     * @param   int     $userid  userid
-     * @param   string  $class   class
-     * @param   string  $icon    icon
-     *
-     * @return  string
+     * @return  integer
      *
      * @since   Kunena 6.0
      */
-    public function showNewIcon(int $userid, $class = 'btn btn-small', $icon = 'icon icon-comments-2'): string
+    public function getUnreadCount(int $userid): int
     {
-        global $_CB_framework, $_CB_PMS;
+        global $_CB_PMS;
 
-        $myid = Application::MyUser()->getUserId();
-
-        // Don't send messages from/to anonymous and to yourself
-        if ($myid == 0 || $userid == 0) {
-            return '';
+        if (! $userid) {
+            return 0;
         }
 
-        $url  = $_CB_framework->userProfileUrl($userid);
-        $html = '<a class="' . $class . '" href="' . $url . '" title="' .
-            Text::_('COM_KUNENA_VIEW_PMS') . '"><i class="' . $icon . '"></i>' . Text::_('COM_KUNENA_PM_WRITE') . '</a>';
-
-        if ($userid == $myid) {
-            $pmCount = $this->getUnreadCount($myid);
-            $text    = $pmCount ? Text::sprintf('COM_KUNENA_PMS_INBOX_NEW', $pmCount) : Text::_('COM_KUNENA_PMS_INBOX');
-            $url     = $this->getInboxURL();
-
-            return '<a class="' . $class . '" href="' . $url . '"><i class="' . $icon . '"></i>' . $text . '</a>';
-        }
-
-        return $html;
+        return ( $_CB_PMS->getPMSunreadCount( $userid )[0] ?? 0 );
     }
 
     /**
@@ -124,43 +72,15 @@ class KunenaPrivateComprofiler extends KunenaPrivate
      */
     public function getInboxURL()
     {
-        global $_CB_framework;
-
-        $userid = $this->getCBUserid();
-
-        if ($userid === null) {
-            return;
-        }
-
-        return $_CB_framework->userProfileUrl($userid);
-    }
-
-    /**
-     * @return  integer|void
-     *
-     * @since   Kunena 6.0
-     */
-    protected function getCBUserid()
-    {
-        global $_CB_framework;
-
-        $cbpath = JPATH_ADMINISTRATOR . '/components/com_comprofiler/plugin.foundation.php';
-
-        if (file_exists($cbpath)) {
-            require_once $cbpath;
-        } else {
-            return;
-        }
+        global $_CB_PMS;
 
         $userid = Application::MyUser()->getUserId();
 
-        $cbUser = \CBuser::getInstance((int) $userid);
-
-        if ($cbUser === null) {
-            return;
+        if (! $userid) {
+            return '';
         }
 
-        return $userid;
+        return ( $_CB_PMS->getPMSlinks( $userid, 0, '', '', 2 )[0]['url'] ?? '' );
     }
 
     /**
@@ -172,19 +92,21 @@ class KunenaPrivateComprofiler extends KunenaPrivate
      */
     public function getInboxLink(string $text)
     {
-        global $_CB_framework;
-
         if (!$text) {
             $text = Text::_('COM_KUNENA_PMS_INBOX');
         }
 
-        $userid = $this->getCBUserid();
-
-        if ($userid === null) {
+        if (! Application::MyUser()->getUserId()) {
             return;
         }
 
-        return '<a href="' . $_CB_framework->userProfileUrl($userid) . '" rel="follow">' . $text . '</a>';
+        $url = $this->getInboxURL();
+
+        if (! $url) {
+            return;
+        }
+
+        return '<a href="' . $url . '" rel="follow">' . $text . '</a>';
     }
 
     /**
@@ -196,5 +118,24 @@ class KunenaPrivateComprofiler extends KunenaPrivate
      */
     protected function getURL(int $userid): string
     {
+        global $_CB_PMS;
+
+        $user = KunenaFactory::getUser($userid);
+
+        if (! $user->exists()) {
+            return '';
+        }
+
+        $myid = Application::MyUser()->getUserId();
+
+        if (UddeIM::isUddeIM()) {
+            if (! $myid || $myid === $user->userid) {
+                return '';
+            }
+        } elseif (! PMSHelper::canMessage( $myid, $user->userid )) {
+            return '';
+        }
+
+        return ( $_CB_PMS->getPMSlinks( $user->userid, $myid, '', '', 1 )[0]['url'] ?? '' );
     }
 }

--- a/src/plugins/plg_kunena_comprofiler/KunenaProfileComprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/KunenaProfileComprofiler.php
@@ -15,6 +15,7 @@ namespace Kunena\Forum\Plugin\Kunena\Comprofiler;
 
 \defined('_JEXEC') or die();
 
+use CB\Database\Table\UserTable;
 use Joomla\CMS\Factory;
 use Kunena\Forum\Libraries\Error\KunenaError;
 use Kunena\Forum\Libraries\Factory\KunenaFactory;
@@ -133,15 +134,12 @@ class KunenaProfileComprofiler extends KunenaProfile
 
         $user = KunenaFactory::getUser($userid);
 
-        if ($user->userid == 0) {
+        if (! $user->exists()) {
             return false;
         }
 
-        // Get CUser object
-        $cbUser = \CBuser::getInstance($user->userid);
-
-        if ($cbUser === null) {
-            return false;
+        if ($task === 'edit') {
+            return $_CB_framework->userProfileEditUrl(null, $xhtml);
         }
 
         return $_CB_framework->userProfileUrl($user->userid, $xhtml);
@@ -229,18 +227,17 @@ class KunenaProfileComprofiler extends KunenaProfile
      */
     public function getProfileName(KunenaUser $user, string $visitorname = '', bool $escape = true): string
     {
-        global $ueConfig;
-
         if ($user->exists()) {
-            if ($ueConfig['name_format'] == 1) {
-                return $user->name;
-            } elseif ($ueConfig['name_format'] == 2) {
-                return $user->name . ' (' . $user->username . ')';
-            } elseif ($ueConfig['name_format'] == 3) {
-                return $user->username;
-            } elseif ($ueConfig['name_format'] == 4) {
-                return $user->username . ' (' . $user->name . ')';
-            }
+            return \CBuser::getUserDataInstance($user->userid)->getFormattedName();
+        }
+
+        if (! $visitorname) {
+            $guestUser = new UserTable();
+
+            $guestUser->set( 'name', $user->name );
+            $guestUser->set( 'username', $user->username );
+
+            return $guestUser->getFormattedName();
         }
 
         return $visitorname;

--- a/src/plugins/plg_kunena_comprofiler/comprofiler.php
+++ b/src/plugins/plg_kunena_comprofiler/comprofiler.php
@@ -13,6 +13,7 @@
 
 defined('_JEXEC') or die();
 
+use CBLib\Core\CBLib;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -41,17 +42,17 @@ class PlgKunenaComprofiler extends CMSPlugin
     /**
      * plgKunenaComprofiler constructor.
      *
-     * @param   object  $subject                The object to observe
-     * @param   array   $config                 An optional associative array of configuration settings.
+     * @param   DispatcherInterface  $subject   The object to observe
+     * @param   array                $config    An optional associative array of configuration settings.
      *                                          Recognized key values include 'name', 'group', 'params', 'language'
      *                                          (this list is not meant to be comprehensive).
      *
      * @throws Exception
      * @since   Kunena 6.0
      */
-    public function __construct(object &$subject, $config = [])
+    public function __construct(&$subject, $config = [])
     {
-        global $ueConfig;
+        global $_PLUGINS;
 
         // Do not load if Kunena version is not supported or Kunena is offline
         if (!(class_exists('Kunena\Forum\Libraries\Forum\KunenaForum') && KunenaForum::isCompatible('6.4') && KunenaForum::enabled())) {
@@ -70,16 +71,21 @@ class PlgKunenaComprofiler extends CMSPlugin
 
         require_once JPATH_ADMINISTRATOR . '/components/com_comprofiler/plugin.foundation.php';
 
+        $this->loadLanguage('plg_kunena_comprofiler.sys', JPATH_ADMINISTRATOR) || $this->loadLanguage('plg_kunena_comprofiler.sys', JPATH_ADMINISTRATOR . '/components/com_kunena');
+
+        if (version_compare($this->minCBVersion, CBLib::version(), '>=')) {
+            if ($app->isClient('administrator')) {
+                $app->enqueueMessage(Text::sprintf('PLG_KUNENA_COMPROFILER_WARN_VERSION', $this->minCBVersion), 'notice');
+            }
+            return;
+        }
+
         cbimport('cb.html');
         cbimport('language.front');
 
+        $_PLUGINS->loadPluginGroup('user');
+
         parent::__construct($subject, $config);
-
-        $this->loadLanguage('plg_kunena_comprofiler.sys', JPATH_ADMINISTRATOR) || $this->loadLanguage('plg_kunena_comprofiler.sys', JPATH_ADMINISTRATOR . '/components/com_kunena');
-
-        if ($app->isClient('administrator') && (!isset($ueConfig ['version']) || version_compare($ueConfig ['version'], $this->minCBVersion) < 0)) {
-            $app->enqueueMessage(Text::sprintf('PLG_KUNENA_COMPROFILER_WARN_VERSION', $this->minCBVersion), 'notice');
-        }
     }
 
     /**


### PR DESCRIPTION
Fixes a few CB integration issues to better utilize CB API.

Pull Request for Issue (https://www.kunena.org/forum/12-Community-Builder/168803-kunena-pms-links-don-t-properly-point-to-cbs-pms#233063) . 
 
#### Summary of Changes 

- Implements compatibility for CB PMS API
- Updates name formatting to utilize CB API to ensure all new, and future, CB name formats are respected
- Implements stricter and safer construct check for CB version to ensure API does not attempt to run on incompatible versions
 
#### Testing Instructions

1. Enable the Kunena CB integration plugin in System > Manage > Plugins
2. Verify the Kunena toolbar dropdown provides proper access to private messages
3. Verify the Kunena toolbar dropdown shows private message unread count
4. Verify the Kunena toolbar dropdown user preferences links to CB profile edit
5. Verify thread sidebar More button has icon to send PMS