### PR TITLE
Fixed: php cli/joomla.php finder:index

### DIFF
--- a/src/libraries/kunena/src/Access/KunenaAccess.php
+++ b/src/libraries/kunena/src/Access/KunenaAccess.php
@@ -145,8 +145,9 @@ class KunenaAccess
         $this->moderatorsByUserid = [];
 
         // Reset read KunenaAccess for the current session
-        $me = KunenaUserHelper::getMyself();
-        Factory::getApplication()->setUserState("com_kunena.user{$me->userid}_read", null);
+        $me  = KunenaUserHelper::getMyself();
+        $app = KunenaFactory::getApplication();
+        $app->setUserState("com_kunena.user{$me->userid}_read", null);
 
         // @var KunenaAccess $access
 
@@ -269,7 +270,7 @@ class KunenaAccess
         if (!$enabled) {
             $enabled = true;
             Factory::getApplication()->getDocument()->addScriptDeclaration(
-            	"function kShowAccessType(htmlclass, el) {
+                "function kShowAccessType(htmlclass, el) {
 	var selectedvalue = el.find(\":selected\").val();
 
 	name = selectedvalue.replace(/[^\\w\\d]+/, '-');
@@ -503,7 +504,7 @@ jQuery(document).ready(function ($) {
 
         if (!isset($read[$user->userid])) {
             $id  = $user->userid;
-            $app = Factory::getApplication();
+            $app = KunenaFactory::getApplication();
 
             // TODO: handle guests/bots with no userstate
             $read[$id] = $app->getUserState("com_kunena.user{$id}_read");

--- a/src/libraries/kunena/src/Factory/KunenaFactory.php
+++ b/src/libraries/kunena/src/Factory/KunenaFactory.php
@@ -15,6 +15,8 @@ namespace Kunena\Forum\Libraries\Factory;
 \defined('_JEXEC') or die();
 
 use Exception;
+use Joomla\CMS\Application\AdministratorApplication;
+use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Factory;
 use Kunena\Forum\Libraries\Config\KunenaConfig;
 use Kunena\Forum\Libraries\Integration\KunenaActivity;
@@ -274,5 +276,52 @@ abstract class KunenaFactory
         $lang->_strings = array_merge($lang->_strings, $strings);
 
         return !empty($strings);
+    }
+
+    /**
+     * Get the Joomla Factory application instance
+     *
+     * In CLI context, returns the application for the given client name (e.g. 'site', 'administrator', or any valid custom client),
+     * falling back to 'site' if not specified.
+     * In non-CLI contexts, returns the current application instance.
+     * 
+     * @param   string  $client  The fallback Application Instance to return when run from 'cli' (Console)
+     *
+     * @return  SiteApplication|AdministratorApplication
+     *
+     * @throws  RuntimeException
+     * @since   Kunena 6.4.3
+     */
+    public static function getApplication(string $client = ''): SiteApplication|AdministratorApplication
+    {
+        if (Factory::getApplication()->isClient('cli')) {
+            if (empty($client)) {
+                $client = 'site';
+            }
+
+            switch ($client) {
+                case 'administrator':
+                    $applicationClass = AdministratorApplication::class;
+                    break;
+
+                case 'site':
+                    $applicationClass = SiteApplication::class;
+                    break;
+
+                default:
+                    $applicationClass = '\\Joomla\\CMS\\Application\\' . \ucfirst($client) . 'Application';
+
+                    if (!class_exists($applicationClass)) {
+                        throw new \RuntimeException('Joomla Application class not found: ' . $applicationClass);
+                    }
+                    break;
+            }
+
+            $app = Factory::getContainer()->get($applicationClass);
+        } else {
+            $app = Factory::getApplication();
+        }
+
+        return $app;
     }
 }

--- a/src/libraries/kunena/src/Route/KunenaRoute.php
+++ b/src/libraries/kunena/src/Route/KunenaRoute.php
@@ -807,10 +807,10 @@ abstract class KunenaRoute
         foreach ($aliases as $object) {
             if (StringHelper::strtolower($alias) == StringHelper::strtolower($object->alias)) {
                 $var         = $object->type != 'legacy' ? $object->type : 'view';
-                $vars [$var] = $object->type != 'layout' ? $object->item : preg_replace('/.*\./', '', $object->item);
+                $vars[$var] = $object->type != 'layout' ? $object->item : preg_replace('/.*\./', '', $object->item);
 
                 if ($var == 'catid') {
-                    $vars ['view'] = 'category';
+                    $vars['view'] = 'category';
                 }
 
                 break;
@@ -833,14 +833,16 @@ abstract class KunenaRoute
         KunenaProfiler::getInstance() ? KunenaProfiler::instance()->start('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
         self::$config = KunenaFactory::getConfig();
 
-        if (Factory::getApplication()->isClient('administrator')) {
+        if (Factory::getApplication()->isClient('administrator') || Factory::getApplication()->isClient('cli')) {
             self::$adminApp = true;
             KunenaProfiler::getInstance() ? KunenaProfiler::instance()->stop('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
 
             return;
         }
 
-        self::$menus   = Factory::getApplication()->getMenu();
+        $app = KunenaFactory::getApplication();
+
+        self::$menus   = $app->getMenu();
         self::$menu    = self::$menus->getMenu();
         self::$default = self::$menus->getDefault();
         $active        = self::$menus->getActive();
@@ -861,7 +863,7 @@ abstract class KunenaRoute
         }
 
         // If values are both in GET and POST, they are only stored in POST
-        $post = Factory::getApplication()->input->post->getArray([]);
+        $post = $app->input->post->getArray([]);
 
         foreach ($post as $key => $value) {
             if (\in_array($key, ['view', 'layout', 'task']) && !preg_match('/[^a-zA-Z0-9_.]/i', $value)) {
@@ -870,7 +872,7 @@ abstract class KunenaRoute
         }
 
         // Make sure that request URI is not broken
-        $get = Factory::getApplication()->input->get->getArray([]);
+        $get = $app->input->get->getArray([]);
 
         foreach ($get as $key => $value) {
             if (preg_match('/[^a-zA-Z]/', $key)) {
@@ -985,7 +987,8 @@ abstract class KunenaRoute
     public static function fixMissingItemID(): int
     {
         $component = ComponentHelper::getComponent('com_kunena');
-        $items     = Factory::getApplication()->getMenu('site')->getItems('component_id', $component->id);
+        $app       = KunenaFactory::getApplication();
+        $items     = $app->getMenu('site')->getItems('component_id', $component->id);
 
         if ($items) {
             return $items[0]->id;

--- a/src/libraries/kunena/src/Template/KunenaTemplate.php
+++ b/src/libraries/kunena/src/Template/KunenaTemplate.php
@@ -319,7 +319,7 @@ class KunenaTemplate
             if ($this->config->activeMenuItem) {
                 $id = htmlspecialchars($this->config->activeMenuItem, ENT_COMPAT, 'UTF-8');
                 $this->addScriptDeclaration(
-                	"
+                    "
 					document.addEventListener('DOMContentLoaded', () => {
 						let activeMenuItem = document.querySelector('" . $id . "');
 						if (activeMenuItem) {
@@ -330,12 +330,12 @@ class KunenaTemplate
                 );
             } else {
                 $Itemid = KunenaRoute::fixMissingItemID();
-                $items  = Factory::getApplication()->getMenu('site')->getItems('link', 'index.php?Itemid=' . $Itemid);
+                $items  = KunenaFactory::getApplication()->getMenu('site')->getItems('link', 'index.php?Itemid=' . $Itemid);
 
                 if ($items) {
                     $id = htmlspecialchars('.item-' . $items[0]->id, ENT_COMPAT, 'UTF-8');
                     $this->addScriptDeclaration(
-                    	"
+                        "
 						document.addEventListener('DOMContentLoaded', () => {
 							let activeMenuItem = document.querySelector('" . $id . "');
 							if (activeMenuItem) {
@@ -357,7 +357,7 @@ class KunenaTemplate
      */
     public function isHmvc()
     {
-        $app = Factory::getApplication();
+        $app = KunenaFactory::getApplication();
 
         if (\is_null($this->hmvc)) {
             if (is_dir(JPATH_THEMES . "/{$app->getTemplate()}/com_kunena/pages")) {
@@ -407,10 +407,10 @@ class KunenaTemplate
      */
     public static function getInstance($name = null)
     {
-        $app = Factory::getApplication();
+        $app = KunenaFactory::getApplication();
 
         if (!$name) {
-            $name = Factory::getApplication()->input->cookie->getString('kunena_template', KunenaFactory::getConfig()->template);
+            $name = $app->input->cookie->getString('kunena_template', KunenaFactory::getConfig()->template);
         }
 
         $name = KunenaPath::clean($name);
@@ -478,9 +478,9 @@ class KunenaTemplate
         if (!strstr($xml, '<config>')) {
             // Update old template files to new format.
             $xml = preg_replace(
-            	['|<params|', '|</params>|', '|<param\s+|', '|</param>|'],
-            	['<config', '</config>', '<field ', '</field>'],
-            	$xml
+                ['|<params|', '|</params>|', '|<param\s+|', '|</param>|'],
+                ['<config', '</config>', '<field ', '</field>'],
+                $xml
             );
         }
 
@@ -511,7 +511,7 @@ class KunenaTemplate
 
         if ($isForumActive) {
             $this->addScriptDeclaration(
-            	'
+                '
 				document.addEventListener("DOMContentLoaded", () => {
 					let currentMenuItem = document.querySelector(".current");
 					let parentMenuItem = document.querySelector(".alias-parent-active");
@@ -585,8 +585,14 @@ class KunenaTemplate
     {
         $types = ['communication' => 'comm', 'user' => 'user', 'moderation' => 'mod'];
         $names = [
-            'unsubscribe' => 'subscribe', 'unfavorite' => 'favorite', 'unsticky' => 'sticky', 'unlock' => 'lock', 'create' => 'newtopic',
-            'quickReply'  => 'reply', 'quote' => 'kquote', 'edit' => 'kedit',
+            'unsubscribe' => 'subscribe',
+            'unfavorite' => 'favorite',
+            'unsticky' => 'sticky',
+            'unlock' => 'lock',
+            'create' => 'newtopic',
+            'quickReply'  => 'reply',
+            'quote' => 'kquote',
+            'edit' => 'kedit',
         ];
 
         $text  = Text::_("COM_KUNENA_BUTTON_{$scope}_{$name}");
@@ -1050,7 +1056,7 @@ HTML;
      */
     public function getTemplatePaths($path = '', $fullpath = false): array
     {
-        $app = Factory::getApplication();
+        $app = KunenaFactory::getApplication();
 
         if ($path) {
             $path = KunenaPath::clean("/$path");

--- a/src/plugins/plg_finder_kunena/kunena.php
+++ b/src/plugins/plg_finder_kunena/kunena.php
@@ -337,7 +337,7 @@ class PlgFinderKunena extends Adapter
     protected function setup()
     {
         // Initialize CLI
-        $api = JPATH_ADMINISTRATOR . '/components/com_kunena/api.php';
+        $api = JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
 
         if (is_file($api)) {
             require_once $api;
@@ -601,7 +601,7 @@ class PlgFinderKunena extends Adapter
     protected function getAccessLevel($catid)
     {
         $category = KunenaCategoryHelper::get($catid);
-        $user =Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById(0);
+        $user = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById(0);
 
         $accesslevels = (array) $user->getAuthorisedViewLevels();
         $groups_r     = (array) Access::getGroupsByUser($user->id, true);


### PR DESCRIPTION
Pull Request for Issue #9669 . 
 
#### Summary of Changes 
the ConsoleApplcations doesn't have all the classes that the Site- and AdministratorApplication.
Kunena only is aware of Site or Administrator (isClient) and as such doesn't handle e.g. updating the smart search index via the console correct.

This PR returns the SiteApplication when in the cli client in those methods that rely either on Site- or AdministratorApplcation being returned by FactorygetApplication().
 
#### Testing Instructions
run ```php cli/joomla.php finder:index``` from the terminal. There should be no errors.

When your site is on a subdirectory, the you also need to set the live_site url in the Joomla configuration: the CLI is NOT aware of the URL that the site is on as that information comes from $_SERVER variables which are not set in the console