### PR TITLE
[K7.0] saveVote(): Argument #2 ($topic) must be of type

### DIFF
--- a/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPoll.php
+++ b/src/libraries/kunena/src/Forum/Topic/Poll/KunenaPoll.php
@@ -376,9 +376,9 @@ class KunenaPoll
      * Save the vote on the poll option choose by the user, increase the number of votes of the user
      *
      * @param   int            $option   option
+     * @param   KunenaTopic    $topic    topic
      * @param   bool           $change   change
      * @param   mixed          $user     user
-     * @param   KunenaTopic    $topic    topic
      *
      * @return  boolean
      *

--- a/src/site/src/Controllers/TopicController.php
+++ b/src/site/src/Controllers/TopicController.php
@@ -2649,7 +2649,7 @@ class TopicController extends KunenaController
         if (!$poll->getMyVotes()) {
             try {
                 // Give a new vote
-                $poll->saveVote($vote, false, null, $topic);
+                $poll->saveVote($vote, $topic);
             } catch (Exception $e) {
                 $this->app->enqueueMessage($e->getMessage(), 'error');
             }
@@ -2658,7 +2658,7 @@ class TopicController extends KunenaController
         } elseif (!$this->config->pollAllowVoteOne) {
             try {
                 // Change existing vote
-                $poll->saveVote($vote, true, null, $topic);
+                $poll->saveVote($vote, $topic, true);
             } catch (Exception $e) {
                 $this->app->enqueueMessage($e->getMessage(), 'error');
             }


### PR DESCRIPTION
Kunena\Forum\Libraries\Forum\Topic\Poll\KunenaPoll::saveVote(): Argument #2 ($topic) must be of type Kunena\Forum\Libraries\Forum\Topic\KunenaTopic, false given, called in C:\Users\xillibit\git\Kunena-forum-K7.0-fork\src\site\src\Controllers\TopicController.php on line 2652 

Pull Request for Issue # . 
 
#### Summary of Changes 
 
#### Testing Instructions