### PR TITLE
Fix: attachment throws 404 when added to topic but not inserted into …

### DIFF
--- a/src/libraries/kunena/src/Route/KunenaRoute.php
+++ b/src/libraries/kunena/src/Route/KunenaRoute.php
@@ -289,7 +289,7 @@ abstract class KunenaRoute
         static $candidates = [];
         KunenaProfiler::getInstance() ? KunenaProfiler::instance()->start('function ' . __CLASS__ . '::' . __FUNCTION__ . '()') : null;
 
-        $view   = $uri->getVar('view');
+        $view   = $uri->getVar('view', '');
         $catid  = (int) $uri->getVar('catid');
         $Itemid = (int) $uri->getVar('Itemid');
         $key    = $view . $catid;

--- a/src/site/src/Service/Router.php
+++ b/src/site/src/Service/Router.php
@@ -374,7 +374,9 @@ class Router extends RouterView
                     $vars    = $variables + $vars;
                     continue;
                 } else {
-                    break;
+                    if ($segment !== 'attachment') {
+                        break;
+                    }
                 }
             }
 

--- a/src/site/template/aurelia/layouts/message/item/default.php
+++ b/src/site/template/aurelia/layouts/message/item/default.php
@@ -40,7 +40,7 @@ $list = [];
         <?php echo $message->getTime()->toSpan('config_postDateFormat', 'config_postDateFormatHover'); ?>
         <?php if ($message->modified_time) :
         ?> - <?php echo KunenaIcons::edit() . ' ' . $message->getModifiedTime()->toSpan('config_postDateFormat', 'config_postDateFormatHover');
-                    endif; ?>
+            endif; ?>
         <a href="#<?php echo $this->message->id; ?>" id="<?php echo $this->message->id; ?>" rel="canonical">#<?php echo $this->getNumlink($this->location); ?></a>
         <span class="d-block d-sm-none"><?php echo Text::_('COM_KUNENA_BY') . ' ' . $message->getAuthor()->getLink(); ?></span>
     </span>
@@ -54,13 +54,13 @@ $list = [];
         echo Text::sprintf($langstr, $message->getAuthor()->getLink(), $this->getTopicLink($this->message->getTopic(), $this->message, $this->message->displayField('subject'), null, KunenaTemplate::getInstance()->tooltips() . ' topictitle')); ?>
         <?php
         if (!empty($this->message->pm) && $this->config->privateMessage) : ?>
-        <div class="kmsg">
-            <div class="kmsgtext-hide">
-                <?php foreach($this->message->pm as $pm) {
-                    echo $pm->displayField('body');
-                } ?>
+            <div class="kmsg">
+                <div class="kmsgtext-hide">
+                    <?php foreach ($this->message->pm as $pm) {
+                        echo $pm->displayField('body');
+                    } ?>
+                </div>
             </div>
-        </div>
         <?php endif ?>
     </div>
     <div class="kmsg">
@@ -81,9 +81,15 @@ $list = [];
     <div class="report pb-5">
         <?php echo KunenaLayout::factory('Widget/Button')
             ->setProperties([
-                'url'   => '#report' . $message->id . '', 'name' => 'report', 'scope' => 'message',
-                'type'  => 'user', 'id' => 'btn_report', 'normal' => '', 'icon' => KunenaIcons::reportname(),
-                'modal' => 'modal', 'pullright' => 'pullright',
+                'url'   => '#report' . $message->id . '',
+                'name' => 'report',
+                'scope' => 'message',
+                'type'  => 'user',
+                'id' => 'btn_report',
+                'normal' => '',
+                'icon' => KunenaIcons::reportname(),
+                'modal' => 'modal',
+                'pullright' => 'pullright',
             ]); ?>
     </div>
     <?php if ($this->me->isModerator($this->topic->getCategory()) || $this->config->userReport || !$this->config->userReport && $this->me->userid != $this->message->userid) : ?>
@@ -106,67 +112,67 @@ $list = [];
     <?php endif; ?>
 <?php endif; ?>
 
-<?php if (!empty($attachments)) : 
-    if (!$this->me->exists() && ($this->config->showImgForGuest || $this->config->showFileForGuest ) || $this->me->exists() && $attachs->inline != count($attachments)) : ?> 	
-	    <div class="card pb-3 pd-3 mb-3">
+<?php if (!empty($attachments)) :
+    if (!$this->me->exists() && ($this->config->showImgForGuest || $this->config->showFileForGuest) || $this->me->exists() && $attachs->inline != count($attachments)) : ?>
+        <div class="card pb-3 pd-3 mb-3">
             <?php if ($this->canSeeAttachments($attachments, $attachs, $this->topic)) : ?>
                 <div class="card-header"><?php echo Text::_('COM_KUNENA_ATTACHMENTS'); ?></div>
-            	<div class="card-body kattach">          		
-             <?php endif; ?>	
-	    <ul class="thumbnails" style="list-style:none;">
-	       		
-	    <?php foreach ($attachments as $attachment) :
-	         if (!$attachment->protected) : ?>
-                  <?php if ($attachment->isAudio()) :
-                       echo $attachment->getLayout()->render('audio'); ?>
-                  <?php elseif ($attachment->isVideo()) :
-                       echo $attachment->getLayout()->render('video'); ?>
-                  <?php else : 
-                       if (!$attachment->inline) : ?>
-                            <li class="col-md-3 text-center">
-                                 <div class="thumbnail">
-                                      <?php echo $attachment->getLayout()->render('thumbnail'); ?>
-                                      <?php echo $attachment->getLayout()->render('textlink'); ?>
-                                 </div>
-                            </li>
-                       <?php endif; ?>
-                  <?php endif; ?>                            
-	         <?php elseif ($attachment->isAuthorised('private')): ?>
-                  <?php if ($attachment->isAudio()) :
-                       echo $attachment->getLayout()->render('audio'); ?>
-                  <?php elseif ($attachment->isVideo()) :
-                       echo $attachment->getLayout()->render('video'); ?>
-                  <?php else :  
-                       if (!$attachment->inline) : ?>
-                            <li class="col-md-3 text-center">
-                                 <div class="thumbnail">
-                                      <?php echo $attachment->getLayout()->render('thumbnail'); ?>
-                                      <?php echo $attachment->getLayout()->render('textlink'); ?>
-                                 </div>
-                            </li>
-                       <?php endif; ?>
-                  <?php endif; ?>
-	         <?php elseif ($this->config->attachmentProtection && $attachment->protected < 32) : 
-                  if (!$attachment->inline) : ?>
-                       <li class="col-md-3 text-center">
-                            <div class="thumbnail">
-                                 <?php echo $attachment->getLayout()->render('thumbnail'); ?>
-                                 <?php echo $attachment->getLayout()->render('textlink'); ?>
-                            </div>
-                       </li>
-                  <?php endif; ?>               
-	         <?php endif;
-	    endforeach; ?>
+                <div class="card-body kattach">
+                <?php endif; ?>
+                <ul class="thumbnails" style="list-style:none;">
 
-						
-						</ul>
-						<?php if ($this->canSeeAttachments($attachments, $attachs, $this->topic)) : ?>						
-            	
-            	</div>
-			<div class="clearfix"></div>
-		<?php endif; ?>
-		</div>
-    <?php  endif; ?> 
+                    <?php foreach ($attachments as $attachment) :
+                        if (!$attachment->protected) : ?>
+                            <?php if ($attachment->isAudio()) :
+                                echo $attachment->getLayout()->render('audio'); ?>
+                            <?php elseif ($attachment->isVideo()) :
+                                echo $attachment->getLayout()->render('video'); ?>
+                                <?php else :
+                                if (!$attachment->inline) : ?>
+                                    <li class="col-md-3 text-center">
+                                        <div class="thumbnail">
+                                            <?php echo $attachment->getLayout()->render('thumbnail'); ?>
+                                            <?php echo $attachment->getLayout()->render('textlink'); ?>
+                                        </div>
+                                    </li>
+                                <?php endif; ?>
+                            <?php endif; ?>
+                        <?php elseif ($attachment->isAuthorised('private')): ?>
+                            <?php if ($attachment->isAudio()) :
+                                echo $attachment->getLayout()->render('audio'); ?>
+                            <?php elseif ($attachment->isVideo()) :
+                                echo $attachment->getLayout()->render('video'); ?>
+                                <?php else :
+                                if (!$attachment->inline) : ?>
+                                    <li class="col-md-3 text-center">
+                                        <div class="thumbnail">
+                                            <?php echo $attachment->getLayout()->render('thumbnail'); ?>
+                                            <?php echo $attachment->getLayout()->render('textlink'); ?>
+                                        </div>
+                                    </li>
+                                <?php endif; ?>
+                            <?php endif; ?>
+                            <?php else :
+                            if (!$attachment->inline) : ?>
+                                <li class="col-md-3 text-center">
+                                    <div class="thumbnail">
+                                        <?php echo $attachment->getLayout()->render('thumbnail'); ?>
+                                        <?php echo $attachment->getLayout()->render('textlink'); ?>
+                                    </div>
+                                </li>
+                            <?php endif; ?>
+                    <?php endif;
+                    endforeach; ?>
+
+
+                </ul>
+                <?php if ($this->canSeeAttachments($attachments, $attachs, $this->topic)) : ?>
+
+                </div>
+                <div class="clearfix"></div>
+            <?php endif; ?>
+        </div>
+    <?php endif; ?>
 <?php endif; ?>
 
 
@@ -206,4 +212,3 @@ $list = [];
         ?>
     </div>
 <?php endif;
-

--- a/src/site/template/aurelia/layouts/message/item/default.php
+++ b/src/site/template/aurelia/layouts/message/item/default.php
@@ -127,33 +127,7 @@ $list = [];
                                 echo $attachment->getLayout()->render('audio'); ?>
                             <?php elseif ($attachment->isVideo()) :
                                 echo $attachment->getLayout()->render('video'); ?>
-                                <?php else :
-                                if (!$attachment->inline) : ?>
-                                    <li class="col-md-3 text-center">
-                                        <div class="thumbnail">
-                                            <?php echo $attachment->getLayout()->render('thumbnail'); ?>
-                                            <?php echo $attachment->getLayout()->render('textlink'); ?>
-                                        </div>
-                                    </li>
-                                <?php endif; ?>
-                            <?php endif; ?>
-                        <?php elseif ($attachment->isAuthorised('private')): ?>
-                            <?php if ($attachment->isAudio()) :
-                                echo $attachment->getLayout()->render('audio'); ?>
-                            <?php elseif ($attachment->isVideo()) :
-                                echo $attachment->getLayout()->render('video'); ?>
-                                <?php else :
-                                if (!$attachment->inline) : ?>
-                                    <li class="col-md-3 text-center">
-                                        <div class="thumbnail">
-                                            <?php echo $attachment->getLayout()->render('thumbnail'); ?>
-                                            <?php echo $attachment->getLayout()->render('textlink'); ?>
-                                        </div>
-                                    </li>
-                                <?php endif; ?>
-                            <?php endif; ?>
-                            <?php else :
-                            if (!$attachment->inline) : ?>
+                            <?php elseif (!$attachment->inline) : ?>
                                 <li class="col-md-3 text-center">
                                     <div class="thumbnail">
                                         <?php echo $attachment->getLayout()->render('thumbnail'); ?>
@@ -161,13 +135,30 @@ $list = [];
                                     </div>
                                 </li>
                             <?php endif; ?>
+                        <?php elseif ($attachment->isAuthorised('private')): ?>
+                            <?php if ($attachment->isAudio()) :
+                                echo $attachment->getLayout()->render('audio'); ?>
+                            <?php elseif ($attachment->isVideo()) :
+                                echo $attachment->getLayout()->render('video'); ?>
+                            <?php elseif (!$attachment->inline) : ?>
+                                <li class="col-md-3 text-center">
+                                    <div class="thumbnail">
+                                        <?php echo $attachment->getLayout()->render('thumbnail'); ?>
+                                        <?php echo $attachment->getLayout()->render('textlink'); ?>
+                                    </div>
+                                </li>
+                            <?php endif; ?>
+                        <?php elseif ($attachment->protected < 32 && !$attachment->inline) : ?>
+                            <li class="col-md-3 text-center">
+                                <div class="thumbnail">
+                                    <?php echo $attachment->getLayout()->render('thumbnail'); ?>
+                                    <?php echo $attachment->getLayout()->render('textlink'); ?>
+                                </div>
+                            </li>
                     <?php endif;
                     endforeach; ?>
-
-
                 </ul>
                 <?php if ($this->canSeeAttachments($attachments, $attachs, $this->topic)) : ?>
-
                 </div>
                 <div class="clearfix"></div>
             <?php endif; ?>


### PR DESCRIPTION
…message

Pull Request for Issue # descibed here . 

1. PHP version 8.5 (could also be issue for 8.4), Joomla 6.0.3
2. in Joomla Global Configuration, set Error Reporting to Maximum
3. login in on front-end
4. in Kunena Forum, click [New Topic]  in menu navbar
5. fill in / select:
 6. category
 7. subject
 8. message
9. click [Add Files] and select a file, e.g. an image
10. do NOT insert this in message and do not set it as private! but directly click [submit]

you will directly get an error 404 because the URI in the browser redirected to after submit has deprecated messages in it and as such cannot be parsed correctly
```
/forum/<br /><b>Deprecated</b>:%20 Using null as an array offset is deprecated, use an empty string instead in <b>/var/www/vhosts/developmenthub.nl/och.developmenthub.nl/j4/libraries/kunena/src/Route/KunenaRoute.php</b> on line <b>324</b><br /><br /><b>Deprecated</b>:%20 Using null as an array offset is deprecated, use an empty string instead in <b>/var/www/vhosts/developmenthub.nl/och.developmenthub.nl/j4/libraries/kunena/src/Route/KunenaRoute.php</b> on line <b>335</b><br />/j4/forum
```

#### Summary of Changes 
in the KunenaRoute.php we get the view needed to build the URI, but because the view is missing the get defaults to null. we do not check this and try to use null as index key which will give the deprecated messages.

#### Testing Instructions
See case above.

Initially Ithought this was the issue posted by @makitso and @c-schmitz but this turned out to be a different not yet raised issue.

pinging also @xillibit and @rich20 