### PR TITLE
fix script + not use old config values

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -632,30 +632,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.4"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^14",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
             },
             "type": "library",
             "autoload": {
@@ -682,7 +681,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
             },
             "funding": [
                 {
@@ -698,7 +697,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2026-01-05T06:47:08+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -1779,16 +1778,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.31",
+            "version": "9.6.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5"
+                "reference": "fea06253ecc0a32faf787bd31b261f56f351d049"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/945d0b7f346a084ce5549e95289962972c4272e5",
-                "reference": "945d0b7f346a084ce5549e95289962972c4272e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fea06253ecc0a32faf787bd31b261f56f351d049",
+                "reference": "fea06253ecc0a32faf787bd31b261f56f351d049",
                 "shasum": ""
             },
             "require": {
@@ -1810,7 +1809,7 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.8",
@@ -1862,7 +1861,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.31"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.33"
             },
             "funding": [
                 {
@@ -1886,7 +1885,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-06T07:45:52+00:00"
+            "time": "2026-01-27T05:25:09+00:00"
         },
         {
             "name": "psr/container",
@@ -2289,16 +2288,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -2351,7 +2350,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -2371,7 +2370,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -4832,12 +4831,12 @@
     "stability-flags": {
         "joomla/cms-coding-standards": 20,
         "joomla/coding-standards": 20,
-        "phing/phing": 20,
-        "kunena/codestyle": 20
+        "kunena/codestyle": 20,
+        "phing/phing": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4305,16 +4305,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.26",
+            "version": "v6.4.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "48bad913268c8cafabbf7034b39c8bb24fbc5ab8"
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/48bad913268c8cafabbf7034b39c8bb24fbc5ab8",
-                "reference": "48bad913268c8cafabbf7034b39c8bb24fbc5ab8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
                 "shasum": ""
             },
             "require": {
@@ -4346,7 +4346,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.26"
+                "source": "https://github.com/symfony/process/tree/v6.4.33"
             },
             "funding": [
                 {
@@ -4366,7 +4366,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T09:57:09+00:00"
+            "time": "2026-01-23T16:02:12+00:00"
         },
         {
             "name": "symfony/service-contracts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1798,9 +1798,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },

--- a/src/admin/script.php
+++ b/src/admin/script.php
@@ -92,73 +92,57 @@ class Com_KunenaInstallerScript extends InstallerScript
         // Convert Config settings to com_kunena component parameters on update and when installed version is < 7.0.0
         if ($type === 'update') {
             if (version_compare($this->installedVersion, '7.0.0', '<')) {
-                $comParams = $this->getItemArray('params', '#__extensions', 'name', 'com_kunena');
 
-                // Only convert when there are not component settings ( = first upgrade to 7.0.0)
-                if (empty($comParams)) {
-                    try {
-                        // Get the configuration settings
-                        /** @var DatabaseDriver  $db */
-                        $db    = Factory::getContainer()->get('DatabaseDriver');
+                try {
+                    // Get the configuration settings
+                    /** @var DatabaseDriver  $db */
+                    $db    = Factory::getContainer()->get('DatabaseDriver');
+
+                    $query = $db->createQuery()
+                        ->select($db->quoteName('params'))
+                        ->from($db->quoteName('#__kunena_configuration'))
+                        ->where($db->quoteName('id') . ' = 1');
+                    $db->setQuery($query);
+
+                    $config = $db->loadResult() ?? '{}';
+
+                    // Convert Config parameters that are now arrays to avoid loosing the setting value on import
+                    $processConfig    = json_decode($config, true);
+                    $arrayConversions = ['latestCategory', 'rssExcludedCategories', 'rssIncludedCategories'];
+
+                    foreach ($processConfig as $param => $value) {
+                        if (in_array($param, $arrayConversions) && is_string($value)) {
+                            $processConfig[$param] = explode(',', $value);
+                        }
+                    }
+
+                    $componentId = $this->getComponentId();
+
+                    if ($componentId) {
+                        $paramsString = json_encode($processConfig);
 
                         $query = $db->createQuery()
-                            ->select($db->quoteName('params'))
-                            ->from($db->quoteName('#__kunena_configuration'))
-                            ->where($db->quoteName('id') . ' = 1');
-                        $db->setQuery($query);
+                            ->update($db->quoteName('#__extensions'))
+                            ->set('params = :params')
+                            ->where('extension_id = :id')
+                            ->bind(':params', $paramsString)
+                            ->bind(':id', $componentId, ParameterType::INTEGER);
 
-                        $config = $db->loadResult() ?? '{}';
-
-                        // Convert Config parameters that are now arrays to avoid loosing the setting value on import
-                        $oldConfig        = json_decode($config, true);
-                        $arrayConversions = ['latestCategory', 'rssExcludedCategories', 'rssIncludedCategories'];
-                        $processConfig    = [];
-                        $usedKeys         = [];
-
-                        foreach ($oldConfig as $param => $value) {
-                            if (in_array(strtolower($param), $usedKeys)) {
-                                // We assume that all newly named Keys are handled first, and the old obsolete ones last
-                                continue;
-                            }
-
-                            $usedKeys[] = strtolower($param);
-
-                            if (in_array($param, $arrayConversions) && is_string($value)) {
-                                $processConfig[$param] = explode(',', $value);
-                                continue;
-                            }
-
-                            $processConfig[$param] = $value;
-                        }
-
-                        $componentId = $this->getComponentId();
-
-                        if ($componentId) {
-                            $paramsString = json_encode($processConfig);
-
-                            $query = $db->createQuery()
-                                ->update($db->quoteName('#__extensions'))
-                                ->set('params = :params')
-                                ->where('extension_id = :id')
-                                ->bind(':params', $paramsString)
-                                ->bind(':id', $componentId, ParameterType::INTEGER);
-
-                            // Update table
-                            $converted = $db->setQuery($query)->execute();
-                        } else {
-                            $converted = false;
-                        }
-
-                        if ($converted) {
-                            // We have  been able to convert the configuration to component parameters
-                            Factory::getApplication()->enqueueMessage('Kunena Configuration settings were automatically converted to the new Configuration settings, please validate after installation completes.');
-                        } else {
-                            // We have not been able to convert the configuration to component parameters
-                            Factory::getApplication()->enqueueMessage('We are sorry to inform you that we were not able to convert you Kunena configuration settings to the new version. You need to do this manually after installation completes.', 'error');
-                        }
-                    } catch (\Exception $e) {
-                        // Do nothing
+                        // Update table
+                        $converted = $db->setQuery($query)->execute();
+                    } else {
+                        $converted = false;
                     }
+
+                    if ($converted) {
+                        // We have  been able to convert the configuration to component parameters
+                        Factory::getApplication()->enqueueMessage('Kunena Configuration settings were automatically converted to the new Configuration settings, please validate after installation completes.');
+                    } else {
+                        // We have not been able to convert the configuration to component parameters
+                        Factory::getApplication()->enqueueMessage('We are sorry to inform you that we were not able to convert you Kunena configuration settings to the new version. You need to do this manually after installation completes.', 'error');
+                    }
+                } catch (\Exception $e) {
+                    // Do nothing
                 }
             }
 

--- a/src/admin/script.php
+++ b/src/admin/script.php
@@ -110,13 +110,25 @@ class Com_KunenaInstallerScript extends InstallerScript
                         $config = $db->loadResult() ?? '{}';
 
                         // Convert Config parameters that are now arrays to avoid loosing the setting value on import
-                        $processConfig    = json_decode($config, true);
+                        $oldConfig        = json_decode($config, true);
                         $arrayConversions = ['latestCategory', 'rssExcludedCategories', 'rssIncludedCategories'];
+                        $processConfig    = [];
+                        $usedKeys         = [];
 
-                        foreach ($processConfig as $param => $value) {
+                        foreach ($oldConfig as $param => $value) {
+                            if (in_array(strtolower($param), $usedKeys)) {
+                                // We assume that all newly named Keys are handled first, and the old obsolete ones last
+                                continue;
+                            }
+
+                            $usedKeys[] = strtolower($param);
+
                             if (in_array($param, $arrayConversions) && is_string($value)) {
                                 $processConfig[$param] = explode(',', $value);
+                                continue;
                             }
+
+                            $processConfig[$param] = $value;
                         }
 
                         $componentId = $this->getComponentId();
@@ -127,8 +139,9 @@ class Com_KunenaInstallerScript extends InstallerScript
                             $query = $db->createQuery()
                                 ->update($db->quoteName('#__extensions'))
                                 ->set('params = :params')
-                                ->where($db->quoteName('extension_id'), $componentId)
-                                ->bind(':params', $paramsString);
+                                ->where('extension_id = :id')
+                                ->bind(':params', $paramsString)
+                                ->bind(':id', $componentId, ParameterType::INTEGER);
 
                             // Update table
                             $converted = $db->setQuery($query)->execute();

--- a/src/admin/script.php
+++ b/src/admin/script.php
@@ -110,13 +110,25 @@ class Com_KunenaInstallerScript extends InstallerScript
                         $config = $db->loadResult() ?? '{}';
 
                         // Convert Config parameters that are now arrays to avoid loosing the setting value on import
-                        $processConfig    = json_decode($config, true);
+                        $oldConfig        = json_decode($config, true);
                         $arrayConversions = ['latestCategory', 'rssExcludedCategories', 'rssIncludedCategories'];
+                        $processConfig    = [];
+                        $usedKeys         = [];
 
-                        foreach ($processConfig as $param => $value) {
+                        foreach ($oldConfig as $param => $value) {
+                            if (in_array(strtolower($param), $usedKeys)) {
+                                // We assume that all newly named Keys are handled first, and the old obsolete ones last
+                                continue;
+                            }
+
+                            $usedKeys[] = strtolower($param);
+
                             if (in_array($param, $arrayConversions) && is_string($value)) {
                                 $processConfig[$param] = explode(',', $value);
+                                continue;
                             }
+
+                            $processConfig[$param] = $value;
                         }
 
                         $componentId = $this->getComponentId();

--- a/src/admin/script.php
+++ b/src/admin/script.php
@@ -127,8 +127,9 @@ class Com_KunenaInstallerScript extends InstallerScript
                             $query = $db->createQuery()
                                 ->update($db->quoteName('#__extensions'))
                                 ->set('params = :params')
-                                ->where($db->quoteName('extension_id'), $componentId)
-                                ->bind(':params', $paramsString);
+                                ->where('extension_id = :id')
+                                ->bind(':params', $paramsString)
+                                ->bind(':id', $componentId, ParameterType::INTEGER);
 
                             // Update table
                             $converted = $db->setQuery($query)->execute();

--- a/src/libraries/kunena/src/Config/KunenaConfig.php
+++ b/src/libraries/kunena/src/Config/KunenaConfig.php
@@ -584,7 +584,6 @@ class KunenaConfig
     public function save(): bool
     {
         $params  = ComponentHelper::getParams(self::COMPONENT);
-        $changed = \false;
 
         foreach ($params as $key => $value) {
             if ($this->config[$key] === $value) {
@@ -592,29 +591,24 @@ class KunenaConfig
             }
 
             $params->set($key, $this->config[$key]);
-            $changed = \true;
         }
 
-        if ($changed) {
-            /** @var DatabaseDriver $db */
-            $db = Factory::getContainer()->get(DatabaseInterface::class);
+        /** @var DatabaseDriver $db */
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
-            $query = $db->createQuery()
-                ->update($db->quoteName('#__extensions'))
-                ->set($db->quoteName('params') . ' = ' . $db->quote(\json_encode($params)))
-                ->where($db->quoteName('name') . ' = ' . $db->quote(self::COMPONENT));
+        $query = $db->createQuery()
+            ->update($db->quoteName('#__extensions'))
+            ->set($db->quoteName('params') . ' = ' . $db->quote(\json_encode($params)))
+            ->where($db->quoteName('name') . ' = ' . $db->quote(self::COMPONENT));
 
-            $db->setQuery($query);
+        $db->setQuery($query);
 
-            $result = $db->execute();
+        $result = $db->execute();
 
-            // Clean out the Cache and start with new value(s)
-            $this->reset();
+        // Clean out the Cache and start with new value(s)
+        $this->reset();
 
-            return $result;
-        }
-
-        return \true;
+        return $result;
     }
 
     /**
@@ -626,10 +620,11 @@ class KunenaConfig
     public function reset(): void
     {
         $cache = self::getConfigCacheController();
-        $cache->clean();
 
-        if (self::$instance !== \null) {
-            self::$instance = \null;
-        }
+        // Clean the Kunena configuration cache and the _system cache as that is where Joomla itself caches the component cache
+        $cache->clean(self::COMPONENT . '_configuration');
+        $cache->clean('_system');
+
+        self::$instance = \null;
     }
 }

--- a/src/plugins/plg_kunena_easysocial/src/Extension/Easysocial.php
+++ b/src/plugins/plg_kunena_easysocial/src/Extension/Easysocial.php
@@ -36,6 +36,14 @@ use Kunena\Forum\Plugin\Kunena\Easysocial\Helper\KunenaLoginEasySocial;
 use Kunena\Forum\Plugin\Kunena\Easysocial\Helper\KunenaPrivateEasySocial;
 use Kunena\Forum\Plugin\Kunena\Easysocial\Helper\KunenaActivityEasySocial;
 
+$file = JPATH_ADMINISTRATOR . '/components/com_easysocial/includes/plugins.php';
+
+if (!is_file($file)) {
+    return;
+}
+
+require_once $file;
+
 /**
  * @package     Kunena
  *
@@ -92,14 +100,6 @@ class Easysocial extends \EasySocialPlugins implements SubscriberInterface, Data
      */
     public function __construct(array $config = [])
     {
-        $file = JPATH_ADMINISTRATOR . '/components/com_easysocial/includes/plugins.php';
-
-        if (!\is_file($file)) {
-            return \true;
-        }
-
-        require_once $file;
-
         // Do not load if Kunena version is not supported or Kunena is offline
         if (!(\class_exists('Kunena\Forum\Libraries\Forum\KunenaForum') && KunenaForum::isCompatible('7.0') && KunenaForum::enabled())) {
             return \true;

--- a/src/plugins/plg_kunena_easysocial/src/Helper/KunenaActivityEasySocial.php
+++ b/src/plugins/plg_kunena_easysocial/src/Helper/KunenaActivityEasySocial.php
@@ -25,8 +25,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
-use Kunena\Forum\Libraries\Integration\KunenaAccess;
 use Kunena\Forum\Libraries\Integration\KunenaActivity;
+use Kunena\Forum\Libraries\Access\KunenaAccess;
 use Kunena\Forum\Libraries\Factory\KunenaFactory;
 use Kunena\Forum\Libraries\Forum\Message\KunenaMessage;
 


### PR DESCRIPTION
Pull Request for Issue #9974 . 
 
#### Summary of Changes 
 revert change #9974 
add cleaning of old / unused configuration values before updating

#### Testing Instructions
1. install on K6.4.8, check if all config settings for Kunena have been imported correct,
2. check if other extensions still have correct configuration 

@xillibit, not sure if the added logic will fix your issue where some config settings where not imported correct, if not I advice not to merge this PR and just revert your own PR.

Note that your PR didn't change anything on the imported configuration, so if the data was correct with your PR it should have also been correct without your PR: the only thing your PR changed where the data was saved to