### PR TITLE
Fix: Creation of dynamic property Kunena\Forum\Libraries\Layout\Kunen…

### DIFF
--- a/src/libraries/kunena/src/Layout/KunenaBase.php
+++ b/src/libraries/kunena/src/Layout/KunenaBase.php
@@ -97,6 +97,7 @@ class KunenaBase extends KunenaLayoutBase
      */
     protected $debug;
 
+    public $id;
     public $output;
     public $user;
     public $headerText;


### PR DESCRIPTION
…aLayout::$id is deprecated

Pull Request for Issue # . 
 
Deprecated: Creation of dynamic property Kunena\Forum\Libraries\Layout\KunenaLayout::$id is deprecated in /....../libraries/kunena/src/Layout/KunenaBase.php on line 574

#### Summary of Changes 
 
#### Testing Instructions