### PR TITLE
Fix: selecting default template not saved to configuration

### DIFF
--- a/src/admin/config.xml
+++ b/src/admin/config.xml
@@ -15,10 +15,9 @@
                 hidden="true" />
             <field
                 name="template"
-                type="text"
+                type="hidden"
                 default="aurelia"
-                label="Template"
-                hidden="true" />
+                label="Template" />
             <field
                 name="boardTitle"
                 type="text"

--- a/src/admin/config.xml
+++ b/src/admin/config.xml
@@ -14,6 +14,12 @@
                 config="false"
                 hidden="true" />
             <field
+                name="template"
+                type="text"
+                default="aurelia"
+                label="Template"
+                hidden="true" />
+            <field
                 name="boardTitle"
                 type="text"
                 default="Kunena"
@@ -2177,14 +2183,5 @@
             validate="rules"
             component="com_kunena"
             section="component" />
-    </fieldset>
-    <fieldset
-        name="no-config-parameters"
-        hidden="true">
-        <field
-            name="template"
-            type="text"
-            default="aurelia"
-            label="Template" />
     </fieldset>
 </config>


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
The config template parameter is hidden as this is not selected in the config, but by the templates view via selecting the default template.
Because the template configuration parameter was listed in a hidden tab, it was not being saved to the database resulting in the configuration always reporting 'aurelia'

This PR moves the (hidden) template parameter into the global field set. now it is saved
 
#### Testing Instructions
install template
switch default template to new / other template > when page refreshed, aurelia is still default
install pr
switching template now works