### PR TITLE
[K7.0] Deprecated: Poll\KunenaPoll::vote() Implicitly marking parameter $topic as nullable is deprecated

### DIFF
--- a/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPoll.php
+++ b/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPoll.php
@@ -385,7 +385,7 @@ class KunenaPoll
      * @throws Exception
      * @since   Kunena 6.0
      */
-    public function vote(int $option, $change = false, $user = null, KunenaTopic $topic = null): bool
+    public function vote(int $option, $change = false, $user = null, KunenaTopic $topic): bool
     {
         if (!$this->exists()) {
             throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_DOES_NOT_EXIST'));


### PR DESCRIPTION
Kunena\Forum\Libraries\Forum\Topic\Poll\KunenaPoll::vote(): Implicitly marking parameter $topic as nullable is deprecated, the explicit nullable type must be used instead

Pull Request for Issue # . 
 
#### Summary of Changes 
 
#### Testing Instructions