### PR TITLE
Update TopicListingModeratorDisplay.php

### DIFF
--- a/src/site/src/Controller/Topic/Listing/Moderator/TopicListingModeratorDisplay.php
+++ b/src/site/src/Controller/Topic/Listing/Moderator/TopicListingModeratorDisplay.php
@@ -35,6 +35,21 @@ use Kunena\Forum\Libraries\Controller\KunenaController;
  */
 class TopicListingModeratorDisplay extends ListDisplay
 {
+    public $model;
+
+    public $state;
+
+    public $moreUri;
+
+    public $access;
+
+    public $params;
+
+    public $embedded;
+
+    public $mesIds;
+
+    public $actions;
     /**
      * Prepare topic list for moderators.
      *


### PR DESCRIPTION
Menu-item Moderator Topics throws deprecated error when error_reporting is enabled:
```
 Deprecated: Creation of dynamic property Kunena\Forum\Site\Controller\Topic\Listing\Moderator\TopicListingModeratorDisplay::$embedded is deprecated in D:
 Deprecated: Creation of dynamic property Kunena\Forum\Site\Controller\Topic\Listing\Moderator\TopicListingModeratorDisplay::$actions is deprecated in D:
 
```
Those lines were missing:
 ```
 public $model;

    public $state;

    public $moreUri;

    public $access;

    public $params;

    public $embedded;

    public $mesIds;

    public $actions;
```