### PR TITLE
Refactor subject in TopicItemDisplay for browser tab

### DIFF
--- a/src/site/src/Controller/Topic/Item/TopicItemDisplay.php
+++ b/src/site/src/Controller/Topic/Item/TopicItemDisplay.php
@@ -657,9 +657,9 @@ class TopicItemDisplay extends KunenaControllerDisplay
 
         $menu_item = $this->app->getMenu()->getActive();
 
-        if ($menu_item) {
+if ($menu_item) {
             $this->params = $menu_item->getParams();
-            $subject      = KunenaParser::parseText($this->topic->displayField('subject'));
+            $subject = $this->topic->subject;
 
             $this->setTitle($subject);
 


### PR DESCRIPTION
Pull Request for Issue:  https://www.kunena.org/forum/k-6-4-0-support/168986-%E2%80%9Ctitles-not-correctly-escaped-in-case-of-special-characters%E2%80%9D#234138
#### Summary of Changes 
Skipping unnecessary parsing
#### Testing Instructions
See topic
Suppose it should be changed in K7 as well.