### PR TITLE
[K7.0] Avoid to show git repository in version footer in backend even on

### DIFF
--- a/scripts/kunena_sym_links.ps1
+++ b/scripts/kunena_sym_links.ps1
@@ -263,6 +263,15 @@ function make-SymLinksKunena {
     $path20 = $joomlaInstallDir + "\plugins\task\kunena"
     $target20 = $kunenaGitDir + "\src\plugins\plg_task_kunena"
     New-Item -ItemType SymbolicLink -Path $path20 -Target $target20
+
+    # Modify pkg_kunena.xml to set versionname to GIT
+    $pkgKunenaPath = $joomlaInstallDir + "\administrator\manifests\packages\pkg_kunena.xml"
+    if (Test-Path -Path $pkgKunenaPath) {
+        $xmlContent = Get-Content -Path $pkgKunenaPath -Raw
+        $xmlContent = $xmlContent -replace '<versionname>.*?</versionname>', '<versionname>GIT</versionname>'
+        $xmlContent | Set-Content -Path $pkgKunenaPath
+        Write-Host "Updated versionname to GIT in pkg_kunena.xml"
+    }
 }
 
 # Make synbolic links for Blue Eagle template

--- a/src/libraries/kunena/src/Forum/KunenaForum.php
+++ b/src/libraries/kunena/src/Forum/KunenaForum.php
@@ -353,17 +353,25 @@ abstract class KunenaForum
         } else {
             $db    = Factory::getContainer()->get('DatabaseDriver');
             $query = $db->createQuery();
-            $query->select('version')->from('#__kunena_version')->order('id');
+            $query->select('*')->from('#__kunena_version')->order('id');
             $query->setLimit(1);
             $db->setQuery($query);
 
-            self::$version      = $db->loadResult();
-            self::$version_date = Factory::getDate()->format('Y-m-d');
-            self::$version_name = 'Git Repository';
+            $version = $db->loadObject();
+
+            self::$version      = $version->version;
+            self::$version_date = $version->versiondate;
+            self::$version_name = $version->versionname;
         }
 
         self::$version_major = substr(self::$version, 0, 3);
-        self::$version_name  = ('@kunenaversionname@' == '@' . 'kunenaversionname' . '@') ? 'Git Repository' : '@kunenaversionname@';
+        
+        // Only set version name to 'Git Repository' if the version contains development indicators
+        if (strpos(self::$version, 'GIT') !== false) {
+            self::$version_name = ('@kunenaversionname@' == '@' . 'kunenaversionname' . '@') ? 'Git Repository' : '@kunenaversionname@';
+        } else {
+            self::$version_name = (string) ($manifest->versionname ?? 'Stable Release');
+        }
 
         $db    = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->createQuery();


### PR DESCRIPTION
production sites

Pull Request for Issue # . 
 
#### Summary of Changes 

When creating symbolic links it change the versionname to GIT in the \administrator\manifests\packages\pkg_kunena.xml and then in footer version it show **Git Repository** only in this case and not on productions sites.
 
#### Testing Instructions