### PR TITLE
Cleanup systemplugin + other improvements

### DIFF
--- a/src/admin/src/Dispatcher/Dispatcher.php
+++ b/src/admin/src/Dispatcher/Dispatcher.php
@@ -16,7 +16,6 @@ namespace Kunena\Forum\Administrator\Dispatcher;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Dispatcher\ComponentDispatcher;
-use Kunena\Forum\Libraries\Exception\KunenaExceptionAuthorise;
 use Kunena\Forum\Libraries\Factory\KunenaFactory;
 
 /**
@@ -26,23 +25,20 @@ use Kunena\Forum\Libraries\Factory\KunenaFactory;
  */
 class Dispatcher extends ComponentDispatcher
 {
+    /**
+     * The URL option for the component.
+     *
+     * @var    string
+     */
     protected $option = 'com_kunena';
 
-    protected $defaultController = 'cpanel';
-
-    protected function onBeforeDispatch()
-    {
-        // Load the languages
-        $this->loadLanguage();
-
-        // Apply the view and controller from the request, falling back to the default view/controller if necessary
-        $this->applyViewAndController();
-
-        // Access control
-        $this->checkAccess();
-    }
-
-    protected function loadLanguage()
+    /**
+     * Load the language
+     *
+     * @return  void
+     * @since   6.0.0
+     */
+    protected function loadLanguage(): void
     {
         KunenaFactory::loadLanguage('com_kunena', 'admin');
         KunenaFactory::loadLanguage('com_kunena.views', 'admin');
@@ -53,40 +49,5 @@ class Dispatcher extends ComponentDispatcher
         KunenaFactory::loadLanguage('com_kunena.controllers', 'admin');
         KunenaFactory::loadLanguage('com_plugins', 'admin');
         KunenaFactory::loadLanguage('com_kunena', 'site');
-    }
-
-    /**
-     * @since K6.0
-     */
-    private function applyViewAndController(): void
-    {
-        // Handle a custom default controller name
-        $view       = $this->input->getCmd('view', $this->defaultController);
-        $controller = $this->input->getCmd('controller', $view);
-        $task       = $this->input->getCmd('task', 'cpanel');
-
-        // Check for a controller.task command.
-        if (strpos($task, '.') !== false) {
-            // Explode the controller.task command.
-            [$controller, $task] = explode('.', $task);
-        }
-
-        $this->input->set('view', $controller);
-        $this->input->set('controller', $controller);
-        $this->input->set('task', $task);
-    }
-
-    /**
-     * Kunena have to check for extension permission
-     *
-     * @return  void
-     *
-     * @since   Kunena 6.0
-     */
-    protected function checkAccess()
-    {
-        if ($this->app->isClient('administrator') && !$this->app->getIdentity()->authorise('core.manage', 'com_kunena')) {
-            throw new KunenaExceptionAuthorise($this->app->getLanguage()->_('COM_KUNENA_NO_ACCESS'), 401);
-        }
     }
 }

--- a/src/admin/src/Extension/ForumComponent.php
+++ b/src/admin/src/Extension/ForumComponent.php
@@ -52,5 +52,9 @@ class ForumComponent extends MVCComponent implements BootableExtensionInterface,
     {
         $this->getRegistry()->register('kunenagrid', new Kunenagrid($container->get(SiteApplication::class)));
         $this->getRegistry()->register('kunenaforum', new Kunenaforum($container->get(SiteApplication::class)));
+
+        // Load Kunena API and autoload vendor libraries
+        require_once JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
+        require_once JPATH_LIBRARIES . '/kunena/External/autoload.php';
     }
 }

--- a/src/pkg_kunena.xml
+++ b/src/pkg_kunena.xml
@@ -86,6 +86,8 @@
             id="kunena">plg_privacy_kunena_v@kunenaversion@.zip</filename>
     </files>
 
+    <blockChildUninstall>true</blockChildUninstall>
+
     <changelogurl>@kunenachangelog@</changelogurl>
 
     <updateservers>
@@ -95,42 +97,4 @@
             name="Kunena 6.5 Update Site">https://update.kunena.org/6.5/list.xml
         </server>
     </updateservers>
-
-    <restorepoint>
-        <customdirs>
-            <dir>administrator/manifests/packages/kunena</dir>
-            <dir>administrator/components/com_kunena</dir>
-            <dir>components/com_kunena</dir>
-            <dir>libraries/kunena</dir>
-            <dir>plugins/kunena</dir>
-            <dir>plugins/system/kunena</dir>
-            <dir>plugins/quickicon/kunena</dir>
-            <dir>plugins/sampledata/kunena</dir>
-            <dir>media/kunena</dir>
-        </customdirs>
-        <customfiles>
-            <file>administrator/manifests/packages/pkg_kunena.xml</file>
-            <file>administrator/manifests/libraries/kunena.xml</file>
-            <file>administrator/manifests/files/kunena_media.xml</file>
-        </customfiles>
-        <langfiles>
-            <lang>com_kunena</lang>
-            <lang>plg_kunena_community</lang>
-            <lang>plg_kunena_comprofiler</lang>
-            <lang>plg_kunena_easyblog</lang>
-            <lang>plg_kunena_easyprofile</lang>
-            <lang>plg_kunena_easysocial</lang>
-            <lang>plg_kunena_gravatar</lang>
-            <lang>plg_kunena_uddeim</lang>
-            <lang>plg_kunena_joomla</lang>
-            <lang>plg_kunena_kunena</lang>
-            <lang>plg_system_kunena</lang>
-            <lang>plg_quickicon_kunena</lang>
-            <lang>plg_sampledata_kunena</lang>
-            <lang>plg_privacy_kunena</lang>
-        </langfiles>
-        <extraprefixes>
-            <prefix>kunena</prefix>
-        </extraprefixes>
-    </restorepoint>
 </extension>

--- a/src/plugins/plg_system_kunena/src/Extension/Kunena.php
+++ b/src/plugins/plg_system_kunena/src/Extension/Kunena.php
@@ -16,19 +16,14 @@ namespace Kunena\Forum\Plugin\System\Kunena\Extension;
 \defined('_JEXEC') or die();
 
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Date\Date;
-use Joomla\CMS\Event\Application\AfterInitialiseEvent;
 use Joomla\CMS\Event\User\AfterSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
-use Joomla\Database\DatabaseDriver;
 use Joomla\Event\SubscriberInterface;
 use Kunena\Forum\Libraries\Factory\KunenaFactory;
 use Kunena\Forum\Libraries\Forum\KunenaForum;
-use Kunena\Forum\Libraries\User\KunenaBan;
 
 /**
  * Class Kunena
@@ -76,132 +71,6 @@ class Kunena extends CMSPlugin implements SubscriberInterface, DatabaseAwareInte
     }
 
     /**
-     * @param   array   $config   Config
-     *
-     * @since   Kunena 6.0
-     * @throws  \Exception
-     */
-    public function __construct(array $config)
-    {
-        parent::__construct($config);
-
-        $app = Factory::getApplication();
-
-        // Do not load when in API client application
-        if ($app->isClient('api')) {
-            return;
-        }
-
-        $kunenaApi = JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
-
-        // Do not load if Kunena is installed, enabled, supported (version) and if api (constants) can be loaded
-        if (
-            !ComponentHelper::isEnabled('com_kunena')
-            || !KunenaForum::isCompatible('6.4')
-            || !KunenaForum::installed()
-            || !\is_file($kunenaApi)
-        ) {
-            return;
-        }
-
-        // Load Kunena API and autoload vendor libraries
-        require_once $kunenaApi;
-        require_once JPATH_LIBRARIES . '/kunena/External/autoload.php';
-
-        // ! Always load language after parent::construct else the name of plugin isn't yet set
-        $app->getLanguage()->load('plg_system_kunena.sys');
-    }
-
-    /**
-     * Routines to run onAfterInitialise
-     *
-     * @param   AfterInitialiseEvent $event  The event instance.
-     * 
-     * @return  void
-     * @since   Kunena 6.0
-     */
-    public function onAfterInitialise(AfterInitialiseEvent $event): void
-    {
-        // Add ban check / only on front-end
-        if ($this->getApplication()->isClient('site')) {
-            $timestamp = \time();
-            $lastCheck = $this->params->get('ban_check_last', 0);
-
-            if ($timestamp - $lastCheck >= 3600) {
-                try {
-                    $this->cleanExpiredBans();
-
-                    // Update last check time
-                    $this->params->set('ban_check_last', $timestamp);
-
-                    // Save the parameters
-                    /** @var DatabaseDriver */
-                    $db    = $this->getDatabase();
-                    $query = $db->createQuery()
-                        ->update($db->quoteName('#__extensions'))
-                        ->set($db->quoteName('params') . ' = ' . $db->quote($this->params->toString()))
-                        ->where([
-                            $db->quoteName('type') . ' = ' . $db->quote('plugin'),
-                            $db->quoteName('folder') . ' = ' . $db->quote('system'),
-                            $db->quoteName('element') . ' = ' . $db->quote('kunena')
-                        ]);
-
-                    $db->setQuery($query);
-                    $db->execute();
-                } catch (\Exception $e) {
-                    $this->getApplication()->enqueueMessage($e->getMessage(), 'error');
-                }
-            }
-        }
-    }
-
-    /**
-     * Clean expired bans from the system
-     *
-     * @return  void
-     * @since   Kunena 6.0
-     */
-    private function cleanExpiredBans(): void
-    {
-        /** @var DatabaseDriver */
-        $db  = $this->getDatabase();
-        $now = new Date();
-
-        // Find expired site-wide bans
-        $query = $db->createQuery()
-            ->select('b.*')
-            ->from($db->quoteName('#__kunena_users_banned', 'b'))
-            ->where($db->quoteName('b.expiration') . ' <= ' . $db->quote($now->toSql()))
-            ->where($db->quoteName('b.blocked') . ' = 1')
-            ->where($db->quoteName('b.expiration') . ' != ' . $db->quote('9999-12-31 23:59:59'));
-
-        $db->setQuery($query);
-        $expiredBans = $db->loadObjectList();
-
-        foreach ($expiredBans as $ban) {
-            // Unblock user in Joomla
-            $user = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($ban->userid);
-            if ($user && $user->block) {
-                $user->block = 0;
-                $user->save();
-            }
-
-            // Update Kunena user profile
-            $profile = KunenaFactory::getUser($ban->userid);
-            $profile->banned = null;
-            $profile->save(true);
-
-            // Update ban record
-            $banInstance = KunenaBan::getInstance($ban->id);
-            if ($banInstance->exists()) {
-                $banInstance->addComment('Automatically unbanned by system');
-                $banInstance->modified_time = $now->toSql();
-                $banInstance->save(true);
-            }
-        }
-    }
-
-    /**
      * Method is called after a succesfull save of the user data
      *
      * @param   AfterSaveEvent  $event  The event instance
@@ -211,6 +80,14 @@ class Kunena extends CMSPlugin implements SubscriberInterface, DatabaseAwareInte
      */
     public function onUserAfterSave(AfterSaveEvent $event): void
     {
+        if (
+            !ComponentHelper::isEnabled('com_kunena')
+            || !KunenaForum::isCompatible('6.4')
+            || !KunenaForum::installed()
+        ) {
+            return;
+        }
+
         $user    = $event->getUser();
         $isNew   = $event->getIsNew();
         $success = $event->getSavingResult();

--- a/src/site/src/Dispatcher/Dispatcher.php
+++ b/src/site/src/Dispatcher/Dispatcher.php
@@ -39,6 +39,11 @@ use Kunena\Forum\Libraries\User\KunenaUserSocials;
  */
 class Dispatcher extends ComponentDispatcher
 {
+    /**
+     * The URL option for the component.
+     *
+     * @var    string
+     */
     public $option = 'com_kunena';
 
     /**
@@ -81,8 +86,8 @@ class Dispatcher extends ComponentDispatcher
             if (!$ksession->save()) {
                 Factory::getApplication()->enqueueMessage(Text::_('COM_KUNENA_ERROR_SESSION_SAVE_FAILED'), 'error');
             }
-        }        
-       
+        }
+
         KunenaUserSocials::addSocialsParams();
 
         $app   = Factory::getApplication();
@@ -123,10 +128,6 @@ class Dispatcher extends ComponentDispatcher
         // Prepare and display the output.
         $params       = new \stdClass();
         $params->text = '';
-        $topics       = new \stdClass();
-        $topics->text = '';
-        PluginHelper::importPlugin('content');
-        Factory::getApplication()->triggerEvent('onContentPrepare', ["com_kunena.{$view}", &$topics, &$params, 0]);
         Factory::getApplication()->triggerEvent('onKunenaBeforeRender', ["com_kunena.{$view}", &$contents]);
         $contents = (string) $contents;
         Factory::getApplication()->triggerEvent('onKunenaAfterRender', ["com_kunena.{$view}", &$contents]);
@@ -144,11 +145,11 @@ class Dispatcher extends ComponentDispatcher
 
             foreach ($kunena_profiler->getAll() as $item) {
                 echo sprintf(
-                	"Kunena %s: %0.3f / %0.3f seconds (%d calls)<br/>",
-                	$item->name,
-                	$item->getInternalTime(),
-                	$item->getTotalTime(),
-                	$item->calls
+                    "Kunena %s: %0.3f / %0.3f seconds (%d calls)<br/>",
+                    $item->name,
+                    $item->getInternalTime(),
+                    $item->getTotalTime(),
+                    $item->calls
                 );
             }
 
@@ -174,10 +175,10 @@ class Dispatcher extends ComponentDispatcher
             Factory::getApplication()->setHeader('Status', '503 Service Temporarily Unavailable', true);
             Factory::getApplication()->sendHeaders();
 
-            ?>
+?>
             <h2><?php echo Text::_('COM_KUNENA_INSTALL_OFFLINE_TOPIC') ?></h2>
             <div><?php echo Text::_('COM_KUNENA_INSTALL_OFFLINE_DESC') ?></div>
-            <?php
+<?php
 
             return;
         }


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes

1. removed onAfterInitialize from system plugin as cleanExpiredBans now is part of task plugin
2. removed constructor from system plugin as loading of api and endor libraries is responsibility of component
3. administrator component dispatcher: removed J3 logic and use J5 core logic (removed checkAccess, applyViewAndController)
4. site component dispatcher, remove onContentPrepare on $topic as that was doing nothing with the result
5. ForumComponent (boot) is now responsible for loading api and vendor libraries
6. pkg_kunena.xml: removed ancient <restorepoint> as that is not existing anymore (pre-joomla 3), added <blockChildUninstall> to prevent from deleting Kunena extensions seperately and by doing that breaking the complete install
 
#### Testing Instructions
Check if everything still works front-end / back-end. Especially look if urls for kunena, but also for ajax calls still work as expected.
Try to uninstall e.g. the Kunena system plugin: this should now not be possible anymore > only the complete Kunena package can be uninstalled