### PR TITLE
[K7.0] Keep the menu item's view when a category alias is parsed

### DIFF
--- a/src/site/src/Service/Router.php
+++ b/src/site/src/Service/Router.php
@@ -370,6 +370,18 @@ class Router extends RouterView
                 
                 if ($variables) {
                     $sefcats = false;
+
+                    // A category alias identifies a category, it does not decide which view
+                    // renders it. resolveAlias() reports view=category alongside the catid,
+                    // but that is only a default. When the active menu item already names a
+                    // view (the stock "New Topic" item is view=topic&layout=create), the menu
+                    // item wins and the alias contributes only the catid. Without this the
+                    // union below replaces view=topic with view=category, which combined with
+                    // layout=create resolves to no controller and returns a 404.
+                    if (!empty($vars['view']) && isset($variables['catid']) && isset($variables['view']) && $variables['view'] === 'category') {
+                        unset($variables['view']);
+                    }
+
                     $vars    = $variables + $vars;
                     continue;
                 }


### PR DESCRIPTION
Hi @xillibit, one more small routing fix from running Kunena 7.0.6 on Joomla 6.1.

### Summary

Any "new topic" URL that carries a `catid` returns a 404 when the site has the **New Topic** menu item that Kunena's own installer creates. The router builds `/<newtopic-alias>/<category-alias>` and then cannot parse that path back.

Because the menu item is created by the installer, a stock site hits this as soon as a link to "start a topic in this category" exists.

### Steps to reproduce

1. Install Kunena. The installer creates a **New Topic** menu item pointing at `index.php?option=com_kunena&view=topic&layout=create` with no `catid` (`KunenaModelInstall.php`).
2. Make sure SEF URLs are on, and that at least one postable category exists.
3. Log in as a user who is allowed to post.
4. Visit `index.php?option=com_kunena&view=topic&layout=create&catid=<id>` for any category.
5. The request is redirected to `/<newtopic-alias>/<category-alias>` and returns **404**.

Without the `catid` the same menu item works, so the failure only shows when a category is requested.

### Cause

`KunenaRoute::resolveAlias()` returns the implied view along with the category:

```php
if ($var == 'catid') {
    $vars['view'] = 'category';
}
```

`Router::parse()` then merges it over the variables taken from the active menu item:

```php
$vars = $variables + $vars;
```

PHP's array union keeps the left operand for duplicate keys, so `view=category` from the alias replaces the `view=topic` the menu item had set. `layout=create` survives from the menu item, and the request becomes:

```
view=category&layout=create&catid=<id>
```

That combination matches no controller, hence the 404. Values observed on a live site:

```
resolveAlias('bug-reports') = {"catid":"5","view":"category"}
menu item query             = {"option":"com_kunena","view":"topic","layout":"create"}
$variables + $vars          = {"catid":"5","view":"category","option":"com_kunena","layout":"create"}
```

### Fix

An alias segment names a category, it does not decide which view renders it. When the active menu item already provides a view, that view wins and the alias contributes only the `catid`.

Topic URLs are unaffected either way, since the numeric branch further down already re-sets `view=topic` when it reads the topic id. The only behaviour that changes is the case that currently 404s.

### Testing Instructions

Tested on a clean install: Joomla 6.1.1, Kunena 7.0.6, PHP 8.5.

Same logged-in session, measured before and after the patch:

| URL | before | after |
|---|---|---|
| `/newtopic/<category-a>` | 404 | 200, form opens in category A |
| `/newtopic/<category-b>` | 404 | 200, form opens in category B |
| `/newtopic` (no catid) | 200, category dropdown | 200, category dropdown |
| forum index, category pages, user view | 200 | 200 |

Also running on a production Joomla 6.1.1 site, where `/forum/newtopic?catid=5` went from 404 to 200 with the right category selected, and normal browsing was unchanged.

### Scope

One file, one guard. `php-cs-fixer` reports nothing on the added lines. It does flag two pre-existing trailing-whitespace spots in this file (the `} else {` around line 224 and the blank line after the `resolveAlias()` call); I left them alone to keep the diff focused, happy to fold them in if you would rather have them cleaned up here.

Happy to adjust the placement or the condition if you would prefer this handled inside `resolveAlias()` instead. I kept it in `parse()` because `resolveAlias()` cannot see whether a menu item supplied a view, and the forum-home case genuinely does need the implied `view=category`.

Thanks for taking a look.
