### PR TITLE
[K7.0] Two string untranslated in backend under an users on tab params

### DIFF
--- a/src/admin/language/en-GB/com_kunena.views.ini
+++ b/src/admin/language/en-GB/com_kunena.views.ini
@@ -1206,6 +1206,8 @@ COM_KUNENA_VIEW_USER_EDIT_AUTH_FAILED = "You are not allowed to edit user %s."
 COM_KUNENA_USER_ADMIN_CANSUBSCRIBE = "Select subscription as default"
 COM_KUNENA_USER_ADMIN_USERLISTTIME = "Select the time limit for pages"
 COM_KUNENA_USER_TITLE_EDIT_USERNAME = "Username"
+COM_KUNENA_USER_AMDIN_SHOWONLINE = "Display the user online"
+COM_KUNENA_USER_HIDEEMAIL = "Hide email"
 
 ; JROOT/administrator/components/com_kunena/views/users/tmpl/move.php
 


### PR DESCRIPTION
Pull Request for Issue # . 
 
Select an user in the backend userlist : 

<img width="3394" height="1028" alt="Capture d&#39;écran 2026-06-02 210630" src="https://github.com/user-attachments/assets/570eb737-0843-449d-a94b-a4c38a9648d6" />


#### Summary of Changes 
 
#### Testing Instructions