### PR TITLE
Change: execute database upgrades from install script instead of via …

### DIFF
--- a/src/admin/script.php
+++ b/src/admin/script.php
@@ -16,8 +16,11 @@ defined('_JEXEC') or die();
 use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\Adapter\ComponentAdapter;
 use Joomla\CMS\Installer\InstallerScript;
+use Joomla\CMS\Language\Text;
 use Joomla\Database\ParameterType;
 use Kunena\Forum\Libraries\Config\KunenaConfig;
+use Kunena\Forum\Libraries\Forum\KunenaForum;
+use Kunena\Forum\Libraries\Install\KunenaModelInstall;
 
 /**
  * Kunena package installer script.
@@ -166,6 +169,12 @@ class Com_KunenaInstallerScript extends InstallerScript
                 // remove cached Kunena Config settings
                 KunenaConfig::getInstance()->reset();
             }
+
+            try {
+                $this->upgradeDatabase();
+            } catch (\Exception $e) {
+                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+            }
         }
     }
 
@@ -190,5 +199,58 @@ class Com_KunenaInstallerScript extends InstallerScript
         $componentId = (int) ($db->loadResult() ?? 0);
 
         return $componentId;
+    }
+
+    /**
+     * Method to upgrade the database at the end of installation.
+     *
+     * @return  boolean
+     *
+     * @throws Exception
+     * @since   Kunena 6.0
+     */
+    protected function upgradeDatabase()
+    {
+        $app = Factory::getApplication();
+        $app->getLanguage()->load('com_kunena.install', JPATH_ADMINISTRATOR . '/components/com_kunena');
+
+        $xml = simplexml_load_file(__DIR__ . '/install/kunena.install.upgrade.xml');
+
+        if ($xml === false) {
+            $app->enqueueMessage(Text::_('COM_KUNENA_INSTALL_DB_UPGRADE_FAILED_XML'), 'error');
+
+            return false;
+        }
+
+        // The column "state" in kunena_version indicate from which version to update
+
+        $modelInstall = new KunenaModelInstall();
+
+        foreach ($xml->upgrade[0] as $version) {
+            // If we have already upgraded to this version, continue to the next one
+            $vernum = (string) $version['version'];
+
+            if (!empty($status[$vernum])) {
+                continue;
+            }
+
+            // Update state
+            $status[$vernum] = 1;
+
+            if ($version['version'] == '@' . 'kunenaversion' . '@') {
+                $git    = 1;
+                $vernum = KunenaForum::version();
+            }
+
+            if (isset($git) || version_compare(strtolower($version['version']), strtolower($this->installedVersion), '>')) {
+                foreach ($version as $action) {
+                    $modelInstall->processUpgradeXMLNode($action);
+
+                    $app->enqueueMessage(Text::sprintf('COM_KUNENA_INSTALL_VERSION_UPGRADED', $vernum), 'success');
+                }
+            }
+        }
+
+        return true;
     }
 }

--- a/src/admin/src/View/Cpanel/HtmlView.php
+++ b/src/admin/src/View/Cpanel/HtmlView.php
@@ -74,8 +74,6 @@ class HtmlView extends BaseHtmlView
 
         $this->KunenaMenusExists = KunenaMenuHelper::KunenaMenusExists();
 
-        $this->upgradeDatabase();
-
         $logFinder = new KunenaLogFinder();
         $this->numberOfLogs = $logFinder->count();
 
@@ -123,75 +121,6 @@ class HtmlView extends BaseHtmlView
         ToolbarHelper::spacer();
         $helpUrl = 'https://docs.kunena.org/en/';
         ToolbarHelper::help('COM_KUNENA', false, $helpUrl);
-    }
-
-    /**
-     * Method to upgrade the database at the end of installation.
-     *
-     * @return  boolean
-     *
-     * @throws Exception
-     * @since   Kunena 6.0
-     */
-    protected function upgradeDatabase()
-    {
-        $app = Factory::getApplication();
-
-        $xml = simplexml_load_file(JPATH_ADMINISTRATOR . '/components/com_kunena/install/kunena.install.upgrade.xml');
-
-        if ($xml === false) {
-            $app->enqueueMessage(Text::_('COM_KUNENA_INSTALL_DB_UPGRADE_FAILED_XML'), 'error');
-
-            return false;
-        }
-
-        // The column "state" in kunena_version indicate from which version to update
-        $db = Factory::getContainer()->get('DatabaseDriver');
-        $db->setQuery("SELECT state FROM #__kunena_version ORDER BY `id` DESC", 0, 1);
-        $stateVersion = $db->loadResult();
-
-        if (!empty($stateVersion)) {
-            $curversion = $stateVersion;
-        } else {
-            return false;
-        }
-
-        $modelInstall = new KunenaModelInstall();
-
-        foreach ($xml->upgrade[0] as $version) {
-            // If we have already upgraded to this version, continue to the next one
-            $vernum = (string) $version['version'];
-
-            if (!empty($status[$vernum])) {
-                continue;
-            }
-
-            // Update state
-            $status[$vernum] = 1;
-
-            if ($version['version'] == '@' . 'kunenaversion' . '@') {
-                $git    = 1;
-                $vernum = KunenaForum::version();
-            }
-
-            if (isset($git) || version_compare(strtolower($version['version']), strtolower($curversion), '>')) {
-                foreach ($version as $action) {
-                    $modelInstall->processUpgradeXMLNode($action);
-
-                    $app->enqueueMessage(Text::sprintf('COM_KUNENA_INSTALL_VERSION_UPGRADED', $vernum), 'success');
-                }
-
-                $query = "UPDATE `#__kunena_version` SET state='';";
-                $db->setQuery($query);
-
-                $db->execute();
-
-                // Database install continues
-                // return false;
-            }
-        }
-
-        return true;
     }
 
     /**

--- a/src/script.php
+++ b/src/script.php
@@ -321,10 +321,6 @@ return new class() implements ServiceProviderInterface {
                         }
                     }
 
-                    if ($installed != 'NONE') {
-                        $state = $installed;
-                    }
-
                     $query = $db->createQuery();
 
                     $values = [


### PR DESCRIPTION
…dashboard

Pull Request for Issue # all issues related to people not going to Kunena Dashboard after install of new package. 
 
#### Summary of Changes 
This PR executes database updates from withing the install script: this to ensure that the updates are always executed instead of being executed via the Kunena Dashboard (which a lot of people forget to do / do not know that they should do that)
 
#### Testing Instructions
install new version with database updates on older version, in the installer you should see the messages that the database was updated. No need to go to the Kunena dashboard.
Check to see if updates are indeed done in the database.

test updates from previous version and from older version.