### PR TITLE
Fix: email sender not set when configured

### DIFF
--- a/src/libraries/kunena/src/Config/KunenaConfig.php
+++ b/src/libraries/kunena/src/Config/KunenaConfig.php
@@ -328,9 +328,7 @@ class KunenaConfig
             }
 
             if ($key === 'email') {
-                $email = $this->email;
-
-                return !empty($email) ? $email : Factory::getApplication()->get('mailfrom', '');
+                return !empty($this->config[$key]) ? $this->config[$key] : Factory::getApplication()->get('mailfrom', '');
             }
 
             // Return the value
@@ -399,7 +397,7 @@ class KunenaConfig
 
         return $config;
     }
-    
+
     /**
      * Function to build the configuration values with default values from config.xml and fill it with values 
      *


### PR DESCRIPTION
Pull Request for Issue #9986 . 
 
#### Summary of Changes 
fix for getting the configured email address and fallback to global config mail address

#### Testing Instructions
in Kunena Config:
1. set email to empty > email should be send by Joomla global config email sender
2. set email to 'custom' email address > email should be send by this configured email address