### PR TITLE
attempt to fix error 500 when URL not correct

### DIFF
--- a/src/site/src/Service/Router.php
+++ b/src/site/src/Service/Router.php
@@ -217,11 +217,12 @@ class Router extends RouterView
             $id = (int) $query['id'];
 
             if ($id) {
-                $subject = KunenaRoute::stringURLSafe(KunenaTopicHelper::get($id)->subject);
+                $subject = KunenaTopicHelper::get($id)->subject;
 
                 if (empty($subject)) {
                     $segments[] = $id;
                 } else {
+                    $subject    = KunenaRoute::stringURLSafe($subject);
                     $segments[] = "{$id}-{$subject}";
                 }
 
@@ -382,9 +383,9 @@ class Router extends RouterView
             $var   = array_shift($seg);
             $value = array_shift($seg);
 
-            if (empty($var) && empty($value)) {
+            if (empty($var) || empty($value)) {
                 // Skip /-/
-                continue;
+                break;
             }
 
             if (is_numeric($var)) {

--- a/src/site/src/Service/Router.php
+++ b/src/site/src/Service/Router.php
@@ -373,6 +373,8 @@ class Router extends RouterView
                     $sefcats = false;
                     $vars    = $variables + $vars;
                     continue;
+                } else {
+                    break;
                 }
             }
 
@@ -383,9 +385,9 @@ class Router extends RouterView
             $var   = array_shift($seg);
             $value = array_shift($seg);
 
-            if (empty($var) || empty($value)) {
+            if (empty($var) && empty($value)) {
                 // Skip /-/
-                break;
+                continue;
             }
 
             if (is_numeric($var)) {


### PR DESCRIPTION
Pull Request for Issue #9949 . 
 
#### Summary of Changes 
When you have a correct URL like: [domain]/forum/category/123-topic-alias where forum is the com_kunena home page, category is a valid category alias and 123 is a valid topic id and you do:
1. change the topic id to a non-existing topic id number
2. change the category alias to a non existing category alias

you will get a:
1. 404 error, but with deprecated messages
2. 500 error

This PR fixes:
1. the deprecated messages
2. when changing to a non-existing category it will now give a correct 404 instead of a 500

What this PR fixes for 2. is that it 'breaks' out of the logic when the category doesn't exist instead of setting the view to category and then use the topic id (123) as category id.

#### Testing Instructions
now this is where it gets tricky as I think we need to get as meny test cases as possible: the category can be wrong, but can also have a ghost category, or subcategories, etc. My test site is verly basic when it comes to sections / categories and I never set a ghost category when doing e.g. a rename of a category etc (not even sure  that is possible).

@c-schmitz can you check if your test cases (could not find these in your original topic) are fixed with this change (after you revert your own fix for testing)