### PR TITLE
Missing config items

### DIFF
--- a/src/admin/config.xml
+++ b/src/admin/config.xml
@@ -1599,7 +1599,7 @@
                 description="COM_KUNENA_CONFIGURATION_EBAY_API_KEY_DESC" />
             <field
                 name="ebayCertId"
-                type="password"
+                type="text"
                 default=""
                 label="COM_KUNENA_CONFIGURATION_EBAY_CERTID_KEY_LABEL"
                 description="COM_KUNENA_CONFIGURATION_EBAY_CERTID_KEY_DESC" />
@@ -1611,7 +1611,7 @@
                 description="COM_KUNENA_CONFIGURATION_BLUESKYAPP_HANDLE_OF_APP_DESC" />
             <field
                 name="blueskyappPasswordOfApp"
-                type="password"
+                type="text"
                 default=""
                 label="COM_KUNENA_CONFIGURATION_BLUESKYAPP_PASSWORD_OF_APP_LABEL"
                 description="COM_KUNENA_CONFIGURATION_BLUESKYAPP_PASSWORD_OF_APP_DESC" />
@@ -1623,7 +1623,7 @@
                 description="COM_KUNENA_CONFIGURATION_X_SOCIAL_API_CONSUMER_KEY_DESC" />
             <field
                 name="XConsumerSecret"
-                type="password"
+                type="text"
                 default=""
                 label="COM_KUNENA_CONFIGURATION_X_SOCIAL_API_CONSUMER_SECRET_LABEL"
                 description="COM_KUNENA_CONFIGURATION_X_SOCIAL_API_CONSUMER_SECRET_DESC" />

--- a/src/admin/script.php
+++ b/src/admin/script.php
@@ -107,7 +107,8 @@ class Com_KunenaInstallerScript extends InstallerScript
                     $config = $db->loadResult() ?? '{}';
 
                     $processConfig    = json_decode($config, true);
-                    // Not all old config settings where converted to snake case, lets do that here
+
+                    // Not all old config settings where converted to camel case, lets do that here
                     $keyConversions = [
                         'email_sender_name'                 => 'emailSenderName',
                         'display_filename_attachment'       => 'displayFilenameAttachment',

--- a/src/admin/script.php
+++ b/src/admin/script.php
@@ -106,8 +106,23 @@ class Com_KunenaInstallerScript extends InstallerScript
 
                     $config = $db->loadResult() ?? '{}';
 
-                    // Convert Config parameters that are now arrays to avoid loosing the setting value on import
                     $processConfig    = json_decode($config, true);
+                    // Not all old config settings where converted to snake case, lets do that here
+                    $keyConversions = [
+                        'email_sender_name'                 => 'emailSenderName',
+                        'display_filename_attachment'       => 'displayFilenameAttachment',
+                        'new_users_prevent_post_url_images' => 'newUsersPreventPostUrlImages',
+                        'minimal_user_posts_add_url_image'  => 'minimalUserPostsAddUrlImage'
+                    ];
+
+                    foreach ($keyConversions as $oldKey => $newKey) {
+                        if (array_key_exists($oldKey, $processConfig)) {
+                            $processConfig[$newKey] = $processConfig[$oldKey];
+                            unset($processConfig[$oldKey]);
+                        }
+                    }
+
+                    // Convert Config parameters that are now arrays to avoid loosing the setting value on import
                     $arrayConversions = ['latestCategory', 'rssExcludedCategories', 'rssIncludedCategories'];
 
                     foreach ($processConfig as $param => $value) {


### PR DESCRIPTION
Pull Request for Issue #9974  . 
 
#### Summary of Changes
Some K6.4.8 configsettings where still in snake case, converthing these to camelcase in upgrade script

- email_sender_name = emailSenderName
- display_filename_attachment = displayFilenameAttachment
- new_users_prevent_post_url_images = newUsersPreventPostUrlImages
- minimal_user_posts_add_url_image = minimalUserPostsAddUrlImage

Converted config password fields to text fields to prevent brwoser from filling in broser stored passwords when fields are left empty.

#### Testing Instructions
upgrade 6.4.8 and check if above mentioned fields are now imported, also check browser behavior on:

- ebayCertId
- blueskyappPasswordOfApp
- XConsumerSecret