### PR TITLE
remove Segoe UI Emoji/Symbol from .kmsg font-family

### DIFF
--- a/src/site/template/aurelia/assets/scss/general.scss
+++ b/src/site/template/aurelia/assets/scss/general.scss
@@ -421,8 +421,7 @@ form {
 
 .kmsg {
     margin: 20px 0;
-    font-family: "Segoe UI", "Segoe UI Emoji", "Segoe UI Symbol", Helvetica,
-        Arial, sans-serif;
+    font-family: Helvetica, Arial, sans-serif;
     word-wrap: break-word;
 }
 


### PR DESCRIPTION
See this topic: https://www.kunena.org/forum/general-questions-and-how-tos/169166-error-following-operating-system-migration#235201

#### Summary of Changes 
The .kmsg selector in general.scss includes 'Segoe UI Emoji' and 'Segoe UI Symbol' in its font-family fallback list, alongside regular text fonts. On Windows this is harmless, since those fonts only get used for actual emoji/symbol glyphs. On Linux, however, fontconfig has no exact match for these font names and substitutes a locally installed emoji font instead — which has completely different glyph metrics for ordinary characters like the space.
 
#### Testing Instructions