### PR TITLE
[K7.0] Allow to save changes in message when the private part is

### DIFF
--- a/src/site/language/en-GB/com_kunena.ini
+++ b/src/site/language/en-GB/com_kunena.ini
@@ -693,6 +693,7 @@ COM_KUNENA_SENDMAIL_REPLYMODERATOR_SUBJECT = "A message has been reported on top
 COM_KUNENA_SENDMAIL_BODY_REPORTMODERATOR = "A message has been reported on the Forum with the following reason : {REASON} and with the following message : {REASONMESSAGE}.\n\nMessage Subject : {SUBJECT}.\nPosted by : {NAME}.\nURL : {MESSAGEURL}.\nMessage: {MESSAGE}"
 COM_KUNENA_SENDMAIL_REPORT_SUBJECT = "Message reported : {SUBJECT}"
 COM_KUNENA_POST_WITH_PRIVATE_ATTACHMENTS_SAVED = "No private message has been set, only private attachments"
+COM_KUNENA_POST_WITH_PRIVATE_ATTACHMENTS_SAVED_NO_ATTACHEMENTS = "No private message has been set"
 
 ; JROOT/components/com_kunena/controllers/topics.php
 

--- a/src/site/src/Controllers/TopicController.php
+++ b/src/site/src/Controllers/TopicController.php
@@ -1589,7 +1589,9 @@ class TopicController extends KunenaController
             return;
         }
 
-        $attachIds = explode(',', $attachIds[0]);
+        if (isset($attachIds[0])) {
+            $attachIds = explode(',', $attachIds[0]);
+        }
 
         $finder    = new KunenaPrivateMessageFinder();
         $finder
@@ -1607,9 +1609,11 @@ class TopicController extends KunenaController
         }
 
         $private->subject = $message->subject;
-
-        if (!trim($body)) {
+        $attachs = $message->getAttachments();
+        if ($message->message && !trim($body) && count($attachs) > 0) {
             $private->body      = Text::_('COM_KUNENA_POST_WITH_PRIVATE_ATTACHMENTS_SAVED');
+        } elseif ($message->message && !trim($body) && count($attachs ) == 0) {
+            $private->body      = Text::_('COM_KUNENA_POST_WITH_PRIVATE_ATTACHMENTS_SAVED_NO_ATTACHEMNTS');
         } else {
             $private->body      = $body;
         }

--- a/src/site/src/Controllers/TopicController.php
+++ b/src/site/src/Controllers/TopicController.php
@@ -1612,8 +1612,8 @@ class TopicController extends KunenaController
         $attachs = $message->getAttachments();
         if ($message->message && !trim($body) && count($attachs) > 0) {
             $private->body      = Text::_('COM_KUNENA_POST_WITH_PRIVATE_ATTACHMENTS_SAVED');
-        } elseif ($message->message && !trim($body) && count($attachs ) == 0) {
-            $private->body      = Text::_('COM_KUNENA_POST_WITH_PRIVATE_ATTACHMENTS_SAVED_NO_ATTACHEMNTS');
+        } elseif ($message->message && !trim($body) && count($attachs) == 0) {
+            $private->body      = Text::_('COM_KUNENA_POST_WITH_PRIVATE_ATTACHMENTS_SAVED_NO_ATTACHEMENTS');
         } else {
             $private->body      = $body;
         }


### PR DESCRIPTION
empty #10031

Pull Request for Issue # . 
 
See : https://www.kunena.org/forum/kunena-7-0-0-support/169118-can-t-delete-private-part-of-topic-messages

#### Summary of Changes 
 
#### Testing Instructions