### PR TITLE
replace removed joomla-chosen.js in Joomla 6

### DIFF
--- a/src/admin/tmpl/tools/report.php
+++ b/src/admin/tmpl/tools/report.php
@@ -20,11 +20,10 @@ use Kunena\Forum\Libraries\Route\KunenaRoute;
 
 /** @var WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
-$wa->usePreset('chosen')
-    ->registerAndUseScript('joomla-chosen', 'legacy/joomla-chosen.min.js', [], [], ['chosen'])
+$wa->usePreset('choicesjs')
     ->useScript('multiselect')
     ->addInlineScript(
-    	"
+        "
 		jQuery(document).ready(function ($) {
 	$('#link_sel_all').click(function(e) {
 		$('#report_final').select();
@@ -61,9 +60,9 @@ $wa->usePreset('chosen')
         <div id="j-main-container" class="col-md-12" role="main">
             <div class="card card-block bg-faded p-2">
                 <form action="<?php echo KunenaRoute::_('administrator/index.php?option=com_kunena&view=tools') ?>"
-                      method="post" id="adminForm" name="adminForm">
-                    <input type="hidden" name="task" value=""/>
-                    <input type="hidden" name="boxchecked" value="1"/>
+                    method="post" id="adminForm" name="adminForm">
+                    <input type="hidden" name="task" value="" />
+                    <input type="hidden" name="boxchecked" value="1" />
                     <fieldset>
                         <legend>
                             <i class="icon icon-support"></i> <?php echo Text::_('COM_KUNENA_REPORT_SYSTEM_COMPLETE'); ?>
@@ -74,12 +73,12 @@ $wa->usePreset('chosen')
                                     <p><?php echo Text::_('COM_KUNENA_REPORT_SYSTEM_COMPLETE_DESC'); ?></p>
                                     <p>
                                         <a href="#" id="link_sel_all" name="link_sel_all" type="button"
-                                           class="btn btn-small btn-outline-primary"><i
-                                                    class="icon icon-signup"></i><?php echo Text::_('COM_KUNENA_REPORT_SELECT_ALL'); ?>
+                                            class="btn btn-small btn-outline-primary"><i
+                                                class="icon icon-signup"></i><?php echo Text::_('COM_KUNENA_REPORT_SELECT_ALL'); ?>
                                         </a>
                                     </p>
                                     <textarea id="report_final" class="input-block-level" name="report_final" cols="80"
-                                              rows="15"><?php echo $this->escape($this->systemReport); ?></textarea>
+                                        rows="15"><?php echo $this->escape($this->systemReport); ?></textarea>
                                 </td>
                             </tr>
                         </table>
@@ -94,14 +93,14 @@ $wa->usePreset('chosen')
                                     <p><?php echo Text::_('COM_KUNENA_REPORT_SYSTEM_ANONYMOUS_DESC'); ?></p>
                                     <p>
                                         <a href="#" id="link_sel_all_complete" name="link_sel_all_complete"
-                                           type="button"
-                                           class="btn btn-small btn-outline-primary"><i
-                                                    class="icon icon-signup"></i><?php echo Text::_('COM_KUNENA_REPORT_SELECT_ALL'); ?>
+                                            type="button"
+                                            class="btn btn-small btn-outline-primary"><i
+                                                class="icon icon-signup"></i><?php echo Text::_('COM_KUNENA_REPORT_SELECT_ALL'); ?>
                                         </a>
                                     </p>
                                     <textarea id="report_final_anonymous" class="input-block-level"
-                                              name="report_final_anonymous" cols="80"
-                                              rows="15"><?php echo $this->escape($this->systemReportAnonymous); ?></textarea>
+                                        name="report_final_anonymous" cols="80"
+                                        rows="15"><?php echo $this->escape($this->systemReportAnonymous); ?></textarea>
                                 </td>
                             </tr>
                         </table>


### PR DESCRIPTION
Pull Request for Issue # https://www.kunena.org/forum/general-questions-and-how-tos/168900-joomla-6-support?start=20#233970 .
Summary of Changes

chosen.js has been deprecated long time, in Joomla 6 it has been removed. choices.js is the replacement
Testing Instructions

in back-end > Kunena > tools > report configuration should work again on Joomla 6
also test on J5
