### PR TITLE
Fix undefined variable language afterlogin on kunena plugin system

### DIFF
--- a/src/plugins/plg_system_kunena/src/Extension/Kunena.php
+++ b/src/plugins/plg_system_kunena/src/Extension/Kunena.php
@@ -205,8 +205,9 @@ class Kunena extends CMSPlugin implements SubscriberInterface, DatabaseAwareInte
      */
     protected function getUserDefaultLanguage($params)
     {
-        if (!empty($params)) {
-            $userParams = json_decode($params);
+        $userParams = json_decode($params);
+        
+        if (!empty($userParams->language)) {              
             $language = $userParams->language;
         } else {
             $language = Factory::getApplication()->getLanguage()->getTag();


### PR DESCRIPTION
Pull Request for Issue # . 
 
Warning:  Undefined property: stdClass::$language in \Kunena-forum-7.0\src\plugins\plg_system_kunena\src\Extension\Kunena.php on line 210

#### Summary of Changes 
 
#### Testing Instructions

Login on kunena you shouldn't have this warning on log