### PR TITLE
[K7.0] round(): Passing null to parameter #1 ($num) of type int|float is

### DIFF
--- a/src/libraries/kunena/src/Forum/Topic/Rate/KunenaRateHelper.php
+++ b/src/libraries/kunena/src/Forum/Topic/Rate/KunenaRateHelper.php
@@ -85,7 +85,11 @@ abstract class KunenaRateHelper
             ->where($db->quoteName('topic_id') . ' = ' . $db->quote($id));
         $db->setQuery($query);
 
-        return round($db->loadResult());
+        if (empty($db->loadResult())) {
+            return '0';
+        } else {
+            return round($db->loadResult());
+        }
     }
 
     /**


### PR DESCRIPTION
deprecated in
\libraries\kunena\src\Forum\Topic\Rate\KunenaRateHelper.php on line 90

Pull Request for Issue # . 
 
#### Summary of Changes 
 
#### Testing Instructions