### PR TITLE
[K7.0] Check session token on setrate and check if rating is enabled in both kconfig and category

### DIFF
--- a/src/site/src/Controllers/TopicController.php
+++ b/src/site/src/Controllers/TopicController.php
@@ -436,12 +436,21 @@ class TopicController extends KunenaController
      */
     public function setrate()
     {
+        if (!Session::checkToken('request')) {
+            throw new RuntimeException(Text::_('JINVALID_TOKEN'), 403);
+        }
+
+        // To use rating feature it should be enabled at same time in Kunena configuration and in the category
+        if (!$this->config->ratingEnabled && KunenaCategoryHelper::get($this->catid)->allowRatings) {
+            throw new RuntimeException(Text::_('Bad Request'), 400);
+        }
+
         $starid   = $this->app->getInput()->get('starid', 0, 'int');
         $topicid  = $this->app->getInput()->get('topic_id', 0, 'int');
         $response = [];
         $user     = KunenaUserHelper::getMyself();
 
-        if ($user->exists() || $this->config->ratingEnabled) {
+        if ($user->exists()) {
             $rate           = KunenaRateHelper::get($topicid);
             $rate->rate     = $starid;
             $rate->topic_id = $topicid;

--- a/src/site/template/aurelia/layouts/topic/item/rating/default.php
+++ b/src/site/template/aurelia/layouts/topic/item/rating/default.php
@@ -17,6 +17,7 @@ namespace Kunena\Forum\Site;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Session\Session;
 use Kunena\Forum\Libraries\Route\KunenaRoute;
 
 if ($this->category->allowRatings) :
@@ -29,7 +30,7 @@ if ($this->category->allowRatings) :
     <input type="hidden" id="krating_url" name="krating_url"
            value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&task=loadrate&format=json'); ?>"/>
     <input type="hidden" id="krating_submit_url" name="url"
-           value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&task=setrate&topic_id=' . $this->topic->id . '&format=json'); ?>"/>
+           value="<?php echo KunenaRoute::_('index.php?option=com_kunena&view=topic&task=setrate&topic_id=' . $this->topic->id . '&format=json&' . Session::getFormToken() . '=1'); ?>"/>
     <div id="krating"
          data-bs-toggle="tooltip" title="<?php echo Text::sprintf('COM_KUNENA_RATE_TOOLTIP', $this->topic->rating, $this->topic->getReviewCount()); ?>"
          class="hasTooltip">


### PR DESCRIPTION
Pull Request for Issue # . 

thanks to @0xBassia
 
#### Summary of Changes 
 
#### Testing Instructions

Set rate shouldn't be allowed when sessio isn't valid and if rating is disabled in both Kunena configuration and in the parent category of the topic