### PR TITLE
Fix: avatars in mention should be limited in size

### DIFF
--- a/src/site/template/aurelia/assets/js/edit.js
+++ b/src/site/template/aurelia/assets/js/edit.js
@@ -8,41 +8,45 @@
  **/
 
 jQuery(document).ready(function ($) {
-    const qreply = $('.qreply');
-    const editor = $('#editor');
+    const qreply = $(".qreply");
+    const editor = $("#editor");
 
-    if(Joomla.getOptions('com_kunena.pollcategoriesid') != undefined){
-		var pollcategoriesid = jQuery.parseJSON(Joomla.getOptions('com_kunena.pollcategoriesid'));
+    if (Joomla.getOptions("com_kunena.pollcategoriesid") != undefined) {
+        var pollcategoriesid = jQuery.parseJSON(
+            Joomla.getOptions("com_kunena.pollcategoriesid"),
+        );
     }
 
-    const pollexist = $('#poll_exist_edit');
-    const pollcatid = jQuery('#poll_catid').val();
+    const pollexist = $("#poll_exist_edit");
+    const pollcatid = jQuery("#poll_catid").val();
     const polliconstatus = false;
 
     // Check is anynomous options can be displayed on newtopic page
-    const catiddefault = $('#postcatid').val();
+    const catiddefault = $("#postcatid").val();
 
-    if(Joomla.getOptions('com_kunena.arrayanynomousbox') != undefined){
-		const arrayanynomousbox = jQuery.parseJSON(Joomla.getOptions('com_kunena.arrayanynomousbox'));
+    if (Joomla.getOptions("com_kunena.arrayanynomousbox") != undefined) {
+        const arrayanynomousbox = jQuery.parseJSON(
+            Joomla.getOptions("com_kunena.arrayanynomousbox"),
+        );
 
-		if (arrayanynomousbox !== null) {
+        if (arrayanynomousbox !== null) {
             if (arrayanynomousbox[catiddefault] == 1) {
-                $('#kanonymous').prop('checked', true);
+                $("#kanonymous").prop("checked", true);
             }
         }
     }
 
-    $('#reset').onclick = function () {
-        localStorage.removeItem('copyKunenaeditor');
+    $("#reset").onclick = function () {
+        localStorage.removeItem("copyKunenaeditor");
     };
 
     /* To enabled emojis in kunena textera feature like on github */
-    if ($('#kemojis_allowed').val() == 1) {
-        let item = '';
+    if ($("#kemojis_allowed").val() == 1) {
+        let item = "";
         if (editor.length > 0 && qreply.length == 0) {
-            item = '#editor';
+            item = "#editor";
         } else if (qreply.length > 0) {
-            item = '.qreply';
+            item = ".qreply";
         }
     }
 
@@ -50,27 +54,27 @@ jQuery(document).ready(function ($) {
     if ($.fn.sisyphus !== undefined) {
         $("#postform").sisyphus({
             locationBased: true,
-            timeout: 5
+            timeout: 5,
         });
     }
 
-    $('#kshow_attach_form').click(function () {
-        if ($('#kattach_form').is(":visible")) {
-            $('#kattach_form').hide();
+    $("#kshow_attach_form").click(function () {
+        if ($("#kattach_form").is(":visible")) {
+            $("#kattach_form").hide();
         } else {
-            $('#kattach_form').show();
+            $("#kattach_form").show();
         }
     });
 
-    $('#form_submit_button').click(function () {
-        $("#subject").attr('required', 'required');
-        $("#editor").attr('required', 'required');
-        localStorage.removeItem('copyKunenaeditor');
+    $("#form_submit_button").click(function () {
+        $("#subject").attr("required", "required");
+        $("#editor").attr("required", "required");
+        localStorage.removeItem("copyKunenaeditor");
     });
 
     // Needed to open and close quickreply from template
-    $('.Kreplyclick').click(function () {
-        const name = '#' + $(this).attr('data-related');
+    $(".Kreplyclick").click(function () {
+        const name = "#" + $(this).attr("data-related");
         if ($(name).is(":visible")) {
             $(name).hide();
         } else {
@@ -78,140 +82,178 @@ jQuery(document).ready(function ($) {
         }
     });
 
-    $('.kreply-cancel').click(function () {
-        const name = '#' + $(this).attr('data-related');
+    $(".kreply-cancel").click(function () {
+        const name = "#" + $(this).attr("data-related");
         $(name).hide();
     });
 
     let category_template_text = null;
-    $('#postcatid').change(function () {
-        const catid = $('select#postcatid option').filter(':selected').val();
-        const kurl_topicons_request = $('#kurl_topicons_request').val();
-        const pollcategoriesid = jQuery.parseJSON(Joomla.getOptions('com_kunena.pollcategoriesid'));
-        const pollexist = jQuery('#poll_exist_edit');
-        const pollcatid = jQuery('#poll_catid').val();
+    $("#postcatid").change(function () {
+        const catid = $("select#postcatid option").filter(":selected").val();
+        const kurl_topicons_request = $("#kurl_topicons_request").val();
+        const pollcategoriesid = jQuery.parseJSON(
+            Joomla.getOptions("com_kunena.pollcategoriesid"),
+        );
+        const pollexist = jQuery("#poll_exist_edit");
+        const pollcatid = jQuery("#poll_catid").val();
         const polliconstatus = true;
 
-        if (typeof pollcategoriesid !== 'undefined' && pollcategoriesid !== null && pollexist.length === 0) {
+        if (
+            typeof pollcategoriesid !== "undefined" &&
+            pollcategoriesid !== null &&
+            pollexist.length === 0
+        ) {
             if (pollcatid !== undefined) {
-                const catid = jQuery('#kcategory_poll').val();
+                const catid = jQuery("#kcategory_poll").val();
             }
 
             if (pollcategoriesid[catid] !== undefined) {
-                if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-                    CKEDITOR.instances.message.getCommand('polls').enable();
+                if (
+                    Joomla.getOptions("com_kunena.ckeditor_config") !==
+                    undefined
+                ) {
+                    CKEDITOR.instances.message.getCommand("polls").enable();
                 }
-
             } else {
-				if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-                    CKEDITOR.instances.message.getCommand('polls').disable();
+                if (
+                    Joomla.getOptions("com_kunena.ckeditor_config") !==
+                    undefined
+                ) {
+                    CKEDITOR.instances.message.getCommand("polls").disable();
                 }
-
             }
         } else if (pollexist.length > 0) {
-			if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-                CKEDITOR.instances.message.getCommand('polls').enable();
+            if (Joomla.getOptions("com_kunena.ckeditor_config") !== undefined) {
+                CKEDITOR.instances.message.getCommand("polls").enable();
             }
-
         } else {
-			if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-                CKEDITOR.instances.message.getCommand('polls').disable();
+            if (Joomla.getOptions("com_kunena.ckeditor_config") !== undefined) {
+                CKEDITOR.instances.message.getCommand("polls").disable();
             }
-
         }
 
-        if ($('#kanynomous-check').length > 0) {
+        if ($("#kanynomous-check").length > 0) {
             if (arrayanynomousbox[catid] !== undefined) {
-                $('#kanynomous-check').show();
-                $('#kanonymous').prop('checked', true);
+                $("#kanynomous-check").show();
+                $("#kanonymous").prop("checked", true);
             } else {
-                $('#kanynomous-check').hide();
-                $('#kanonymous').prop('checked', false);
+                $("#kanynomous-check").hide();
+                $("#kanonymous").prop("checked", false);
             }
         }
 
         // Load topic icons by ajax request
-      $.ajax({
-    type: 'POST',
-    url: kurl_topicons_request,
-    async: true,
-    dataType: 'json',
-    data: {catid: catid}
-})
-.done(function (data) {
-    $('#iconset_topicList').remove();
+        $.ajax({
+            type: "POST",
+            url: kurl_topicons_request,
+            async: true,
+            dataType: "json",
+            data: { catid: catid },
+        })
+            .done(function (data) {
+                $("#iconset_topicList").remove();
 
-    const div_object = $('<div>', {'id': 'iconset_topicList'});
-    $('#iconset_inject').append(div_object);
+                const div_object = $("<div>", { id: "iconset_topicList" });
+                $("#iconset_inject").append(div_object);
 
-    $.each(data, function (index, value) {
-        if (value.type !== 'system') {
-            // Create input consistently for all icons
-            const input = $('<input>', {
-                type: 'radio',
-                id: 'radio' + value.id,
-                name: 'topic_emoticon',
-                value: value.id,
-                // Set first icon as checked by default
-                ...(index === 0 ? { checked: true } : {})
+                $.each(data, function (index, value) {
+                    if (value.type !== "system") {
+                        // Create input consistently for all icons
+                        const input = $("<input>", {
+                            type: "radio",
+                            id: "radio" + value.id,
+                            name: "topic_emoticon",
+                            value: value.id,
+                            // Set first icon as checked by default
+                            ...(index === 0 ? { checked: true } : {}),
+                        });
+
+                        // Create span with consistent class
+                        const span_object = $("<span>", {
+                            class: "kiconsel",
+                        }).append(input);
+
+                        // Create label consistently based on icon type
+                        let label;
+                        if (
+                            Joomla.getOptions(
+                                "com_kunena.kunena_topicicontype",
+                            ) === "fa"
+                        ) {
+                            label = $("<label>", {
+                                class: "radio inline",
+                                for: "radio" + value.id,
+                            }).append(
+                                $("<i>", {
+                                    class:
+                                        "fa glyphicon-topic fa-2x fa-" +
+                                        value.fa,
+                                    border: "0",
+                                    al: "",
+                                }),
+                            );
+                        } else if (
+                            Joomla.getOptions(
+                                "com_kunena.kunena_topicicontype",
+                            ) === "svg"
+                        ) {
+                            label = $("<label>", {
+                                class: "radio inline",
+                                for: "radio" + value.id,
+                            }).append($(value.svg));
+                        } else {
+                            label = $("<label>", {
+                                class: "radio inline",
+                                for: "radio" + value.id,
+                            }).append(
+                                $("<img>", {
+                                    src: value.path,
+                                    border: "0",
+                                    al: "",
+                                }),
+                            );
+                        }
+
+                        span_object.append(label);
+                        $("#iconset_topicList").append(span_object);
+                    }
+                });
+            })
+            .fail(function () {
+                //TODO: handle the error of ajax request
             });
-
-            // Create span with consistent class
-            const span_object = $('<span>', {'class': 'kiconsel'}).append(input);
-
-            // Create label consistently based on icon type
-            let label;
-            if (Joomla.getOptions('com_kunena.kunena_topicicontype') === 'fa') {
-                label = $('<label>', {
-                    'class': 'radio inline',
-                    'for': 'radio' + value.id
-                }).append($('<i>', {
-                    'class': 'fa glyphicon-topic fa-2x fa-' + value.fa,
-                    'border': '0',
-                    'al': ''
-                }));
-            } else if (Joomla.getOptions('com_kunena.kunena_topicicontype') === 'svg') {
-                label = $('<label>', {
-                    'class': 'radio inline',
-                    'for': 'radio' + value.id
-                }).append($(value.svg));
-            } else {
-                label = $('<label>', {
-                    'class': 'radio inline',
-                    'for': 'radio' + value.id
-                }).append($('<img>', {'src': value.path, 'border': '0', 'al': ''}));
-            }
-
-            span_object.append(label);
-            $('#iconset_topicList').append(span_object);
-        }
-    });
-})
-.fail(function () {
-    //TODO: handle the error of ajax request
-});
         // Load template text for the category by ajax request
-        category_template_text = function cat_template_text() {
+        category_template_text = (function cat_template_text() {
             return $.ajax({
-                type: 'POST',
-                url: $('#kurl_category_template_text').val(),
+                type: "POST",
+                url: $("#kurl_category_template_text").val(),
                 async: true,
-                dataType: 'json',
-                data: {catid: catid}
+                dataType: "json",
+                data: { catid: catid },
             })
                 .done(function (data) {
-                    if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-                        const editor_text = CKEDITOR.instances.message.getData();
+                    if (
+                        Joomla.getOptions("com_kunena.ckeditor_config") !==
+                        undefined
+                    ) {
+                        const editor_text =
+                            CKEDITOR.instances.message.getData();
 
                         if (editor_text.length > 1) {
                             if (editor_text.length > 1) {
-                                $('#modal_confirm_template_category').modal('show');
+                                $("#modal_confirm_template_category").modal(
+                                    "show",
+                                );
                             } else {
-                                CKEDITOR.instances.message.setData(category_template_text);
+                                CKEDITOR.instances.message.setData(
+                                    category_template_text,
+                                );
                             }
                         } else {
                             if (data.length > 1) {
-                                $('#modal_confirm_template_category').modal('show');
+                                $("#modal_confirm_template_category").modal(
+                                    "show",
+                                );
                             } else {
                                 CKEDITOR.instances.message.setData(data.data);
                             }
@@ -221,46 +263,51 @@ jQuery(document).ready(function ($) {
                 .fail(function () {
                     //TODO: handle the error of ajax request
                 });
-        }();
+        })();
     });
 
-    $('#modal_confirm_erase').click(function () {
-        $('#modal_confirm_template_category').modal('hide');
+    $("#modal_confirm_erase").click(function () {
+        $("#modal_confirm_template_category").modal("hide");
         const textarea = $("#editor").next();
         textarea.empty();
-        CKEDITOR.instances.message.setData(category_template_text?.responseJSON?.data);
+        CKEDITOR.instances.message.setData(
+            category_template_text?.responseJSON?.data,
+        );
     });
 
-    $('#modal_confirm_erase_keep_old').click(function () {
-        $('#modal_confirm_template_category').modal('hide');
+    $("#modal_confirm_erase_keep_old").click(function () {
+        $("#modal_confirm_template_category").modal("hide");
         const existing_content = CKEDITOR.instances.message.getData();
         const textarea = $("#editor").next();
         textarea.empty();
-        CKEDITOR.instances.message.setData(category_template_text?.responseJSON?.data + ' ' + existing_content);
+        CKEDITOR.instances.message.setData(
+            category_template_text?.responseJSON?.data + " " + existing_content,
+        );
     });
 
     if ($.fn.datepicker !== undefined) {
         // Load datepicker for poll
-        $('#datepoll-container .input-append.date').datepicker({
-            orientation: "top auto"
+        $("#datepoll-container .input-append.date").datepicker({
+            orientation: "top auto",
         });
     }
 
-	$('#gotoeditor').click(function () {
-		localStorage.setItem("copyKunenaeditor", $('#editor').val());
-	});
+    $("#gotoeditor").click(function () {
+        localStorage.setItem("copyKunenaeditor", $("#editor").val());
+    });
 
-    if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
-        CKEDITOR.replace('message', {
-			customConfig: Joomla.getOptions('com_kunena.ckeditor_config'),
-			on: {
-				instanceReady: function (event) {
-					CKEDITOR.plugins.clipboard.preventDefaultDropOnElement(event.editor.document);
+    if (Joomla.getOptions("com_kunena.ckeditor_config") !== undefined) {
+        CKEDITOR.replace("message", {
+            customConfig: Joomla.getOptions("com_kunena.ckeditor_config"),
+            on: {
+                instanceReady: function (event) {
+                    CKEDITOR.plugins.clipboard.preventDefaultDropOnElement(
+                        event.editor.document,
+                    );
 
-					if (event.editor.getData().length > 0)
-					{
-						$('#form_submit_button').removeAttr("disabled");
-					}
+                    if (event.editor.getData().length > 0) {
+                        $("#form_submit_button").removeAttr("disabled");
+                    }
 
                     event.editor.on("beforeCommandExec", function (event) {
                         // Show the paste dialog for the paste buttons and right-click paste
@@ -269,144 +316,162 @@ jQuery(document).ready(function ($) {
                         }
 
                         // Don't show the paste dialog for Ctrl+Shift+V
-                        if (event.data.name == "pastetext" && event.data.commandData.from == "keystrokeHandler") {
+                        if (
+                            event.data.name == "pastetext" &&
+                            event.data.commandData.from == "keystrokeHandler"
+                        ) {
                             event.cancel();
                         }
-                    })
-                    
-				},
-				change : function (event) {
-					if (event.editor.getData().length > 0)
-					{
-						$('#form_submit_button').removeAttr("disabled");
-					}
+                    });
+                },
+                change: function (event) {
+                    if (event.editor.getData().length > 0) {
+                        $("#form_submit_button").removeAttr("disabled");
+                    }
 
-					if (event.editor.getData().length == 0 && $('#form_submit_button').disabled === undefined)
-					{
-						$('#form_submit_button').prop("disabled", true);
-					}
-
-				},
+                    if (
+                        event.editor.getData().length == 0 &&
+                        $("#form_submit_button").disabled === undefined
+                    ) {
+                        $("#form_submit_button").prop("disabled", true);
+                    }
+                },
                 mode: function (evt) {
-                    const cat = localStorage.getItem('copyKunenaeditor');
+                    const cat = localStorage.getItem("copyKunenaeditor");
 
                     if (cat) {
                         evt.editor.setData(cat);
-                        localStorage.removeItem('copyKunenaeditor');
+                        localStorage.removeItem("copyKunenaeditor");
                     }
 
                     if (polliconstatus === false) {
                         if (pollcatid !== undefined) {
-                            if (typeof pollcategoriesid !== 'undefined' && pollcategoriesid !== null && pollexist.length === 0) {
-                                const catid = $('#kcategory_poll').val();
+                            if (
+                                typeof pollcategoriesid !== "undefined" &&
+                                pollcategoriesid !== null &&
+                                pollexist.length === 0
+                            ) {
+                                const catid = $("#kcategory_poll").val();
 
                                 if (pollcategoriesid[catid] !== undefined) {
-                                    evt.editor.getCommand('polls').enable();
+                                    evt.editor.getCommand("polls").enable();
                                 } else {
-                                    evt.editor.getCommand('polls').disable();
+                                    evt.editor.getCommand("polls").disable();
                                 }
                             } else if (pollexist.length > 0) {
-                                evt.editor.getCommand('polls').enable();
+                                evt.editor.getCommand("polls").enable();
                             } else {
-                                evt.editor.getCommand('polls').disable();
+                                evt.editor.getCommand("polls").disable();
                             }
                         } else {
-                            evt.editor.getCommand('polls').disable();
+                            evt.editor.getCommand("polls").disable();
                         }
                     }
-                }
+                },
             },
-            mentions: [ {
-      feed: dataFeed,
-      itemTemplate:
-        '<li data-id="{id}">' +
-        '<img src="{avatar}" />' +
-        ' '+
-        '<strong class="username">{username}</strong>' +
-        '</li>',
-      outputTemplate:
-        '[mention userid={userid}]{username}[/mention]',
-      minChars: 1
-    }
-  ]
+            mentions: [
+                {
+                    feed: dataFeed,
+                    itemTemplate:
+                        '<li data-id="{id}">' +
+                        '<img src="{avatar}" width="36" height="36"/>' +
+                        " " +
+                        '<strong class="username">{username}</strong>' +
+                        "</li>",
+                    outputTemplate:
+                        "[mention userid={userid}]{username}[/mention]",
+                    minChars: 1,
+                },
+            ],
         });
 
-// Get the data for the mentions list
-function dataFeed(opts, callback) {
-    $.getJSON( Joomla.getOptions('com_kunena.kunena_url_topic_get_mentions'))
-    .done(function( json ) {
-        callback(JSON.parse(json));
-    })
-    .fail(function( jqxhr, textStatus, error ) {
-		var err = textStatus + ", " + error;
-        console.log( 'Request Failed: ' + err );
-    });
-}
+        // Get the data for the mentions list
+        function dataFeed(opts, callback) {
+            $.getJSON(
+                Joomla.getOptions("com_kunena.kunena_url_topic_get_mentions"),
+            )
+                .done(function (json) {
+                    callback(JSON.parse(json));
+                })
+                .fail(function (jqxhr, textStatus, error) {
+                    var err = textStatus + ", " + error;
+                    console.log("Request Failed: " + err);
+                });
+        }
 
-        CKEDITOR.on('dialogDefinition', function (ev) {
+        CKEDITOR.on("dialogDefinition", function (ev) {
             const dialogName = ev.data.name;
             const dialogDefinition = ev.data.definition;
 
-            if (dialogName == 'link') {
-                const linkType = dialogDefinition.getContents('info').get('linkType');
+            if (dialogName == "link") {
+                const linkType = dialogDefinition
+                    .getContents("info")
+                    .get("linkType");
                 // Remove the 'anchor' link option.
                 linkType.items.splice(1, 1);
                 // Remove the 'phone' link option.
                 linkType.items.splice(2, 2);
 
-                const protocol = dialogDefinition.getContents('info').get('protocol');
+                const protocol = dialogDefinition
+                    .getContents("info")
+                    .get("protocol");
                 protocol.items.splice(2, 4);
             }
         });
 
-        CKEDITOR.replace('message_private', {
-			customConfig: Joomla.getOptions('com_kunena.ckeditor_config'),
-			on: {
-				instanceReady: function (event) {
-					CKEDITOR.plugins.clipboard.preventDefaultDropOnElement(event.editor.document);
+        CKEDITOR.replace("message_private", {
+            customConfig: Joomla.getOptions("com_kunena.ckeditor_config"),
+            on: {
+                instanceReady: function (event) {
+                    CKEDITOR.plugins.clipboard.preventDefaultDropOnElement(
+                        event.editor.document,
+                    );
 
-					if (event.editor.getData().length > 0)
-					{
-						$('#form_submit_button').removeAttr("disabled");
-					}
+                    if (event.editor.getData().length > 0) {
+                        $("#form_submit_button").removeAttr("disabled");
+                    }
 
-					event.editor.on("beforeCommandExec", function (event) {
+                    event.editor.on("beforeCommandExec", function (event) {
                         // Show the paste dialog for the paste buttons and right-click paste
                         if (event.data.name == "paste") {
                             event.editor._.forcePasteDialog = true;
                         }
 
                         // Don't show the paste dialog for Ctrl+Shift+V
-                        if (event.data.name == "pastetext" && event.data.commandData.from == "keystrokeHandler") {
+                        if (
+                            event.data.name == "pastetext" &&
+                            event.data.commandData.from == "keystrokeHandler"
+                        ) {
                             event.cancel();
                         }
-                    })
-				},
-				change : function (event) {
-					if (event.editor.getData().length > 0)
-					{
-						$('#form_submit_button').removeAttr("disabled");
-					}
+                    });
+                },
+                change: function (event) {
+                    if (event.editor.getData().length > 0) {
+                        $("#form_submit_button").removeAttr("disabled");
+                    }
 
-					if (CKEDITOR.instances.message.getData().length == 0 && event.editor.getData().length == 0 && $('#form_submit_button').disabled === undefined)
-					{
-						$('#form_submit_button').prop("disabled", true);
-					}
-
-				},
+                    if (
+                        CKEDITOR.instances.message.getData().length == 0 &&
+                        event.editor.getData().length == 0 &&
+                        $("#form_submit_button").disabled === undefined
+                    ) {
+                        $("#form_submit_button").prop("disabled", true);
+                    }
+                },
                 mode: function (evt) {
-                    if (Joomla.getOptions('com_kunena.localstorage')) {
-						const cat = localStorage.getItem('copyKunenaeditor');
-	
-	                    if (cat) {
-	                        evt.editor.setData(cat);
-	                        localStorage.removeItem('copyKunenaeditor');
-	                    }
-					}
+                    if (Joomla.getOptions("com_kunena.localstorage")) {
+                        const cat = localStorage.getItem("copyKunenaeditor");
 
-                    evt.editor.getCommand('polls').disable();
-                }
-            }
+                        if (cat) {
+                            evt.editor.setData(cat);
+                            localStorage.removeItem("copyKunenaeditor");
+                        }
+                    }
+
+                    evt.editor.getCommand("polls").disable();
+                },
+            },
         });
     }
 });

--- a/src/site/template/aurelia/assets/js/edit.js
+++ b/src/site/template/aurelia/assets/js/edit.js
@@ -8,45 +8,41 @@
  **/
 
 jQuery(document).ready(function ($) {
-    const qreply = $(".qreply");
-    const editor = $("#editor");
+    const qreply = $('.qreply');
+    const editor = $('#editor');
 
-    if (Joomla.getOptions("com_kunena.pollcategoriesid") != undefined) {
-        var pollcategoriesid = jQuery.parseJSON(
-            Joomla.getOptions("com_kunena.pollcategoriesid"),
-        );
+    if(Joomla.getOptions('com_kunena.pollcategoriesid') != undefined){
+		var pollcategoriesid = jQuery.parseJSON(Joomla.getOptions('com_kunena.pollcategoriesid'));
     }
 
-    const pollexist = $("#poll_exist_edit");
-    const pollcatid = jQuery("#poll_catid").val();
+    const pollexist = $('#poll_exist_edit');
+    const pollcatid = jQuery('#poll_catid').val();
     const polliconstatus = false;
 
     // Check is anynomous options can be displayed on newtopic page
-    const catiddefault = $("#postcatid").val();
+    const catiddefault = $('#postcatid').val();
 
-    if (Joomla.getOptions("com_kunena.arrayanynomousbox") != undefined) {
-        const arrayanynomousbox = jQuery.parseJSON(
-            Joomla.getOptions("com_kunena.arrayanynomousbox"),
-        );
+    if(Joomla.getOptions('com_kunena.arrayanynomousbox') != undefined){
+		const arrayanynomousbox = jQuery.parseJSON(Joomla.getOptions('com_kunena.arrayanynomousbox'));
 
-        if (arrayanynomousbox !== null) {
+		if (arrayanynomousbox !== null) {
             if (arrayanynomousbox[catiddefault] == 1) {
-                $("#kanonymous").prop("checked", true);
+                $('#kanonymous').prop('checked', true);
             }
         }
     }
 
-    $("#reset").onclick = function () {
-        localStorage.removeItem("copyKunenaeditor");
+    $('#reset').onclick = function () {
+        localStorage.removeItem('copyKunenaeditor');
     };
 
     /* To enabled emojis in kunena textera feature like on github */
-    if ($("#kemojis_allowed").val() == 1) {
-        let item = "";
+    if ($('#kemojis_allowed').val() == 1) {
+        let item = '';
         if (editor.length > 0 && qreply.length == 0) {
-            item = "#editor";
+            item = '#editor';
         } else if (qreply.length > 0) {
-            item = ".qreply";
+            item = '.qreply';
         }
     }
 
@@ -54,27 +50,27 @@ jQuery(document).ready(function ($) {
     if ($.fn.sisyphus !== undefined) {
         $("#postform").sisyphus({
             locationBased: true,
-            timeout: 5,
+            timeout: 5
         });
     }
 
-    $("#kshow_attach_form").click(function () {
-        if ($("#kattach_form").is(":visible")) {
-            $("#kattach_form").hide();
+    $('#kshow_attach_form').click(function () {
+        if ($('#kattach_form').is(":visible")) {
+            $('#kattach_form').hide();
         } else {
-            $("#kattach_form").show();
+            $('#kattach_form').show();
         }
     });
 
-    $("#form_submit_button").click(function () {
-        $("#subject").attr("required", "required");
-        $("#editor").attr("required", "required");
-        localStorage.removeItem("copyKunenaeditor");
+    $('#form_submit_button').click(function () {
+        $("#subject").attr('required', 'required');
+        $("#editor").attr('required', 'required');
+        localStorage.removeItem('copyKunenaeditor');
     });
 
     // Needed to open and close quickreply from template
-    $(".Kreplyclick").click(function () {
-        const name = "#" + $(this).attr("data-related");
+    $('.Kreplyclick').click(function () {
+        const name = '#' + $(this).attr('data-related');
         if ($(name).is(":visible")) {
             $(name).hide();
         } else {
@@ -82,178 +78,140 @@ jQuery(document).ready(function ($) {
         }
     });
 
-    $(".kreply-cancel").click(function () {
-        const name = "#" + $(this).attr("data-related");
+    $('.kreply-cancel').click(function () {
+        const name = '#' + $(this).attr('data-related');
         $(name).hide();
     });
 
     let category_template_text = null;
-    $("#postcatid").change(function () {
-        const catid = $("select#postcatid option").filter(":selected").val();
-        const kurl_topicons_request = $("#kurl_topicons_request").val();
-        const pollcategoriesid = jQuery.parseJSON(
-            Joomla.getOptions("com_kunena.pollcategoriesid"),
-        );
-        const pollexist = jQuery("#poll_exist_edit");
-        const pollcatid = jQuery("#poll_catid").val();
+    $('#postcatid').change(function () {
+        const catid = $('select#postcatid option').filter(':selected').val();
+        const kurl_topicons_request = $('#kurl_topicons_request').val();
+        const pollcategoriesid = jQuery.parseJSON(Joomla.getOptions('com_kunena.pollcategoriesid'));
+        const pollexist = jQuery('#poll_exist_edit');
+        const pollcatid = jQuery('#poll_catid').val();
         const polliconstatus = true;
 
-        if (
-            typeof pollcategoriesid !== "undefined" &&
-            pollcategoriesid !== null &&
-            pollexist.length === 0
-        ) {
+        if (typeof pollcategoriesid !== 'undefined' && pollcategoriesid !== null && pollexist.length === 0) {
             if (pollcatid !== undefined) {
-                const catid = jQuery("#kcategory_poll").val();
+                const catid = jQuery('#kcategory_poll').val();
             }
 
             if (pollcategoriesid[catid] !== undefined) {
-                if (
-                    Joomla.getOptions("com_kunena.ckeditor_config") !==
-                    undefined
-                ) {
-                    CKEDITOR.instances.message.getCommand("polls").enable();
+                if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+                    CKEDITOR.instances.message.getCommand('polls').enable();
                 }
+
             } else {
-                if (
-                    Joomla.getOptions("com_kunena.ckeditor_config") !==
-                    undefined
-                ) {
-                    CKEDITOR.instances.message.getCommand("polls").disable();
+				if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+                    CKEDITOR.instances.message.getCommand('polls').disable();
                 }
+
             }
         } else if (pollexist.length > 0) {
-            if (Joomla.getOptions("com_kunena.ckeditor_config") !== undefined) {
-                CKEDITOR.instances.message.getCommand("polls").enable();
+			if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+                CKEDITOR.instances.message.getCommand('polls').enable();
             }
+
         } else {
-            if (Joomla.getOptions("com_kunena.ckeditor_config") !== undefined) {
-                CKEDITOR.instances.message.getCommand("polls").disable();
+			if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+                CKEDITOR.instances.message.getCommand('polls').disable();
             }
+
         }
 
-        if ($("#kanynomous-check").length > 0) {
+        if ($('#kanynomous-check').length > 0) {
             if (arrayanynomousbox[catid] !== undefined) {
-                $("#kanynomous-check").show();
-                $("#kanonymous").prop("checked", true);
+                $('#kanynomous-check').show();
+                $('#kanonymous').prop('checked', true);
             } else {
-                $("#kanynomous-check").hide();
-                $("#kanonymous").prop("checked", false);
+                $('#kanynomous-check').hide();
+                $('#kanonymous').prop('checked', false);
             }
         }
 
         // Load topic icons by ajax request
-        $.ajax({
-            type: "POST",
-            url: kurl_topicons_request,
-            async: true,
-            dataType: "json",
-            data: { catid: catid },
-        })
-            .done(function (data) {
-                $("#iconset_topicList").remove();
+      $.ajax({
+    type: 'POST',
+    url: kurl_topicons_request,
+    async: true,
+    dataType: 'json',
+    data: {catid: catid}
+})
+.done(function (data) {
+    $('#iconset_topicList').remove();
 
-                const div_object = $("<div>", { id: "iconset_topicList" });
-                $("#iconset_inject").append(div_object);
+    const div_object = $('<div>', {'id': 'iconset_topicList'});
+    $('#iconset_inject').append(div_object);
 
-                $.each(data, function (index, value) {
-                    if (value.type !== "system") {
-                        // Create input consistently for all icons
-                        const input = $("<input>", {
-                            type: "radio",
-                            id: "radio" + value.id,
-                            name: "topic_emoticon",
-                            value: value.id,
-                            // Set first icon as checked by default
-                            ...(index === 0 ? { checked: true } : {}),
-                        });
-
-                        // Create span with consistent class
-                        const span_object = $("<span>", {
-                            class: "kiconsel",
-                        }).append(input);
-
-                        // Create label consistently based on icon type
-                        let label;
-                        if (
-                            Joomla.getOptions(
-                                "com_kunena.kunena_topicicontype",
-                            ) === "fa"
-                        ) {
-                            label = $("<label>", {
-                                class: "radio inline",
-                                for: "radio" + value.id,
-                            }).append(
-                                $("<i>", {
-                                    class:
-                                        "fa glyphicon-topic fa-2x fa-" +
-                                        value.fa,
-                                    border: "0",
-                                    al: "",
-                                }),
-                            );
-                        } else if (
-                            Joomla.getOptions(
-                                "com_kunena.kunena_topicicontype",
-                            ) === "svg"
-                        ) {
-                            label = $("<label>", {
-                                class: "radio inline",
-                                for: "radio" + value.id,
-                            }).append($(value.svg));
-                        } else {
-                            label = $("<label>", {
-                                class: "radio inline",
-                                for: "radio" + value.id,
-                            }).append(
-                                $("<img>", {
-                                    src: value.path,
-                                    border: "0",
-                                    al: "",
-                                }),
-                            );
-                        }
-
-                        span_object.append(label);
-                        $("#iconset_topicList").append(span_object);
-                    }
-                });
-            })
-            .fail(function () {
-                //TODO: handle the error of ajax request
+    $.each(data, function (index, value) {
+        if (value.type !== 'system') {
+            // Create input consistently for all icons
+            const input = $('<input>', {
+                type: 'radio',
+                id: 'radio' + value.id,
+                name: 'topic_emoticon',
+                value: value.id,
+                // Set first icon as checked by default
+                ...(index === 0 ? { checked: true } : {})
             });
+
+            // Create span with consistent class
+            const span_object = $('<span>', {'class': 'kiconsel'}).append(input);
+
+            // Create label consistently based on icon type
+            let label;
+            if (Joomla.getOptions('com_kunena.kunena_topicicontype') === 'fa') {
+                label = $('<label>', {
+                    'class': 'radio inline',
+                    'for': 'radio' + value.id
+                }).append($('<i>', {
+                    'class': 'fa glyphicon-topic fa-2x fa-' + value.fa,
+                    'border': '0',
+                    'al': ''
+                }));
+            } else if (Joomla.getOptions('com_kunena.kunena_topicicontype') === 'svg') {
+                label = $('<label>', {
+                    'class': 'radio inline',
+                    'for': 'radio' + value.id
+                }).append($(value.svg));
+            } else {
+                label = $('<label>', {
+                    'class': 'radio inline',
+                    'for': 'radio' + value.id
+                }).append($('<img>', {'src': value.path, 'border': '0', 'al': ''}));
+            }
+
+            span_object.append(label);
+            $('#iconset_topicList').append(span_object);
+        }
+    });
+})
+.fail(function () {
+    //TODO: handle the error of ajax request
+});
         // Load template text for the category by ajax request
-        category_template_text = (function cat_template_text() {
+        category_template_text = function cat_template_text() {
             return $.ajax({
-                type: "POST",
-                url: $("#kurl_category_template_text").val(),
+                type: 'POST',
+                url: $('#kurl_category_template_text').val(),
                 async: true,
-                dataType: "json",
-                data: { catid: catid },
+                dataType: 'json',
+                data: {catid: catid}
             })
                 .done(function (data) {
-                    if (
-                        Joomla.getOptions("com_kunena.ckeditor_config") !==
-                        undefined
-                    ) {
-                        const editor_text =
-                            CKEDITOR.instances.message.getData();
+                    if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+                        const editor_text = CKEDITOR.instances.message.getData();
 
                         if (editor_text.length > 1) {
                             if (editor_text.length > 1) {
-                                $("#modal_confirm_template_category").modal(
-                                    "show",
-                                );
+                                $('#modal_confirm_template_category').modal('show');
                             } else {
-                                CKEDITOR.instances.message.setData(
-                                    category_template_text,
-                                );
+                                CKEDITOR.instances.message.setData(category_template_text);
                             }
                         } else {
                             if (data.length > 1) {
-                                $("#modal_confirm_template_category").modal(
-                                    "show",
-                                );
+                                $('#modal_confirm_template_category').modal('show');
                             } else {
                                 CKEDITOR.instances.message.setData(data.data);
                             }
@@ -263,51 +221,46 @@ jQuery(document).ready(function ($) {
                 .fail(function () {
                     //TODO: handle the error of ajax request
                 });
-        })();
+        }();
     });
 
-    $("#modal_confirm_erase").click(function () {
-        $("#modal_confirm_template_category").modal("hide");
+    $('#modal_confirm_erase').click(function () {
+        $('#modal_confirm_template_category').modal('hide');
         const textarea = $("#editor").next();
         textarea.empty();
-        CKEDITOR.instances.message.setData(
-            category_template_text?.responseJSON?.data,
-        );
+        CKEDITOR.instances.message.setData(category_template_text?.responseJSON?.data);
     });
 
-    $("#modal_confirm_erase_keep_old").click(function () {
-        $("#modal_confirm_template_category").modal("hide");
+    $('#modal_confirm_erase_keep_old').click(function () {
+        $('#modal_confirm_template_category').modal('hide');
         const existing_content = CKEDITOR.instances.message.getData();
         const textarea = $("#editor").next();
         textarea.empty();
-        CKEDITOR.instances.message.setData(
-            category_template_text?.responseJSON?.data + " " + existing_content,
-        );
+        CKEDITOR.instances.message.setData(category_template_text?.responseJSON?.data + ' ' + existing_content);
     });
 
     if ($.fn.datepicker !== undefined) {
         // Load datepicker for poll
-        $("#datepoll-container .input-append.date").datepicker({
-            orientation: "top auto",
+        $('#datepoll-container .input-append.date').datepicker({
+            orientation: "top auto"
         });
     }
 
-    $("#gotoeditor").click(function () {
-        localStorage.setItem("copyKunenaeditor", $("#editor").val());
-    });
+	$('#gotoeditor').click(function () {
+		localStorage.setItem("copyKunenaeditor", $('#editor').val());
+	});
 
-    if (Joomla.getOptions("com_kunena.ckeditor_config") !== undefined) {
-        CKEDITOR.replace("message", {
-            customConfig: Joomla.getOptions("com_kunena.ckeditor_config"),
-            on: {
-                instanceReady: function (event) {
-                    CKEDITOR.plugins.clipboard.preventDefaultDropOnElement(
-                        event.editor.document,
-                    );
+    if (Joomla.getOptions('com_kunena.ckeditor_config') !== undefined) {
+        CKEDITOR.replace('message', {
+			customConfig: Joomla.getOptions('com_kunena.ckeditor_config'),
+			on: {
+				instanceReady: function (event) {
+					CKEDITOR.plugins.clipboard.preventDefaultDropOnElement(event.editor.document);
 
-                    if (event.editor.getData().length > 0) {
-                        $("#form_submit_button").removeAttr("disabled");
-                    }
+					if (event.editor.getData().length > 0)
+					{
+						$('#form_submit_button').removeAttr("disabled");
+					}
 
                     event.editor.on("beforeCommandExec", function (event) {
                         // Show the paste dialog for the paste buttons and right-click paste
@@ -316,162 +269,144 @@ jQuery(document).ready(function ($) {
                         }
 
                         // Don't show the paste dialog for Ctrl+Shift+V
-                        if (
-                            event.data.name == "pastetext" &&
-                            event.data.commandData.from == "keystrokeHandler"
-                        ) {
+                        if (event.data.name == "pastetext" && event.data.commandData.from == "keystrokeHandler") {
                             event.cancel();
                         }
-                    });
-                },
-                change: function (event) {
-                    if (event.editor.getData().length > 0) {
-                        $("#form_submit_button").removeAttr("disabled");
-                    }
+                    })
+                    
+				},
+				change : function (event) {
+					if (event.editor.getData().length > 0)
+					{
+						$('#form_submit_button').removeAttr("disabled");
+					}
 
-                    if (
-                        event.editor.getData().length == 0 &&
-                        $("#form_submit_button").disabled === undefined
-                    ) {
-                        $("#form_submit_button").prop("disabled", true);
-                    }
-                },
+					if (event.editor.getData().length == 0 && $('#form_submit_button').disabled === undefined)
+					{
+						$('#form_submit_button').prop("disabled", true);
+					}
+
+				},
                 mode: function (evt) {
-                    const cat = localStorage.getItem("copyKunenaeditor");
+                    const cat = localStorage.getItem('copyKunenaeditor');
 
                     if (cat) {
                         evt.editor.setData(cat);
-                        localStorage.removeItem("copyKunenaeditor");
+                        localStorage.removeItem('copyKunenaeditor');
                     }
 
                     if (polliconstatus === false) {
                         if (pollcatid !== undefined) {
-                            if (
-                                typeof pollcategoriesid !== "undefined" &&
-                                pollcategoriesid !== null &&
-                                pollexist.length === 0
-                            ) {
-                                const catid = $("#kcategory_poll").val();
+                            if (typeof pollcategoriesid !== 'undefined' && pollcategoriesid !== null && pollexist.length === 0) {
+                                const catid = $('#kcategory_poll').val();
 
                                 if (pollcategoriesid[catid] !== undefined) {
-                                    evt.editor.getCommand("polls").enable();
+                                    evt.editor.getCommand('polls').enable();
                                 } else {
-                                    evt.editor.getCommand("polls").disable();
+                                    evt.editor.getCommand('polls').disable();
                                 }
                             } else if (pollexist.length > 0) {
-                                evt.editor.getCommand("polls").enable();
+                                evt.editor.getCommand('polls').enable();
                             } else {
-                                evt.editor.getCommand("polls").disable();
+                                evt.editor.getCommand('polls').disable();
                             }
                         } else {
-                            evt.editor.getCommand("polls").disable();
+                            evt.editor.getCommand('polls').disable();
                         }
                     }
-                },
+                }
             },
-            mentions: [
-                {
-                    feed: dataFeed,
-                    itemTemplate:
-                        '<li data-id="{id}">' +
-                        '<img src="{avatar}" width="36" height="36"/>' +
-                        " " +
-                        '<strong class="username">{username}</strong>' +
-                        "</li>",
-                    outputTemplate:
-                        "[mention userid={userid}]{username}[/mention]",
-                    minChars: 1,
-                },
-            ],
+            mentions: [ {
+      feed: dataFeed,
+      itemTemplate:
+        '<li data-id="{id}">' +
+        '<img src="{avatar}" width="36" height="36"/>' +
+        ' '+
+        '<strong class="username">{username}</strong>' +
+        '</li>',
+      outputTemplate:
+        '[mention userid={userid}]{username}[/mention]',
+      minChars: 1
+    }
+  ]
         });
 
-        // Get the data for the mentions list
-        function dataFeed(opts, callback) {
-            $.getJSON(
-                Joomla.getOptions("com_kunena.kunena_url_topic_get_mentions"),
-            )
-                .done(function (json) {
-                    callback(JSON.parse(json));
-                })
-                .fail(function (jqxhr, textStatus, error) {
-                    var err = textStatus + ", " + error;
-                    console.log("Request Failed: " + err);
-                });
-        }
+// Get the data for the mentions list
+function dataFeed(opts, callback) {
+    $.getJSON( Joomla.getOptions('com_kunena.kunena_url_topic_get_mentions'))
+    .done(function( json ) {
+        callback(JSON.parse(json));
+    })
+    .fail(function( jqxhr, textStatus, error ) {
+		var err = textStatus + ", " + error;
+        console.log( 'Request Failed: ' + err );
+    });
+}
 
-        CKEDITOR.on("dialogDefinition", function (ev) {
+        CKEDITOR.on('dialogDefinition', function (ev) {
             const dialogName = ev.data.name;
             const dialogDefinition = ev.data.definition;
 
-            if (dialogName == "link") {
-                const linkType = dialogDefinition
-                    .getContents("info")
-                    .get("linkType");
+            if (dialogName == 'link') {
+                const linkType = dialogDefinition.getContents('info').get('linkType');
                 // Remove the 'anchor' link option.
                 linkType.items.splice(1, 1);
                 // Remove the 'phone' link option.
                 linkType.items.splice(2, 2);
 
-                const protocol = dialogDefinition
-                    .getContents("info")
-                    .get("protocol");
+                const protocol = dialogDefinition.getContents('info').get('protocol');
                 protocol.items.splice(2, 4);
             }
         });
 
-        CKEDITOR.replace("message_private", {
-            customConfig: Joomla.getOptions("com_kunena.ckeditor_config"),
-            on: {
-                instanceReady: function (event) {
-                    CKEDITOR.plugins.clipboard.preventDefaultDropOnElement(
-                        event.editor.document,
-                    );
+        CKEDITOR.replace('message_private', {
+			customConfig: Joomla.getOptions('com_kunena.ckeditor_config'),
+			on: {
+				instanceReady: function (event) {
+					CKEDITOR.plugins.clipboard.preventDefaultDropOnElement(event.editor.document);
 
-                    if (event.editor.getData().length > 0) {
-                        $("#form_submit_button").removeAttr("disabled");
-                    }
+					if (event.editor.getData().length > 0)
+					{
+						$('#form_submit_button').removeAttr("disabled");
+					}
 
-                    event.editor.on("beforeCommandExec", function (event) {
+					event.editor.on("beforeCommandExec", function (event) {
                         // Show the paste dialog for the paste buttons and right-click paste
                         if (event.data.name == "paste") {
                             event.editor._.forcePasteDialog = true;
                         }
 
                         // Don't show the paste dialog for Ctrl+Shift+V
-                        if (
-                            event.data.name == "pastetext" &&
-                            event.data.commandData.from == "keystrokeHandler"
-                        ) {
+                        if (event.data.name == "pastetext" && event.data.commandData.from == "keystrokeHandler") {
                             event.cancel();
                         }
-                    });
-                },
-                change: function (event) {
-                    if (event.editor.getData().length > 0) {
-                        $("#form_submit_button").removeAttr("disabled");
-                    }
+                    })
+				},
+				change : function (event) {
+					if (event.editor.getData().length > 0)
+					{
+						$('#form_submit_button').removeAttr("disabled");
+					}
 
-                    if (
-                        CKEDITOR.instances.message.getData().length == 0 &&
-                        event.editor.getData().length == 0 &&
-                        $("#form_submit_button").disabled === undefined
-                    ) {
-                        $("#form_submit_button").prop("disabled", true);
-                    }
-                },
+					if (CKEDITOR.instances.message.getData().length == 0 && event.editor.getData().length == 0 && $('#form_submit_button').disabled === undefined)
+					{
+						$('#form_submit_button').prop("disabled", true);
+					}
+
+				},
                 mode: function (evt) {
-                    if (Joomla.getOptions("com_kunena.localstorage")) {
-                        const cat = localStorage.getItem("copyKunenaeditor");
+                    if (Joomla.getOptions('com_kunena.localstorage')) {
+						const cat = localStorage.getItem('copyKunenaeditor');
+	
+	                    if (cat) {
+	                        evt.editor.setData(cat);
+	                        localStorage.removeItem('copyKunenaeditor');
+	                    }
+					}
 
-                        if (cat) {
-                            evt.editor.setData(cat);
-                            localStorage.removeItem("copyKunenaeditor");
-                        }
-                    }
-
-                    evt.editor.getCommand("polls").disable();
-                },
-            },
+                    evt.editor.getCommand('polls').disable();
+                }
+            }
         });
     }
 });


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
When fetching an avatar, a size can be requested. The returned avatar will then be in that size.
But not all avatar providers have the option of returning resized images and as such will return a different size avatar.

This can be (and is) handed by adding width and height to the img element displaying the avatar.

When in a message reply and doing a mention however, the width and height is not set to the avatar and as such the mention popup can have very large images.

This change set the with and height of the avatar in the mention list to 36 (the image size actually requested for this avatar.
 
#### Testing Instructions

install this PR, do a mention and check if the avatars still display correct, also check in the source code via inspect if the width and height of the avatar in the mention list is set to 36 via the attributes on the img element.