### PR TITLE
[K7.0] Create method bootApi to load only api.php to be used in modules and plugins

### DIFF
--- a/src/admin/src/Extension/ForumComponent.php
+++ b/src/admin/src/Extension/ForumComponent.php
@@ -52,24 +52,9 @@ class ForumComponent extends MVCComponent implements BootableExtensionInterface,
     {
         $this->getRegistry()->register('kunenagrid', new Kunenagrid($container->get(SiteApplication::class)));
         $this->getRegistry()->register('kunenaforum', new Kunenaforum($container->get(SiteApplication::class)));
-
+    
         // Load Kunena API and autoload vendor libraries
         require_once JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
         require_once JPATH_LIBRARIES . '/kunena/External/autoload.php';
-    }
-    
-    /**
-     * Booting the api file when it's needed in plugins and modules to avoid to use boot().
-     *
-     * Plugins and modules doens't need extra things like are loaded with boot().
-     *
-     * @return  void
-     *
-     * @since   Kunena 7.0.4
-     */
-    public function bootApi()
-    {
-        require_once JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
-    }
-        
+    }        
 }

--- a/src/admin/src/Extension/ForumComponent.php
+++ b/src/admin/src/Extension/ForumComponent.php
@@ -56,5 +56,5 @@ class ForumComponent extends MVCComponent implements BootableExtensionInterface,
         // Load Kunena API and autoload vendor libraries
         require_once JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
         require_once JPATH_LIBRARIES . '/kunena/External/autoload.php';
-    }    
+    }
 }

--- a/src/admin/src/Extension/ForumComponent.php
+++ b/src/admin/src/Extension/ForumComponent.php
@@ -52,9 +52,9 @@ class ForumComponent extends MVCComponent implements BootableExtensionInterface,
     {
         $this->getRegistry()->register('kunenagrid', new Kunenagrid($container->get(SiteApplication::class)));
         $this->getRegistry()->register('kunenaforum', new Kunenaforum($container->get(SiteApplication::class)));
-    
+
         // Load Kunena API and autoload vendor libraries
         require_once JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
         require_once JPATH_LIBRARIES . '/kunena/External/autoload.php';
-    }        
+    }    
 }

--- a/src/admin/src/Extension/ForumComponent.php
+++ b/src/admin/src/Extension/ForumComponent.php
@@ -57,4 +57,19 @@ class ForumComponent extends MVCComponent implements BootableExtensionInterface,
         require_once JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
         require_once JPATH_LIBRARIES . '/kunena/External/autoload.php';
     }
+    
+    /**
+     * Booting the api file when it's needed in plugins and modules to avoid to use boot().
+     *
+     * Plugins and modules doens't need extra things like are loaded with boot().
+     *
+     * @return  void
+     *
+     * @since   Kunena 7.0.4
+     */
+    public function bootApi()
+    {
+        require_once JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
+    }
+        
 }

--- a/src/libraries/kunena/src/Forum/KunenaForum.php
+++ b/src/libraries/kunena/src/Forum/KunenaForum.php
@@ -525,4 +525,16 @@ abstract class KunenaForum
         // Render the view.
         $view->displayLayout($layout, $template);
     }
+    
+    /**
+     * Just load the API to be used in modules and plugins instead of booting component.
+     *
+     *
+     * @return  void
+     *
+     * @since   Kunena 7.0
+     */
+    public static function loadApi() {
+        require_once JPATH_ADMINISTRATOR . '/components/com_kunena/api/api.php';
+    }
 }


### PR DESCRIPTION
Pull Request for Issue # . 

For users experiencing issue with moudles and plungs like : https://www.kunena.org/forum/kunena-7-0-0-support/169084-error-undefined-constant-kunena-forum-libraries-factory-kpath_site?start=0 : 

`Undefined constant "Kunena\Forum\Libraries\Factory\KPATH_SITE`
`Undefined constant "Kunena\Forum\Plugin\Kunena\Gravatar\Extension\KPATH_FRAMEWORK`
 
#### Summary of Changes 
 
#### Testing Instructions