### PR TITLE
Refactor filter layout in default.php

### DIFF
--- a/src/site/template/aurelia/layouts/message/list/default.php
+++ b/src/site/template/aurelia/layouts/message/list/default.php
@@ -43,8 +43,8 @@ $view    = Factory::getApplication()->getInput()->getWord('view');
 
         <?php if ($view != 'user') :
         ?>
-            <div class="filter-sel float-end">
-                <h2 class="filter-time float-end" id="filter-time"></h2>
+            <div class="float-end" id="filter-time">
+                <h2 class="filter-sel float-end"></h2>
                 <form action="<?php echo $this->escape(Uri::getInstance()->toString()); ?>"
                     id="timeselect" name="timeselect"
                     method="post" target="_self" class="form-inline d-none d-sm-block">


### PR DESCRIPTION
See https://www.kunena.org/forum/k-6-4-0-support/169178-kunena-6-4-x-pagination-issue-ntskbee#235248
As I am using NTSKPraxis and had the same issue, decided to check Aurelia as well as Kunena forum shows the same issue.
This pull request fixes the layout and now shows the filter also on the first page.