### PR TITLE
Fix for #10017

### DIFF
--- a/src/site/src/Service/Router.php
+++ b/src/site/src/Service/Router.php
@@ -374,7 +374,9 @@ class Router extends RouterView
                     $vars    = $variables + $vars;
                     continue;
                 } else {
-                    break;
+                    if ($segment !== 'attachment') {
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
Pull Request for Issue #10017  . 
 
#### Summary of Changes 
When adding an attachment AND kunena is configured to 'protect attachments = yes', the the attachments gets a sef URL, the build for this url failed due to earlier change. This PR fixes that.

#### Testing Instructions

Do not only test the issue as described in https://github.com/Kunena/Kunena-Forum/issues/10017#issuecomment-4031177476

But test all scenario's where URLs are build for kunena, so topics, links, user settings, attachment, announcements, etc.