### PR TITLE
[K6.4] Fix Smart Search finder plugin: abort on stray output, endless progress loop, 404 result links

### DIFF
--- a/src/plugins/plg_finder_kunena/kunena.php
+++ b/src/plugins/plg_finder_kunena/kunena.php
@@ -515,9 +515,11 @@ class PlgFinderKunena extends Adapter
         // Set title context.
         $item->title = $message->subject;
 
-        // Build the necessary url, route, path and alias information.
-        $itemid = KunenaRoute::fixMissingItemID();
-        $item->url   = $message->getUrl($message->catid, 'last', $itemid);
+        // Build the necessary url, route, path and alias information. Use the
+        // message permalink (mesid) without a hardcoded Itemid: Kunena resolves
+        // the page and position at request time, while menu ids baked into
+        // stored urls can turn into 404s.
+        $item->url   = 'index.php?option=com_kunena&view=topic&catid=' . (int) $message->catid . '&id=' . (int) $message->thread . '&mesid=' . (int) $message->id;
         $item->route = $item->url;
         $item->alias = KunenaRoute::stringURLSafe($message->subject);
 

--- a/src/plugins/plg_finder_kunena/kunena.php
+++ b/src/plugins/plg_finder_kunena/kunena.php
@@ -259,28 +259,31 @@ class PlgFinderKunena extends Adapter
         $offset = (int) $aState['offset'];
         $limit  = (int) ($iState->batchSize - $iState->batchOffset);
 
+        // The adapter state offset counts indexed items (like core adapters), while
+        // the item query walks message ids. Track the id cursor separately so the
+        // progress accounting adds up even when message ids have gaps.
+        $lastId = (int) ($aState['last_id'] ?? 0);
+
         // Get the content items to index.
         // Capture any stray output/warnings so they get logged instead of bubbling
         // up to com_finder, which treats any output as a plugin failure.
         ob_start();
 
         try {
-            $items = $this->getItems($offset, $limit);
+            $items = $this->getItems($lastId, $limit);
         } catch (\Throwable $e) {
             ob_end_clean();
-            Log::add("Finder Kunena plugin: getItems({$offset}, {$limit}) threw " . get_class($e) . ': ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine(), Log::ERROR);
+            Log::add("Finder Kunena plugin: getItems({$lastId}, {$limit}) threw " . get_class($e) . ': ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine(), Log::ERROR);
             throw $e;
         }
 
         $stray = trim(ob_get_clean());
 
         if ($stray !== '') {
-            Log::add("Finder Kunena plugin: getItems({$offset}, {$limit}) produced output: " . substr($stray, 0, 3000), Log::ERROR);
+            Log::add("Finder Kunena plugin: getItems({$lastId}, {$limit}) produced output: " . substr($stray, 0, 3000), Log::ERROR);
         }
 
         // Iterate through the items and index them.
-        $item = null;
-
         foreach ($items as $item) {
             ob_start();
 
@@ -297,18 +300,27 @@ class PlgFinderKunena extends Adapter
             if ($stray !== '') {
                 Log::add("Finder Kunena plugin: message {$item->id} produced output: " . substr($stray, 0, 3000), Log::ERROR);
             }
-        }
 
-        if ($item) {
             // Adjust the offsets.
-            $iState->batchOffset = $iState->batchSize;
-            $iState->totalItems  -= $item->id - $offset;
-
-            // Update the indexer state.
-            $aState['offset']                    = $item->id;
-            $iState->pluginState[$this->context] = $aState;
-            Indexer::setState($iState);
+            $offset++;
+            $lastId = (int) $item->id;
+            $iState->batchOffset++;
+            $iState->totalItems--;
         }
+
+        // If the query returned fewer items than requested, all messages are indexed.
+        // Settle any difference between the counted total and the items actually
+        // delivered (e.g. messages deleted while indexing was running).
+        if (\count($items) < $limit) {
+            $iState->totalItems -= max(0, (int) $aState['total'] - $offset);
+            $offset             = (int) $aState['total'];
+        }
+
+        // Update the indexer state.
+        $aState['offset']                    = $offset;
+        $aState['last_id']                   = $lastId;
+        $iState->pluginState[$this->context] = $aState;
+        Indexer::setState($iState);
 
         unset($items, $item);
 
@@ -395,9 +407,10 @@ class PlgFinderKunena extends Adapter
     {
         Log::add('FinderIndexerAdapter::getContentCount', Log::INFO);
 
-        // Get the list query.
+        // Get the list query. Count the actual number of messages: the indexer's
+        // progress accounting expects the item count, not the highest id.
         $sql = $this->db->createQuery();
-        $sql->select('MAX(id)')->from('#__kunena_messages');
+        $sql->select('COUNT(*)')->from('#__kunena_messages');
 
         // Get the total number of content items to index.
         $this->db->setQuery($sql);

--- a/src/plugins/plg_finder_kunena/kunena.php
+++ b/src/plugins/plg_finder_kunena/kunena.php
@@ -260,13 +260,43 @@ class PlgFinderKunena extends Adapter
         $limit  = (int) ($iState->batchSize - $iState->batchOffset);
 
         // Get the content items to index.
-        $items = $this->getItems($offset, $limit);
+        // Capture any stray output/warnings so they get logged instead of bubbling
+        // up to com_finder, which treats any output as a plugin failure.
+        ob_start();
+
+        try {
+            $items = $this->getItems($offset, $limit);
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            Log::add("Finder Kunena plugin: getItems({$offset}, {$limit}) threw " . get_class($e) . ': ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine(), Log::ERROR);
+            throw $e;
+        }
+
+        $stray = trim(ob_get_clean());
+
+        if ($stray !== '') {
+            Log::add("Finder Kunena plugin: getItems({$offset}, {$limit}) produced output: " . substr($stray, 0, 3000), Log::ERROR);
+        }
 
         // Iterate through the items and index them.
         $item = null;
 
         foreach ($items as $item) {
-            $this->index($item);
+            ob_start();
+
+            try {
+                $this->index($item);
+            } catch (\Throwable $e) {
+                ob_end_clean();
+                Log::add("Finder Kunena plugin: index of message {$item->id} threw " . get_class($e) . ': ' . $e->getMessage() . ' @ ' . $e->getFile() . ':' . $e->getLine(), Log::ERROR);
+                throw $e;
+            }
+
+            $stray = trim(ob_get_clean());
+
+            if ($stray !== '') {
+                Log::add("Finder Kunena plugin: message {$item->id} produced output: " . substr($stray, 0, 3000), Log::ERROR);
+            }
         }
 
         if ($item) {


### PR DESCRIPTION
Fixes three independent bugs in the Smart Search finder plugin (`plg_finder_kunena`), found while debugging why Smart Search could not index my forum. All three fixes have been running on my production site (Joomla 5.4.7, Kunena 6.4.12, PHP 8.x) where indexing now completes and result links work.

### 1. Indexing aborts with "A finder plugin has had an error"
com_finder treats **any** output produced during a batch as a plugin failure (`IndexerController::batch()` checks the output buffer). The BBCode parser echoes `No eBay APP ID and/or Cert ID defined in Kunena configuration` while `KunenaParser::stripBBCode()` processes a post containing an `[ebay]` tag without configured API keys, so one old post with a dead eBay embed aborts the whole run with no useful log entry. The plugin now buffers output around `getItems()`/`index()` and logs it instead. (The deeper fix - the parser never echoing - would live in the BBCode library; this makes the indexer robust regardless.)

### 2. Progress bar never reaches 100% - indexer loops forever (root cause of #9751)
`getContentCount()` returned `MAX(id)`, but the com_finder admin JS loops until the accumulated per-batch offsets (actually indexed items) reach `totalItems`. On any forum with deleted messages (id gaps), the inflated total is unreachable: the bar freezes (~85% on my site) and the browser fires batch requests indefinitely (~5/s), even though the server finished. Now returns `COUNT(*)` and keeps the id-based query cursor in a separate `last_id` state field while counting offsets per indexed item, like the core Joomla adapters. Note: K7.0 already reworked this with `COUNT(*)` + `setLimit($limit, $offset)`; this is the equivalent fix for the K6.4 series (the id-cursor keeps the `id > n` query, which needs no `ORDER BY` and stays stable while rows are deleted).

### 3. Search result links can 404
`createIndexerResult()` baked the `Itemid` from `KunenaRoute::fixMissingItemID()` into the stored URL, and the call `$message->getUrl($message->catid, 'last', $itemid)` does not match the signature `getUrl($category = null, $xhtml = true, $itemid = 0)` (the string `'last'` lands in `$xhtml`). On my site every Kunena result 404'd because the baked-in menu item does not route the topic view; the same URL without `Itemid` works. The plugin now stores the permalink form `index.php?option=com_kunena&view=topic&catid={catid}&id={thread}&mesid={msgid}`, which Kunena resolves (page + scroll position) at request time. Related: #9663, #6025.

Bugs 1 and 3 also affect K7.0 (`src/plugins/plg_finder_kunena/src/Extension/Kunena.php` still uses `fixMissingItemID()`/`getUrl(..., 'last', ...)` and has no output capture) - happy to port this PR there if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
