### PR TITLE
[K6.4] Fix avatar path and update username display logic in community plugin

### DIFF
--- a/src/plugins/plg_kunena_community/KunenaAvatarCommunity.php
+++ b/src/plugins/plg_kunena_community/KunenaAvatarCommunity.php
@@ -93,7 +93,7 @@ class KunenaAvatarCommunity extends KunenaAvatar
         $user = \CFactory::getUser($kuser->userid);
 
         if ($kuser->userid == 0) {
-            $avatar = str_replace(Uri::root(true), '', COMMUNITY_PATH_ASSETS) . "user-Male.png";
+            $avatar = Uri::root() . "components/com_community/assets/user-Male.png";
         } elseif ($sizex <= 90) {
             $avatar = $user->getThumbAvatar();
         } else {

--- a/src/plugins/plg_kunena_community/KunenaProfileCommunity.php
+++ b/src/plugins/plg_kunena_community/KunenaProfileCommunity.php
@@ -160,7 +160,9 @@ class KunenaProfileCommunity extends KunenaProfile
         $cconfig         = \CFactory::getConfig();
         $displayusername = $cconfig->get('displayname');
 
-        if ($displayusername == 'name') {
+        if ($user->id == 0) {
+            return $user->name;
+        } elseif ($displayusername == 'name') {
             return \CFactory::getUser($user->userid)->name;
         } else {
             return \CFactory::getUser($user->userid)->username;


### PR DESCRIPTION
### Steps to Reproduce

* Install JomSocial and Kunena
* Enable the `plg_kunena_community` plugin
* Allow guests to comment
* Create a topic
* Post a comment as a guest
* Log in as an existing user
* Return to the topic created above
* Notice that the guest’s comment shows an incorrect avatar and displays the currently logged-in user’s name

### Summary of Changes

* Fixed the avatar link and display name for guest users

### Testing Instructions

* A guest’s comment should display the default avatar from JomSocial and the correct guest name
