### PR TITLE
[K7.0] vote() method is set deprecated and replaced by savevote() method

### DIFF
--- a/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPoll.php
+++ b/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPoll.php
@@ -371,10 +371,10 @@ class KunenaPoll
 
         return $this->mytime[$user->userid];
     }
-
+    
     /**
-     * Save the vote on the poll option choose by the user
-     * 
+     * Save the vote on the poll option choose by the user, increase the number of votes of the user
+     *
      * @param   int            $option   option
      * @param   bool           $change   change
      * @param   mixed          $user     user
@@ -383,9 +383,137 @@ class KunenaPoll
      * @return  boolean
      *
      * @throws Exception
+     * @since   Kunena 7.0.6
+     */
+    public function saveVote(int $option, KunenaTopic $topic, $change = false, $user = null): bool
+    {
+        if (!$this->exists()) {
+            throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_DOES_NOT_EXIST'));
+        }
+        
+        $options = $this->getOptions();
+        
+        if (!isset($options[$option])) {
+            throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_OPTION_DOES_NOT_EXIST'));
+        }
+        
+        $user = KunenaFactory::getUser($user);
+        
+        if (!$user->exists()) {
+            throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_USER_NOT_EXIST'));
+        }
+        
+        if (!$topic->isAuthorised('poll.vote', null, true)) {
+            throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_NOT_AUTHORIZED'));
+        }
+        
+        $lastVoteId = $this->getLastVoteId($user);
+        $myvotes    = $this->getMyVotes($user);
+        
+        if (!$myvotes) {
+            // First vote
+            $votes         = new StdClass();
+            $votes->new    = true;
+            $votes->pollid = $this->id;
+            $votes->votes  = 1;
+        } elseif ($change && isset($lastVoteId)) {
+            $votes           = new StdClass();
+            $votes->new      = false;
+            $votes->lasttime = null;
+            $votes->lastvote = null;
+            $votes->votes    = 1;
+            
+            // Change vote: decrease votes in the last option
+            if (!$this->changeOptionVotes($lastVoteId, -1)) {
+                // Saving option failed, add a vote to the user
+                $votes->votes++;
+            }
+        } else {
+            $votes      = new StdClass();
+            $votes->new = false;
+            
+            // Change vote: decrease votes in the last option
+            if (!$this->changeOptionVotes($lastVoteId, -1)) {
+                // Add a vote to the user
+                $votes->votes++;
+            }
+        }
+        
+        $votes->lasttime = KunenaUserHelper::getMyself()->getTime();
+        $votes->lastvote = $option;
+        $votes->userid   = (int) $user->userid;
+        
+        // Increase vote count from current option
+        $this->changeOptionVotes($votes->lastvote, 1);
+        
+        if ($votes->new) {
+            // No votes
+            $query = $this->_db->createQuery();
+            
+            // Insert columns.
+            $columns = ['pollid', 'userid', 'votes', 'lastvote', 'lasttime'];
+            
+            // Insert values.
+            $values = [$this->_db->quote($this->id), $this->_db->quote($votes->userid), $this->_db->quote($votes->votes), $this->_db->quote($votes->lastvote), $this->_db->quote($votes->lasttime)];
+            
+            // Prepare the insert query.
+            $query
+            ->insert($this->_db->quoteName('#__kunena_polls_users'))
+            ->columns($this->_db->quoteName($columns))
+            ->values(implode(',', $values));
+            $this->_db->setQuery($query);
+            
+            try {
+                $this->_db->execute();
+            } catch (ExecutionFailureException $e) {
+                KunenaError::displayDatabaseError($e);
+                
+                throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_USER_INSERT_FAIL'));
+            }
+        } else {
+            // Already voted
+            $query = $this->_db->createQuery();
+            
+            // Insert columns.
+            $columns = ['votes', 'lastvote', 'lasttime'];
+            
+            // Insert values.
+            $values = [$this->_db->quote($votes->votes), $this->_db->quote($votes->lastvote), $this->_db->quote($votes->lasttime)];
+            
+            // Prepare the insert query.
+            $query
+            ->insert($this->_db->quoteName('#__kunena_polls_users'))
+            ->columns($this->_db->quoteName($columns))
+            ->values(implode(',', $values))
+            ->where('pollid=' . $this->_db->quote($this->id) . ' AND userid=' . $this->_db->quote($votes->userid));
+            $this->_db->setQuery($query);
+            
+            try {
+                $this->_db->execute();
+            } catch (ExecutionFailureException $e) {
+                KunenaError::displayDatabaseError($e);
+                
+                throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_USER_UPDATE_FAIL'));
+            }
+        }
+        
+        return true;
+    }
+
+    /**
+     * Save the vote on the poll option choose by the user
+     * 
+     * @param   int            $option   option
+     * @param   bool           $change   change
+     * @param   mixed          $user     user
+     *
+     * @return  boolean
+     *
+     * @throws Exception
+     * @deprecated Kunena 7.0 will be removed in 7.1, use instead saveVote() in KunenaPoll
      * @since   Kunena 6.0
      */
-    public function vote(int $option, $change = false, $user = null, KunenaTopic $topic): bool
+    public function vote(int $option, $change = false, $user = null): bool
     {
         if (!$this->exists()) {
             throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_DOES_NOT_EXIST'));
@@ -401,10 +529,6 @@ class KunenaPoll
 
         if (!$user->exists()) {
             throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_USER_NOT_EXIST'));
-        }
-        
-        if (!$topic->isAuthorised('poll.vote', null, true)) {
-            throw new Exception(Text::_('COM_KUNENA_LIB_POLL_VOTE_ERROR_NOT_AUTHORIZED'));
         }
 
         $lastVoteId = $this->getLastVoteId($user);

--- a/src/site/src/Controllers/TopicController.php
+++ b/src/site/src/Controllers/TopicController.php
@@ -2649,7 +2649,7 @@ class TopicController extends KunenaController
         if (!$poll->getMyVotes()) {
             try {
                 // Give a new vote
-                $poll->vote($vote, false, null, $topic);
+                $poll->saveVote($vote, false, null, $topic);
             } catch (Exception $e) {
                 $this->app->enqueueMessage($e->getMessage(), 'error');
             }
@@ -2658,7 +2658,7 @@ class TopicController extends KunenaController
         } elseif (!$this->config->pollAllowVoteOne) {
             try {
                 // Change existing vote
-                $poll->vote($vote, true, null, $topic);
+                $poll->saveVote($vote, true, null, $topic);
             } catch (Exception $e) {
                 $this->app->enqueueMessage($e->getMessage(), 'error');
             }


### PR DESCRIPTION
Pull Request for Issue # . 
 
#### Summary of Changes 
 
vote() method in KunenaPoll class is set deprecated and will be removed in K7.1 and replaced by saveVote() method in KunenaPoll because of new mandatory params which can't be in the last params else php throw errors

#### Testing Instructions