### PR TITLE
Change: add error handling + small refactoring

### DIFF
--- a/src/libraries/kunena/src/Config/KunenaConfig.php
+++ b/src/libraries/kunena/src/Config/KunenaConfig.php
@@ -1683,9 +1683,9 @@ class KunenaConfig
             if (!$instance) {
                 $instance = new KunenaConfig();
                 $instance->load();
-            }
 
-            $cache->store($instance, 'configuration', 'com_kunena');
+                $cache->store($instance, 'configuration', 'com_kunena');
+            }
         }
 
         return $instance;
@@ -1716,7 +1716,12 @@ class KunenaConfig
 
         if ($config) {
             $params = json_decode($config['params']);
-            $this->bind($params);
+
+            if ($params !== null && \json_last_error() === JSON_ERROR_NONE) {
+                $this->bind($params);
+            } else {
+                throw new Exception(\json_last_error_msg(), 500);
+            }
         }
 
         // Perform custom validation of config data before we let anybody access it.
@@ -1776,11 +1781,10 @@ class KunenaConfig
         foreach ($params as $key => $value) {
             // Check if the key starts with a null byte (indicating a mangled private/protected property)
             // or if it's the specific '_errors' key (if it's not mangled)
-            if (!str_starts_with($key, "\0") && $key !== '_errors') {
+            if (!str_starts_with($key, "\0") && $key !== '_errors' && $key !== 'id') {
                 $cleanedParams[$key] = $value;
             }
         }
-        unset($cleanedParams['id']);
 
         $db->setQuery("REPLACE INTO #__kunena_configuration SET id=1, params={$db->quote(json_encode($cleanedParams))}");
 


### PR DESCRIPTION
Pull Request for Issue #9873 . (part 2)
 
#### Summary of Changes 
 So finally found the root cause!
 In Kunena 6.3.10, the class KunenaConfig extends CMSobject. CMSObject adds the protected _errors property via traits.
When KunenaConfig is instanciated, it is written to cache: the cache data was 'including' the _errors property.
Now when updating to Kunena 6.4.x the KunenaConfig is NOT extending anything, so there is no _errors property.

So the fix I wrote yesterday is actually the correct fix: we need to consider the _errors property even though in Kunena 6.4.x this is not existing any more.

I also move the storing of the cache to only be executed when the config is loaded from the database (it was always storing the cache even when it got the data from the cache.

I added error checking on the json_decode so when this situation is happening again we will at least have an error displaying instead of nothing and continuing with default settings.

#### Testing Instructions
buid new version and try upgrade from pre 6.4.0 version