### PR TITLE
Add canonical link to topic item display

### DIFF
--- a/src/site/src/Controller/Topic/Item/TopicItemDisplay.php
+++ b/src/site/src/Controller/Topic/Item/TopicItemDisplay.php
@@ -654,6 +654,10 @@ class TopicItemDisplay extends KunenaControllerDisplay
                 }
             }
         }
+        else {
+            $uri = trim(strtok($this->topic->getUrl(), '?'));
+            $doc->addHeadLink($uri, 'canonical');
+        }
 
         $menu_item = $this->app->getMenu()->getActive();
 


### PR DESCRIPTION
Pull Request for Issue #4875 and #6302 . 
 
#### Summary of Changes 
 
Topics with more than one page create "duplicate without canonical" issues on their first page. To my understanding, this simple code fixes it completely, by adding a canonical <link> in the first page. Other pages don't need it, because their content is unique to a single URL.