### PR TITLE
[K7.0] Fix double-encoded entities in topic meta description tags

### DIFF
--- a/src/site/src/Controller/Topic/Item/TopicItemDisplay.php
+++ b/src/site/src/Controller/Topic/Item/TopicItemDisplay.php
@@ -619,7 +619,7 @@ class TopicItemDisplay extends KunenaControllerDisplay
 
         $multispaces_replaced = '';
         if (!empty($this->topic->first_post_message)) {
-            $firstPostMessage = KunenaParser::stripBBCode($this->topic->first_post_message, 160);
+            $firstPostMessage = KunenaParser::stripBBCode($this->topic->first_post_message, 160, false);
             $multispaces_replaced = preg_replace('/\s+/', ' ', $firstPostMessage);
         }
 
@@ -688,7 +688,7 @@ class TopicItemDisplay extends KunenaControllerDisplay
             $multispaces_replaced_desc = preg_replace('/\s+/', ' ', $this->topic->first_post_message);
 
             if ($total > 1 && $page > 1) {
-                $small = KunenaParser::stripBBCode($multispaces_replaced_desc, 130);
+                $small = KunenaParser::stripBBCode($multispaces_replaced_desc, 130, false);
 
                 if (empty($small)) {
                     $small = $headerText;
@@ -696,7 +696,7 @@ class TopicItemDisplay extends KunenaControllerDisplay
 
                 $this->setDescription($small . " - " . Text::_('COM_KUNENA_PAGES') . " {$page}");
             } else {
-                $small = KunenaParser::stripBBCode($multispaces_replaced_desc, 160);
+                $small = KunenaParser::stripBBCode($multispaces_replaced_desc, 160, false);
 
                 if (empty($small)) {
                     $small = $headerText;

--- a/src/site/src/View/Topic/HtmlView.php
+++ b/src/site/src/View/Topic/HtmlView.php
@@ -428,7 +428,7 @@ class HtmlView extends KunenaView
                 } else {
                     // Create Meta Description form the content of the first message
                     // better for search results display but NOT for search ranking!
-                    $description = KunenaParser::stripBBCode($this->topic->first_post_message, 182);
+                    $description = KunenaParser::stripBBCode($this->topic->first_post_message, 182, false);
                     $description = preg_replace('/\s+/', ' ', $description); // Remove newlines
                     $description = trim($description); // Remove trailing spaces and beginning
 


### PR DESCRIPTION
### Summary

A topic's meta description and Open Graph / Twitter card tags double-encode HTML entities. The visible post body is fine; only the `<meta>` tags are affected, which degrades search snippets and social-share previews.

### Steps to reproduce

1. On any Joomla version, create a forum topic whose first post contains a double quote in the first ~160 characters, e.g. `Sites can show "not secure" warnings.`
2. Open the topic and View Source.
3. The meta tags render:
   ```html
   <meta name="description" content="Sites can show &amp;quot;not secure&amp;quot; warnings.">
   <meta property="og:description" content="... &amp;quot; ...">
   <meta name="twitter:description" content="... &amp;quot; ...">
   ```
   The entity is double-encoded (`&amp;quot;`) instead of `&quot;`.

### Cause

`KunenaParser::stripBBCode()` returns HTML-encoded text when its `$html` argument is `true` (the default) — the `UnHTMLEncode()` step is gated behind `if (!$html)`. The meta-building code passes that already-encoded string to `setDescription()` / `setMetaData()`, and the document layer applies `htmlspecialchars()` again when emitting the `<meta>` tag, producing the double encoding.

### Fix

Pass `$html = false` at the four meta-description call sites so `stripBBCode()` returns plain text and the document encodes it exactly once. This matches how the codebase already builds plain-text page titles and tooltips (`KunenaLayout`, Topics JSON views already pass `false`).

### Scope / risk

Two files, four one-token changes. No effect on visible post content — only `<meta>` description/OG/Twitter tags. Verified on a clean Kunena 7.0.6 install: double-encoded `&amp;quot;` count drops from 3 to 0; visible body unchanged.
