### PR TITLE
Fix: set sender name from configuration

### DIFF
--- a/src/libraries/kunena/src/Config/KunenaConfig.php
+++ b/src/libraries/kunena/src/Config/KunenaConfig.php
@@ -303,6 +303,19 @@ class KunenaConfig
     }
 
     /**
+     * Magic method to check if the key exists in the protected array.
+     * This allows empty() and isset() to work correctly.
+     *
+     * @param   string $key The key requested (e.g., 'name' for $class->name)
+     * @return  bool true if the key exists
+     * @since   7.0.2
+     */
+    public function __isset(string $key): bool
+    {
+        return isset($this->config[$key]);
+    }
+
+    /**
      * Magic method to get protected properties by key.
      * This is called when reading data from inaccessible properties.
      *

--- a/src/libraries/kunena/src/Forum/Message/KunenaMessage.php
+++ b/src/libraries/kunena/src/Forum/Message/KunenaMessage.php
@@ -671,7 +671,7 @@ class KunenaMessage extends KunenaDatabaseObject
                 }
             }
 
-            $mailnamesender  = !empty($config->emailSenderName) ? MailHelper::cleanAddress($config->emailSenderName) : MailHelper::cleanAddress($config->boardTitle);
+            $mailnamesender  = !empty((string) $config->emailSenderName) ? MailHelper::cleanAddress($config->emailSenderName) : MailHelper::cleanAddress($config->boardTitle);
             $mailsubject = MailHelper::cleanSubject($topic->subject . " (" . $this->getCategory()->name . ")");
             $subject     = $this->subject ? $this->subject : $topic->subject;
 

--- a/src/libraries/kunena/src/Forum/Message/KunenaMessage.php
+++ b/src/libraries/kunena/src/Forum/Message/KunenaMessage.php
@@ -671,7 +671,7 @@ class KunenaMessage extends KunenaDatabaseObject
                 }
             }
 
-            $mailnamesender  = !empty((string) $config->emailSenderName) ? MailHelper::cleanAddress($config->emailSenderName) : MailHelper::cleanAddress($config->boardTitle);
+            $mailnamesender  = !empty($config->emailSenderName) ? MailHelper::cleanAddress($config->emailSenderName) : MailHelper::cleanAddress($config->boardTitle);
             $mailsubject = MailHelper::cleanSubject($topic->subject . " (" . $this->getCategory()->name . ")");
             $subject     = $this->subject ? $this->subject : $topic->subject;
 


### PR DESCRIPTION
Pull Request for Issue #9996 . 

also for issue: https://www.kunena.org/forum/kunena-7-0-0-support/169081-email-kunena-logo-image-suddenly-disappeared-after-update
 
#### Summary of Changes 
the empty function doesn't handle the config get correct resulting in an empty = true while a string was returned by config
this resulted in the site sender name being used instead of the configured one.

#### Testing Instructions
set Sender name for mail to a name and check if that name is correctly displayed in the receid email next to the sender's email