### PR TITLE
Fix: Warning: Attempt to read property "id" on null when using cli

### DIFF
--- a/src/libraries/kunena/src/User/KunenaUserHelper.php
+++ b/src/libraries/kunena/src/User/KunenaUserHelper.php
@@ -109,8 +109,9 @@ abstract class KunenaUserHelper
      */
     public static function initialize(): void
     {
-        $id        = Factory::getApplication()->getIdentity()->id;
-        self::$_me = self::$_instances [$id] = new KunenaUser($id);
+        // Get the user ide for the current user, note that when run from the cli we need to set it to 0 as cli cannot handle user methods like getIdentity()
+        $id        = Factory::getApplication()->getIdentity()->id ?? 0;
+        self::$_me = self::$_instances[$id] = new KunenaUser($id);
 
         // Initialize avatar if configured.
         $avatars = KunenaFactory::getAvatarIntegration();
@@ -132,12 +133,12 @@ abstract class KunenaUserHelper
     {
         $id = (int) $id;
 
-        if ($id && !empty(self::$_instances [$id])) {
-            return self::$_instances [$id];
+        if ($id && !empty(self::$_instances[$id])) {
+            return self::$_instances[$id];
         }
 
-        if (!empty(self::$_instances_name [$name])) {
-            return self::$_instances_name [$name];
+        if (!empty(self::$_instances_name[$name])) {
+            return self::$_instances_name[$name];
         }
 
         $user = self::get($id);
@@ -146,7 +147,7 @@ abstract class KunenaUserHelper
             $user->username = $user->name = $name;
         }
 
-        self::$_instances_name [$name] = $user;
+        self::$_instances_name[$name] = $user;
 
         return $user;
     }
@@ -195,11 +196,11 @@ abstract class KunenaUserHelper
             KunenaProfiler::getInstance() ? KunenaProfiler::instance()->stop('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
 
             $newUser = new KunenaUser($id);
-            $newUser->userid = $id;            
-            
+            $newUser->userid = $id;
+
             return $newUser;
-        } elseif ($reload || empty(self::$_instances [$id])) {
-            self::$_instances [$id] = new KunenaUser($id);
+        } elseif ($reload || empty(self::$_instances[$id])) {
+            self::$_instances[$id] = new KunenaUser($id);
 
             // Preload avatar if configured.
             $avatars = KunenaFactory::getAvatarIntegration();
@@ -208,7 +209,7 @@ abstract class KunenaUserHelper
 
         KunenaProfiler::getInstance() ? KunenaProfiler::instance()->stop('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
 
-        return self::$_instances [$id];
+        return self::$_instances[$id];
     }
 
     /**
@@ -267,8 +268,8 @@ abstract class KunenaUserHelper
         $list = [];
 
         foreach ($userids as $userid) {
-            if (isset(self::$_instances [$userid])) {
-                $list [$userid] = self::$_instances [$userid];
+            if (isset(self::$_instances[$userid])) {
+                $list[$userid] = self::$_instances[$userid];
             }
         }
 
@@ -582,14 +583,14 @@ abstract class KunenaUserHelper
                 self::getOnlineUsers();
             }
 
-            $online = isset(self::$_online [$user->userid]) ? (self::$_online [$user->userid]->time > time() - Factory::getApplication()->get('lifetime', 15) * 60) : false;
+            $online = isset(self::$_online[$user->userid]) ? (self::$_online[$user->userid]->time > time() - Factory::getApplication()->get('lifetime', 15) * 60) : false;
         }
 
         if (!$online || ($user->status == 3 && !$user->isMyself() && !self::getMyself()->isModerator())) {
             return -1;
         }
 
-        if ($online && self::$_online [$user->userid]->time < time() - 30) {
+        if ($online && self::$_online[$user->userid]->time < time() - 30) {
             return 1;
         }
 
@@ -774,16 +775,16 @@ abstract class KunenaUserHelper
                 $log = KunenaLog::LOG_USER_REPORT_STOPFORUMSPAM;
 
                 KunenaLog::log(
-                	KunenaLog::TYPE_ACTION,
-                	$log,
-                	[
+                    KunenaLog::TYPE_ACTION,
+                    $log,
+                    [
                         'user_ip_reported'  => $data['ip'],
                         'username_reported' => $data['username'],
                         'email_reported'    => $data['email'],
                     ],
-                	null,
-                	null,
-                	null
+                    null,
+                    null,
+                    null
                 );
             }
 


### PR DESCRIPTION
Pull Request for Issue #9669 . 
 
#### Summary of Changes 
As suspected, cli doesn't know how to handle user methods, so when asking what user is logged in (getIdentity()) it will not result in a user object, but in null.
This PR will handle this situation and will set the ID for the user to 0 (guest)

#### Testing Instructions
turn on error reporting to maximum in Joomla global config
run php cli/joomla.php finder:index

there should be no errors.
Make sure that the indexing works as that is where the difference is.
When indexing is started from the backend (manual), the there is a user logged in. The user is used to determine category access. When run from the cli, there is no user logged in.

I do not think this impacts the search index, but as I do not use that functionality myself I have no means and no knowledge on how to test this.