### PR TITLE
Changing a category that has a Topic Template causes an error in the editor

### DIFF
--- a/src/site/template/aurelia/assets/js/edit.js
+++ b/src/site/template/aurelia/assets/js/edit.js
@@ -228,7 +228,7 @@ jQuery(document).ready(function ($) {
         $('#modal_confirm_template_category').modal('hide');
         const textarea = $("#editor").next();
         textarea.empty();
-        CKEDITOR.instances.message.setData(category_template_text.responseJSON);
+        CKEDITOR.instances.message.setData(category_template_text?.responseJSON?.data);
     });
 
     $('#modal_confirm_erase_keep_old').click(function () {
@@ -236,7 +236,7 @@ jQuery(document).ready(function ($) {
         const existing_content = CKEDITOR.instances.message.getData();
         const textarea = $("#editor").next();
         textarea.empty();
-        CKEDITOR.instances.message.setData(category_template_text.responseJSON + ' ' + existing_content);
+        CKEDITOR.instances.message.setData(category_template_text?.responseJSON?.data + ' ' + existing_content);
     });
 
     if ($.fn.datepicker !== undefined) {


### PR DESCRIPTION
**Issue:** Changing a category that has a `Topic Template` causes an error in the editor.

**Steps to Reproduce:**

1. Use core Kunena.
2. Allow users to change the category when creating a new topic.
3. Open the **New Topic** page.
4. Make sure some categories have a `Topic Template`.
5. Switch between those categories.
6. Confirm replacing the content.
7. Notice the incorrect string displayed in the editor (see screenshot below).

<img width="1015" height="675" alt="image" src="https://github.com/user-attachments/assets/fe8effaa-5524-4283-8edb-6c56bb834a75" />  

**Summary of Changes:**

* The AJAX request for `Topic Template` returns with a `data` property.
* This property needs to be added to the handler.
