### PR TITLE
[K7.0] Handle null category iconset when rendering topic icons

### DIFF
--- a/src/libraries/kunena/src/Template/KunenaTemplate.php
+++ b/src/libraries/kunena/src/Template/KunenaTemplate.php
@@ -1270,7 +1270,7 @@ HTML;
     public function getTopicIcon(KunenaTopic $topic): string
     {
         $topicicontype   = $this->params->get('topicicontype');
-        $categoryIconset = $topic->getCategory()->iconset;
+        $categoryIconset = $topic->getCategory()->iconset ?: 'default';
 
         if ($this->config->topicIcons) {
             $xmlfile = JPATH_ROOT . '/media/kunena/topic_icons/' . $categoryIconset . '/topicicons.xml';


### PR DESCRIPTION
Hi @xillibit and Kunena team,

First contribution from me. We use Kunena on a community forum and ran into this one while getting a fresh install up on Joomla 6, so figured the fix might be useful upstream too. Really appreciate the work you all put into keeping the project going.

Not linked to an existing forum thread; happy to open one if you'd prefer that as the canonical discussion home, and I'll adjust the approach if you'd rather see it done differently.

#### Summary of Changes

One-line change in `KunenaTemplate::getTopicIcon()` to coalesce a possibly-null category iconset to `'default'` at the point of assignment:

```diff
-        $categoryIconset = $topic->getCategory()->iconset;
+        $categoryIconset = $topic->getCategory()->iconset ?: 'default';
```

The underlying issue: when a category is created without a custom SVG iconset, `#__kunena_categories.iconset` is stored as `NULL`. That null reaches two `KunenaSvgIcons::loadsvg()` calls in the same method (lines 1317 and 1375), whose third argument is typed `string` (no nullable). The result is a hard fatal:

```
TypeError: KunenaSvgIcons::loadsvg(): Argument #3 ($iconset)
must be of type string, null given
```

On Joomla 6 the fatal gets absorbed further up the stack by a `class_exists()` check and surfaces to the user as the somewhat misleading message `View not found [name, type, prefix]: topic, html, site`. On Joomla 5 it is the plain TypeError.

Two `<img src="...">` fragments in the same method also interpolate `$categoryIconset` into the image path, so in the null case they render as `/media/kunena/topic_icons//...` (double slash). The one-line coalesce fixes those too, which is why I did it at the source rather than adding guards at each `loadsvg()` call site.

Since `loadsvg()`'s own default for the third argument is already `'default'`, the runtime behavior for a null iconset now matches the behavior for an explicit `'default'` iconset. No behavioral delta for installs that were already working, just a clean exit for the null path.

#### Testing Instructions

1. Install Kunena 7.0.4 on Joomla 6.0.x (Joomla 5.x exhibits the same TypeError, so either works for repro).
2. In **Kunena → Configuration → General**, set **Category and Topic Icons** enabled and **Topic Icon Type** to `svg`.
3. Create a category and leave **Topic Icon Set** at its default (don't pick a custom iconset). The DB column `#__kunena_categories.iconset` will be `NULL`.
4. Visit any page that renders the category row or topic list with SVG icons.

Before the patch: fatal `TypeError` (or "View not found" on J6).
After the patch: the topic icon renders from the default iconset, same as if the admin had explicitly selected `default`.

No automated test added — I couldn't find existing test coverage for `getTopicIcon()` in the repo, so verified manually per the steps above. Happy to add something if you'd like; just point me at a similar test you'd want me to pattern it after.

<details><summary>Stack trace (click to expand)</summary>

```
PHP Fatal error:  Uncaught TypeError: KunenaSvgIcons::loadsvg(): Argument #3 ($iconset)
must be of type string, null given, called in .../libraries/kunena/src/Template/KunenaTemplate.php
on line 1317 and defined in .../libraries/kunena/src/Icons/KunenaSvgIcons.php:38
Stack trace:
#0 .../libraries/kunena/src/Template/KunenaTemplate.php(1317):
   Kunena\Forum\Libraries\Icons\KunenaSvgIcons::loadsvg('...', 'usertopicIcons', NULL)
#1 .../components/com_kunena/template/aurelia/pages/category/item/default.php:
   Kunena\Forum\Libraries\Template\KunenaTemplate->getTopicIcon(Object(KunenaTopic))
```

For reference, the non-nullable signature that fatals on null:

```php
// src/libraries/kunena/src/Icons/KunenaSvgIcons.php:38
public static function loadsvg(
    string $svgname,
    string $group = 'default',
    string $iconset = 'default'
): string
```

</details>

#### Environment

- Kunena: 7.0.4 (verified still present on `K7.0` HEAD at time of PR — file unchanged since the 7.0.4 tag; same code path in `K7.1`)
- Joomla: 6.0.x (also reproduces on 5.x)
- PHP: 8.3

---

No existing issue covered this — I searched `categoryIconset`, `loadsvg`, `iconset null`, and the exact TypeError message in both issues and PRs before drafting. If I missed a duplicate or an in-flight fix, apologies in advance and just let me know.

Thanks for the review, and glad to iterate on whatever you'd like changed.
