### PR TITLE
fix for broken pagination

### DIFF
--- a/src/site/template/aurelia/layouts/widget/pagination/item/default.php
+++ b/src/site/template/aurelia/layouts/widget/pagination/item/default.php
@@ -22,7 +22,7 @@ if ($item->base !== null) {
     // Check if the item can be clicked.
     $limit = 'limitstart.value=' . (int) $item->base;
     echo '<li class="page-item">
-			<a class="page-link" ' . KunenaTemplate::getInstance()->tooltips(true) . ' href="' . $item->link . '" data-bs-toggle="tooltip" title="' . Text::_('COM_KUNENA_PAGE') . $item->text . '">' . $item->text . '</a>
+			<a class="page-link ' . KunenaTemplate::getInstance()->tooltips() . '" href="' . $item->link . '" data-bs-toggle="tooltip" title="' . Text::_('COM_KUNENA_PAGE') . $item->text . '">' . $item->text . '</a>
 		  </li>';
 } elseif (!empty($item->active)) {
     // Check if the item is the active (or current) page.


### PR DESCRIPTION
Pull Request for Issue # https://www.kunena.org/forum/k-6-4-0-support/169075-kunena-6-4-x-paginator-issue
 
#### Summary of Changes 
 Pagination was broken due to not correctly setting tooltip class (adding double class on element)

#### Testing Instructions
test if pagination is working when tooltips are on and off